### PR TITLE
Add "born digital" SIP type

### DIFF
--- a/internal/activities/identify_sip.go
+++ b/internal/activities/identify_sip.go
@@ -28,5 +28,5 @@ func (a *IdentifySIP) Execute(ctx context.Context, params *IdentifySIPParams) (*
 		return nil, fmt.Errorf("IdentifySIP: %v", err)
 	}
 
-	return &IdentifySIPResult{SIP: s}, nil
+	return &IdentifySIPResult{SIP: *s}, nil
 }

--- a/internal/activities/identify_sip_test.go
+++ b/internal/activities/identify_sip_test.go
@@ -30,7 +30,7 @@ func TestIdentifySIP(t *testing.T) {
 			params: activities.IdentifySIPParams{Path: path},
 			result: activities.IdentifySIPResult{
 				SIP: sip.SIP{
-					Type:          enums.SIPTypeVecteurAIP,
+					Type:          enums.SIPTypeDigitizedAIP,
 					Path:          path,
 					ContentPath:   filepath.Join(path, "content", "content"),
 					MetadataPath:  filepath.Join(path, "additional", "UpdatedAreldaMetadata.xml"),

--- a/internal/activities/transform_sip_test.go
+++ b/internal/activities/transform_sip_test.go
@@ -103,17 +103,17 @@ func TestTransformSIP(t *testing.T) {
 	}{
 		{
 			name:    "Transforms a Vecteur AIP",
-			params:  activities.TransformSIPParams{SIP: vecteurAIP},
+			params:  activities.TransformSIPParams{SIP: *vecteurAIP},
 			wantSIP: expectedVecteurAIP,
 		},
 		{
 			name:    "Transforms a Vecteur SIP",
-			params:  activities.TransformSIPParams{SIP: vecteurSIP},
+			params:  activities.TransformSIPParams{SIP: *vecteurSIP},
 			wantSIP: expectedVecteurSIP,
 		},
 		{
 			name:   "Fails with a SIP missing the metadata file",
-			params: activities.TransformSIPParams{SIP: missingMetadataSIP},
+			params: activities.TransformSIPParams{SIP: *missingMetadataSIP},
 			wantErr: fmt.Sprintf(
 				"rename %s/header/metadata.xml %s/metadata/metadata.xml: no such file or directory",
 				missingMetadataSIP.Path,
@@ -122,7 +122,7 @@ func TestTransformSIP(t *testing.T) {
 		},
 		{
 			name:   "Fails with a SIP missing the content directory",
-			params: activities.TransformSIPParams{SIP: missingContentSIP},
+			params: activities.TransformSIPParams{SIP: *missingContentSIP},
 			wantErr: fmt.Sprintf(
 				"lstat %s/content: no such file or directory",
 				missingContentSIP.Path,

--- a/internal/activities/transform_sip_test.go
+++ b/internal/activities/transform_sip_test.go
@@ -16,7 +16,7 @@ import (
 func TestTransformSIP(t *testing.T) {
 	t.Parallel()
 
-	vecteurAIPPath := fs.NewDir(t, "",
+	digitizedAIPPath := fs.NewDir(t, "",
 		fs.WithDir("additional",
 			fs.WithFile("UpdatedAreldaMetadata.xml", ""),
 		),
@@ -40,7 +40,7 @@ func TestTransformSIP(t *testing.T) {
 			),
 		),
 	).Path()
-	vecteurSIPPath := fs.NewDir(t, "",
+	digitizedSIPPath := fs.NewDir(t, "",
 		fs.WithDir("content",
 			fs.WithDir("d_0000001",
 				fs.WithFile("00000001.jp2", ""),
@@ -56,12 +56,12 @@ func TestTransformSIP(t *testing.T) {
 		),
 	).Path()
 
-	vecteurAIP, err := sip.NewSIP(vecteurAIPPath)
+	digitizedAIP, err := sip.NewSIP(digitizedAIPPath)
 	assert.NilError(t, err)
-	vecteurSIP, err := sip.NewSIP(vecteurSIPPath)
+	digitizedSIP, err := sip.NewSIP(digitizedSIPPath)
 	assert.NilError(t, err)
 
-	expectedVecteurAIP := fs.Expected(t,
+	expectedDigitizedAIP := fs.Expected(t,
 		fs.WithDir("objects", fs.WithMode(0o700),
 			fs.WithDir("d_0000001",
 				fs.WithFile("00000001.jp2", ""),
@@ -73,7 +73,7 @@ func TestTransformSIP(t *testing.T) {
 			fs.WithFile("UpdatedAreldaMetadata.xml", ""),
 		),
 	)
-	expectedVecteurSIP := fs.Expected(t,
+	expectedDigitizedSIP := fs.Expected(t,
 		fs.WithDir("objects", fs.WithMode(0o700),
 			fs.WithDir("d_0000001",
 				fs.WithFile("00000001.jp2", ""),
@@ -102,14 +102,14 @@ func TestTransformSIP(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "Transforms a Vecteur AIP",
-			params:  activities.TransformSIPParams{SIP: *vecteurAIP},
-			wantSIP: expectedVecteurAIP,
+			name:    "Transforms a digitized AIP",
+			params:  activities.TransformSIPParams{SIP: *digitizedAIP},
+			wantSIP: expectedDigitizedAIP,
 		},
 		{
-			name:    "Transforms a Vecteur SIP",
-			params:  activities.TransformSIPParams{SIP: *vecteurSIP},
-			wantSIP: expectedVecteurSIP,
+			name:    "Transforms a digitized SIP",
+			params:  activities.TransformSIPParams{SIP: *digitizedSIP},
+			wantSIP: expectedDigitizedSIP,
 		},
 		{
 			name:   "Fails with a SIP missing the metadata file",

--- a/internal/activities/validate_structure_test.go
+++ b/internal/activities/validate_structure_test.go
@@ -72,15 +72,15 @@ func TestValidateStructure(t *testing.T) {
 	}{
 		{
 			name:   "Validates a Vecteur AIP",
-			params: activities.ValidateStructureParams{SIP: vecteurAIP},
+			params: activities.ValidateStructureParams{SIP: *vecteurAIP},
 		},
 		{
 			name:   "Validates a Vecteur SIP",
-			params: activities.ValidateStructureParams{SIP: vecteurSIP},
+			params: activities.ValidateStructureParams{SIP: *vecteurSIP},
 		},
 		{
 			name:   "Returns failures when the SIP has unexpected components",
-			params: activities.ValidateStructureParams{SIP: unexpectedPiecesSIP},
+			params: activities.ValidateStructureParams{SIP: *unexpectedPiecesSIP},
 			want: activities.ValidateStructureResult{
 				Failures: []string{
 					fmt.Sprintf("Unexpected directory: %q", unexpectedPiecesSIP.Path+"/unexpected"),
@@ -90,7 +90,7 @@ func TestValidateStructure(t *testing.T) {
 		},
 		{
 			name:   "Returns failures when the SIP is missing components",
-			params: activities.ValidateStructureParams{SIP: missingPiecesSIP},
+			params: activities.ValidateStructureParams{SIP: *missingPiecesSIP},
 			want: activities.ValidateStructureResult{
 				Failures: []string{
 					"Content folder is missing",

--- a/internal/activities/validate_structure_test.go
+++ b/internal/activities/validate_structure_test.go
@@ -16,7 +16,7 @@ import (
 func TestValidateStructure(t *testing.T) {
 	t.Parallel()
 
-	vecteurAIP, err := sip.NewSIP(fs.NewDir(t, "",
+	digitizedAIP, err := sip.NewSIP(fs.NewDir(t, "",
 		fs.WithDir("additional",
 			fs.WithFile("UpdatedAreldaMetadata.xml", ""),
 		),
@@ -33,7 +33,7 @@ func TestValidateStructure(t *testing.T) {
 	).Path())
 	assert.NilError(t, err)
 
-	vecteurSIP, err := sip.NewSIP(fs.NewDir(t, "",
+	digitizedSIP, err := sip.NewSIP(fs.NewDir(t, "",
 		fs.WithDir("content",
 			fs.WithDir("d_0000001"),
 		),
@@ -71,12 +71,12 @@ func TestValidateStructure(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:   "Validates a Vecteur AIP",
-			params: activities.ValidateStructureParams{SIP: *vecteurAIP},
+			name:   "Validates a digitized AIP",
+			params: activities.ValidateStructureParams{SIP: *digitizedAIP},
 		},
 		{
-			name:   "Validates a Vecteur SIP",
-			params: activities.ValidateStructureParams{SIP: *vecteurSIP},
+			name:   "Validates a digitized SIP",
+			params: activities.ValidateStructureParams{SIP: *digitizedSIP},
 		},
 		{
 			name:   "Returns failures when the SIP has unexpected components",

--- a/internal/enums/sip_type.go
+++ b/internal/enums/sip_type.go
@@ -1,8 +1,8 @@
 package enums
 
 // ENUM(
-// VecteurAIP,
-// VecteurSIP,
+// DigitizedAIP,
+// DigitizedSIP,
 // BornDigital,
 // ).
 type SIPType string

--- a/internal/enums/sip_type.go
+++ b/internal/enums/sip_type.go
@@ -3,5 +3,6 @@ package enums
 // ENUM(
 // VecteurAIP,
 // VecteurSIP,
+// BornDigital,
 // ).
 type SIPType string

--- a/internal/enums/sip_type_enum.go
+++ b/internal/enums/sip_type_enum.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	// SIPTypeVecteurAIP is a SIPType of type VecteurAIP.
-	SIPTypeVecteurAIP SIPType = "VecteurAIP"
-	// SIPTypeVecteurSIP is a SIPType of type VecteurSIP.
-	SIPTypeVecteurSIP SIPType = "VecteurSIP"
+	// SIPTypeDigitizedAIP is a SIPType of type DigitizedAIP.
+	SIPTypeDigitizedAIP SIPType = "DigitizedAIP"
+	// SIPTypeDigitizedSIP is a SIPType of type DigitizedSIP.
+	SIPTypeDigitizedSIP SIPType = "DigitizedSIP"
 	// SIPTypeBornDigital is a SIPType of type BornDigital.
 	SIPTypeBornDigital SIPType = "BornDigital"
 )
@@ -25,8 +25,8 @@ const (
 var ErrInvalidSIPType = fmt.Errorf("not a valid SIPType, try [%s]", strings.Join(_SIPTypeNames, ", "))
 
 var _SIPTypeNames = []string{
-	string(SIPTypeVecteurAIP),
-	string(SIPTypeVecteurSIP),
+	string(SIPTypeDigitizedAIP),
+	string(SIPTypeDigitizedSIP),
 	string(SIPTypeBornDigital),
 }
 
@@ -50,9 +50,9 @@ func (x SIPType) IsValid() bool {
 }
 
 var _SIPTypeValue = map[string]SIPType{
-	"VecteurAIP":  SIPTypeVecteurAIP,
-	"VecteurSIP":  SIPTypeVecteurSIP,
-	"BornDigital": SIPTypeBornDigital,
+	"DigitizedAIP": SIPTypeDigitizedAIP,
+	"DigitizedSIP": SIPTypeDigitizedSIP,
+	"BornDigital":  SIPTypeBornDigital,
 }
 
 // ParseSIPType attempts to convert a string to a SIPType.

--- a/internal/enums/sip_type_enum.go
+++ b/internal/enums/sip_type_enum.go
@@ -18,6 +18,8 @@ const (
 	SIPTypeVecteurAIP SIPType = "VecteurAIP"
 	// SIPTypeVecteurSIP is a SIPType of type VecteurSIP.
 	SIPTypeVecteurSIP SIPType = "VecteurSIP"
+	// SIPTypeBornDigital is a SIPType of type BornDigital.
+	SIPTypeBornDigital SIPType = "BornDigital"
 )
 
 var ErrInvalidSIPType = fmt.Errorf("not a valid SIPType, try [%s]", strings.Join(_SIPTypeNames, ", "))
@@ -25,6 +27,7 @@ var ErrInvalidSIPType = fmt.Errorf("not a valid SIPType, try [%s]", strings.Join
 var _SIPTypeNames = []string{
 	string(SIPTypeVecteurAIP),
 	string(SIPTypeVecteurSIP),
+	string(SIPTypeBornDigital),
 }
 
 // SIPTypeNames returns a list of possible string values of SIPType.
@@ -47,8 +50,9 @@ func (x SIPType) IsValid() bool {
 }
 
 var _SIPTypeValue = map[string]SIPType{
-	"VecteurAIP": SIPTypeVecteurAIP,
-	"VecteurSIP": SIPTypeVecteurSIP,
+	"VecteurAIP":  SIPTypeVecteurAIP,
+	"VecteurSIP":  SIPTypeVecteurSIP,
+	"BornDigital": SIPTypeBornDigital,
 }
 
 // ParseSIPType attempts to convert a string to a SIPType.

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -1,12 +1,39 @@
 package fsutil
 
 import (
+	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 )
 
+// FileExists returns true if path references an existing file.  FileExists will
+// return false if path doesn't reference an existing file, or if
+// `os.Stat(path)` returns an error (e.g. ErrPermission).
 func FileExists(path string) bool {
 	if _, err := os.Stat(path); err == nil {
 		return true
 	}
 	return false
+}
+
+// FindFilename searches root for files named name and returns the paths of any
+// matching files.
+func FindFilename(root, name string) (found []string, err error) {
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.Name() == name {
+			found = append(found, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("find filename: %v", err)
+	}
+
+	return found, nil
 }

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -1,0 +1,52 @@
+package fsutil_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/fsutil"
+)
+
+func TestFileExists(t *testing.T) {
+	t.Parallel()
+
+	td := fs.NewDir(t, "preprocessing-sfa-test",
+		fs.WithDir("a", fs.WithFile("needle", "")),
+	)
+
+	assert.Assert(t, fsutil.FileExists(td.Join("a", "needle")))
+	assert.Assert(t, !fsutil.FileExists(td.Join("b")))
+}
+
+func TestFindFilename(t *testing.T) {
+	t.Parallel()
+
+	td := fs.NewDir(t, "preprocessing-sfa-test",
+		fs.WithDir("a",
+			fs.WithFile("needle", ""),
+			fs.WithFile("hay", ""),
+		),
+		fs.WithDir("needle"),
+	)
+
+	t.Run("Find files", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := fsutil.FindFilename(td.Path(), "needle")
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got, []string{
+			td.Join("a", "needle"),
+			td.Join("needle"),
+		})
+	})
+
+	t.Run("No filename matches", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := fsutil.FindFilename(td.Path(), "cat")
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got, []string(nil))
+	})
+}

--- a/internal/sip/sip.go
+++ b/internal/sip/sip.go
@@ -27,7 +27,7 @@ func NewSIP(path string) (*SIP, error) {
 	}
 
 	if fsutil.FileExists(filepath.Join(s.Path, "additional")) {
-		return s.vecteurAIP(), nil
+		return s.digitizedAIP(), nil
 	}
 
 	f, err := fsutil.FindFilename(s.Path, "Prozess_Digitalisierung_PREMIS.xml")
@@ -35,14 +35,14 @@ func NewSIP(path string) (*SIP, error) {
 		return nil, fmt.Errorf("NewSIP: %v", err)
 	}
 	if len(f) > 0 && strings.Contains(s.Path, "Vecteur") {
-		return s.vecteurSIP(), nil
+		return s.digitizedSIP(), nil
 	}
 
 	return s.bornDigital(), nil
 }
 
-func (s *SIP) vecteurAIP() *SIP {
-	s.Type = enums.SIPTypeVecteurAIP
+func (s *SIP) digitizedAIP() *SIP {
+	s.Type = enums.SIPTypeDigitizedAIP
 	s.ContentPath = filepath.Join(s.Path, "content", "content")
 	s.MetadataPath = filepath.Join(s.Path, "additional", "UpdatedAreldaMetadata.xml")
 	s.XSDPath = filepath.Join(s.Path, "content", "header", "xsd", "arelda.xsd")
@@ -54,9 +54,9 @@ func (s *SIP) vecteurAIP() *SIP {
 	return s
 }
 
-func (s *SIP) vecteurSIP() *SIP {
+func (s *SIP) digitizedSIP() *SIP {
 	s.bornDigital()
-	s.Type = enums.SIPTypeVecteurSIP
+	s.Type = enums.SIPTypeDigitizedSIP
 
 	return s
 }

--- a/internal/sip/sip_test.go
+++ b/internal/sip/sip_test.go
@@ -38,7 +38,7 @@ func TestNewSIP(t *testing.T) {
 			name: "Creates a new digitized AIP",
 			path: aipPath,
 			wantSIP: &sip.SIP{
-				Type:         enums.SIPTypeVecteurAIP,
+				Type:         enums.SIPTypeDigitizedAIP,
 				Path:         aipPath,
 				ContentPath:  filepath.Join(aipPath, "content", "content"),
 				MetadataPath: filepath.Join(aipPath, "additional", "UpdatedAreldaMetadata.xml"),
@@ -53,7 +53,7 @@ func TestNewSIP(t *testing.T) {
 			name: "Creates a new digitized SIP",
 			path: sipPath,
 			wantSIP: &sip.SIP{
-				Type:         enums.SIPTypeVecteurSIP,
+				Type:         enums.SIPTypeDigitizedSIP,
 				Path:         sipPath,
 				ContentPath:  filepath.Join(sipPath, "content"),
 				MetadataPath: filepath.Join(sipPath, "header", "metadata.xml"),

--- a/internal/sip/sip_test.go
+++ b/internal/sip/sip_test.go
@@ -15,36 +15,68 @@ func TestNewSIP(t *testing.T) {
 	t.Parallel()
 
 	aipPath := fs.NewDir(t, "", fs.WithDir("content"), fs.WithDir("additional")).Path()
-	sipPath := fs.NewDir(t, "", fs.WithDir("content"), fs.WithDir("header")).Path()
+	sipPath := fs.NewDir(t, "SIP_20201201_Vecteur",
+		fs.WithDir("content",
+			fs.WithDir("d_0000001",
+				fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
+			),
+		),
+		fs.WithDir("header"),
+	).Path()
+	bornDigital := fs.NewDir(t, "",
+		fs.WithDir("content"),
+		fs.WithDir("header"),
+	)
 
 	tests := []struct {
 		name    string
 		path    string
-		wantSIP sip.SIP
+		wantSIP *sip.SIP
 		wantErr string
 	}{
 		{
-			name: "Creates a new SIP (type: VecteurAIP)",
+			name: "Creates a new digitized AIP",
 			path: aipPath,
-			wantSIP: sip.SIP{
-				Type:          enums.SIPTypeVecteurAIP,
-				Path:          aipPath,
-				ContentPath:   filepath.Join(aipPath, "content", "content"),
-				MetadataPath:  filepath.Join(aipPath, "additional", "UpdatedAreldaMetadata.xml"),
-				XSDPath:       filepath.Join(aipPath, "content", "header", "xsd", "arelda.xsd"),
-				TopLevelPaths: []string{filepath.Join(aipPath, "content"), filepath.Join(aipPath, "additional")},
+			wantSIP: &sip.SIP{
+				Type:         enums.SIPTypeVecteurAIP,
+				Path:         aipPath,
+				ContentPath:  filepath.Join(aipPath, "content", "content"),
+				MetadataPath: filepath.Join(aipPath, "additional", "UpdatedAreldaMetadata.xml"),
+				XSDPath:      filepath.Join(aipPath, "content", "header", "xsd", "arelda.xsd"),
+				TopLevelPaths: []string{
+					filepath.Join(aipPath, "content"),
+					filepath.Join(aipPath, "additional"),
+				},
 			},
 		},
 		{
-			name: "Creates a new SIP (type: VecteurSIP)",
+			name: "Creates a new digitized SIP",
 			path: sipPath,
-			wantSIP: sip.SIP{
-				Type:          enums.SIPTypeVecteurSIP,
-				Path:          sipPath,
-				ContentPath:   filepath.Join(sipPath, "content"),
-				MetadataPath:  filepath.Join(sipPath, "header", "metadata.xml"),
-				XSDPath:       filepath.Join(sipPath, "header", "xsd", "arelda.xsd"),
-				TopLevelPaths: []string{filepath.Join(sipPath, "content"), filepath.Join(sipPath, "header")},
+			wantSIP: &sip.SIP{
+				Type:         enums.SIPTypeVecteurSIP,
+				Path:         sipPath,
+				ContentPath:  filepath.Join(sipPath, "content"),
+				MetadataPath: filepath.Join(sipPath, "header", "metadata.xml"),
+				XSDPath:      filepath.Join(sipPath, "header", "xsd", "arelda.xsd"),
+				TopLevelPaths: []string{
+					filepath.Join(sipPath, "content"),
+					filepath.Join(sipPath, "header"),
+				},
+			},
+		},
+		{
+			name: "Creates a new born digital SIP",
+			path: bornDigital.Path(),
+			wantSIP: &sip.SIP{
+				Type:         enums.SIPTypeBornDigital,
+				Path:         bornDigital.Path(),
+				ContentPath:  bornDigital.Join("content"),
+				MetadataPath: bornDigital.Join("header", "metadata.xml"),
+				XSDPath:      bornDigital.Join("header", "xsd", "arelda.xsd"),
+				TopLevelPaths: []string{
+					bornDigital.Join("content"),
+					bornDigital.Join("header"),
+				},
 			},
 		},
 		{

--- a/internal/workflow/preprocessing_test.go
+++ b/internal/workflow/preprocessing_test.go
@@ -97,9 +97,9 @@ func TestPreprocessingWorkflow(t *testing.T) {
 	suite.Run(t, new(PreprocessingTestSuite))
 }
 
-func vecteurAIP(path string) sip.SIP {
+func digitizedAIP(path string) sip.SIP {
 	return sip.SIP{
-		Type:         enums.SIPTypeVecteurAIP,
+		Type:         enums.SIPTypeDigitizedAIP,
 		Path:         path,
 		ContentPath:  filepath.Join(path, "content", "content"),
 		MetadataPath: filepath.Join(path, "additional", "UpdatedAreldaMetadata.xml"),
@@ -114,7 +114,7 @@ func vecteurAIP(path string) sip.SIP {
 func (s *PreprocessingTestSuite) TestPreprocessingWorkflowSuccess() {
 	s.SetupTest(config.Configuration{})
 	sipPath := filepath.Join(s.testDir, relPath)
-	expectedSIP := vecteurAIP(sipPath)
+	expectedSIP := digitizedAIP(sipPath)
 
 	// Mock activities.
 	sessionCtx := mock.AnythingOfType("*context.timerCtx")
@@ -152,7 +152,7 @@ func (s *PreprocessingTestSuite) TestPreprocessingWorkflowSuccess() {
 			Agent:          premis.AgentDefault(),
 			Type:           "validation",
 			Detail:         "name=\"Validate SIP structure\"",
-			OutcomeDetail:  "SIP structure identified: VecteurAIP. SIP structure matches validation criteria.",
+			OutcomeDetail:  "SIP structure identified: DigitizedAIP. SIP structure matches validation criteria.",
 			Failures:       nil,
 		},
 	).Return(
@@ -232,7 +232,7 @@ func (s *PreprocessingTestSuite) TestPreprocessingWorkflowSuccess() {
 			PreservationTasks: []eventlog.Event{
 				{
 					Name:        "Identify SIP structure",
-					Message:     "SIP structure identified: VecteurAIP",
+					Message:     "SIP structure identified: DigitizedAIP",
 					Outcome:     enums.EventOutcomeSuccess,
 					StartedAt:   testTime,
 					CompletedAt: testTime,
@@ -323,7 +323,7 @@ func (s *PreprocessingTestSuite) TestPreprocessingWorkflowIdentifySIPFails() {
 func (s *PreprocessingTestSuite) TestPreprocessingWorkflowValidationFails() {
 	s.SetupTest(config.Configuration{})
 	sipPath := filepath.Join(s.testDir, relPath)
-	expectedSIP := vecteurAIP(sipPath)
+	expectedSIP := digitizedAIP(sipPath)
 
 	// Mock activities.
 	sessionCtx := mock.AnythingOfType("*context.timerCtx")
@@ -390,7 +390,7 @@ func (s *PreprocessingTestSuite) TestPreprocessingWorkflowValidationFails() {
 			PreservationTasks: []eventlog.Event{
 				{
 					Name:        "Identify SIP structure",
-					Message:     "SIP structure identified: VecteurAIP",
+					Message:     "SIP structure identified: DigitizedAIP",
 					Outcome:     enums.EventOutcomeSuccess,
 					StartedAt:   testTime,
 					CompletedAt: testTime,


### PR DESCRIPTION
Fixes #34.

- Add "born digital" SIP type and add it to the "identify SIP" activity,
- Replace "Vecteur" with "digitized" for SIP types