### PR TITLE
Verify the SIP header files match the manifest

### DIFF
--- a/internal/activities/verify_manifest.go
+++ b/internal/activities/verify_manifest.go
@@ -2,15 +2,16 @@ package activities
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/antchfx/xmlquery"
 	goset "github.com/deckarep/golang-set/v2"
 
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/enums"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/sip"
 )
 
@@ -30,28 +31,40 @@ func NewVerifyManifest() *VerifyManifest {
 	return &VerifyManifest{}
 }
 
+// Execute parses a SIP's manifest and verifies it against the actual files in
+// the SIP directory. Any missing or unexpected files on disk are reported as
+// failures.
 func (a *VerifyManifest) Execute(ctx context.Context, params *VerifyManifestParams) (*VerifyManifestResult, error) {
 	manifestFiles, err := manifestFiles(params.SIP)
 	if err != nil {
 		return nil, fmt.Errorf("verify manifest: parse manifest: %v", err)
 	}
 
-	sipFiles, err := sipFiles(params.SIP.ContentPath)
+	sipFiles, err := sipFiles(params.SIP)
 	if err != nil {
 		return nil, fmt.Errorf("verify manifest: get SIP contents: %v", err)
 	}
 
 	var failures []string
-	for _, p := range manifestFiles.Difference(sipFiles).ToSlice() {
-		failures = append(failures, fmt.Sprintf("Missing file: %s", p))
+
+	if s := manifestFiles.Difference(sipFiles).ToSlice(); len(s) > 0 {
+		slices.Sort(s)
+		for _, p := range s {
+			failures = append(failures, fmt.Sprintf("Missing file: %s", p))
+		}
 	}
-	for _, p := range sipFiles.Difference(manifestFiles).ToSlice() {
-		failures = append(failures, fmt.Sprintf("Unexpected file: %s", p))
+
+	if s := sipFiles.Difference(manifestFiles).ToSlice(); len(s) > 0 {
+		slices.Sort(s)
+		for _, p := range s {
+			failures = append(failures, fmt.Sprintf("Unexpected file: %s", p))
+		}
 	}
 
 	return &VerifyManifestResult{Failures: failures}, nil
 }
 
+// manifestFiles returns the set of all files paths listed in a SIP's manifest.
 func manifestFiles(s sip.SIP) (goset.Set[string], error) {
 	f, err := os.Open(s.ManifestPath)
 	if err != nil {
@@ -63,43 +76,67 @@ func manifestFiles(s sip.SIP) (goset.Set[string], error) {
 		return nil, fmt.Errorf("parse document: %v", err)
 	}
 
-	contentDir, err := xmlquery.Query(doc, "//paket/inhaltsverzeichnis/ordner/name[text()='content']/..")
-	if err != nil || contentDir == nil {
-		return nil, fmt.Errorf("missing content path: %v", err)
+	manifest, err := xmlquery.Query(doc, "//paket/inhaltsverzeichnis")
+	if err != nil || manifest == nil {
+		return nil, fmt.Errorf("missing inhaltsverzeichnis entry: %v", err)
 	}
 
-	dossiers := contentDir.SelectElements("ordner")
-	if dossiers == nil {
-		return nil, errors.New("no dossiers in content path")
+	root := ""
+	if s.Type == enums.SIPTypeDigitizedAIP {
+		root = "content"
 	}
 
-	paths := goset.NewSet[string]()
-	for _, d := range dossiers {
-		for _, f := range d.SelectElements("datei") {
-			paths.Add(filepath.Join(
-				d.SelectElement("name").InnerText(),
-				f.SelectElement("name").InnerText(),
-			))
-		}
-	}
-
-	return paths, nil
+	return walkNode(manifest, root), nil
 }
 
-func sipFiles(dir string) (goset.Set[string], error) {
+// walkNode recursively walks node's xpath tree and returns the set of all file
+// (excluding directories) paths found.
+func walkNode(node *xmlquery.Node, path string) goset.Set[string] {
 	paths := goset.NewSet[string]()
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+
+	for _, n := range node.SelectElements("ordner") {
+		name := n.SelectElement("name").InnerText()
+		paths = paths.Union(walkNode(n, filepath.Join(path, name)))
+	}
+
+	for _, n := range node.SelectElements("datei") {
+		name := n.SelectElement("name").InnerText()
+		paths.Add(filepath.Join(path, name))
+	}
+
+	return paths
+}
+
+// sipFiles recursively walks dir's tree and returns the set of all file
+// (excluding directories) paths found.
+func sipFiles(s sip.SIP) (goset.Set[string], error) {
+	root := s.Path
+	if s.Type == enums.SIPTypeDigitizedAIP {
+		root = filepath.Join(s.Path, "content")
+	}
+
+	paths := goset.NewSet[string]()
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if !d.IsDir() {
-			p, err := filepath.Rel(dir, path)
-			if err != nil {
-				return err
-			}
-			paths.Add(p)
+		if d.IsDir() {
+			return nil
 		}
+
+		p, err := filepath.Rel(s.Path, path)
+		if err != nil {
+			return err
+		}
+
+		// Digitized SIP and born-digital SIPs don't include metadata.xml in the
+		// manifest, so ignore the file here.
+		if s.Type != enums.SIPTypeDigitizedAIP && p == "header/metadata.xml" {
+			return nil
+		}
+
+		paths.Add(p)
 
 		return nil
 	})

--- a/internal/activities/verify_manifest_test.go
+++ b/internal/activities/verify_manifest_test.go
@@ -1,8 +1,6 @@
 package activities_test
 
 import (
-	"fmt"
-	"path/filepath"
 	"testing"
 
 	temporalsdk_activity "go.temporal.io/sdk/activity"
@@ -14,7 +12,8 @@ import (
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/sip"
 )
 
-const manifest = `
+const (
+	aipManifest = `
 <?xml version="1.0" encoding="UTF-8"?>
 <paket
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -91,126 +90,225 @@ const manifest = `
 </paket>
 `
 
+	sipManifest = `
+<?xml version="1.0" encoding="UTF-8"?>
+<paket
+	xmlns="http://bar.admin.ch/arelda/v4"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="4.0" xsi:type="paketSIP">
+	<paketTyp>SIP</paketTyp>
+	<inhaltsverzeichnis>
+		<ordner>
+			<name>header</name>
+			<originalName>header</originalName>
+			<ordner>
+				<name>xsd</name>
+				<originalName>xsd</originalName>
+				<datei id="_ZSANrSklQ9HGn99yjlUumz">
+					<name>arelda.xsd</name>
+					<originalName>arelda.xsd</originalName>
+					<pruefalgorithmus>MD5</pruefalgorithmus>
+					<pruefsumme>f8454632e1ebf97e0aa8d9527ce2641f</pruefsumme>
+				</datei>
+			</ordner>
+		</ordner>
+		<ordner>
+			<name>content</name>
+			<originalName>content</originalName>
+			<ordner>
+				<name>d_0000001</name>
+				<originalName>d_0000001</originalName>
+				<datei id="_zodSTSD0nv05CpOp6JoV3X">
+					<name>00000001.jp2</name>
+					<originalName>00000001.jp2</originalName>
+					<pruefalgorithmus>MD5</pruefalgorithmus>
+					<pruefsumme>dc29291d0e2a18363d0efd2ec2fe81c9</pruefsumme>
+				</datei>
+				<datei id="_rlPKJX9ZcAl4ooc4IfoIkM">
+					<name>00000002.jp2</name>
+					<originalName>00000002.jp2</originalName>
+					<pruefalgorithmus>MD5</pruefalgorithmus>
+					<pruefsumme>9093907ec32f06fe595e0f14982c4bf0</pruefsumme>
+				</datei>
+				<datei id="_WuDmXAs5UDwKTGVLsCcZxa">
+					<name>00000001_PREMIS.xml</name>
+					<originalName>00000001_PREMIS.xml</originalName>
+					<pruefalgorithmus>MD5</pruefalgorithmus>
+					<pruefsumme>1d310772d26138a42eb2d6bebb637457</pruefsumme>
+				</datei>
+				<datei id="_Ohk77y2DJa82RXqsWG4S90">
+					<name>00000002_PREMIS.xml</name>
+					<originalName>00000002_PREMIS.xml</originalName>
+					<pruefalgorithmus>MD5</pruefalgorithmus>
+					<pruefsumme>abe7d286e9fa8db7ab8a3078df761c8e</pruefsumme>
+				</datei>
+				<datei id="_cQ6sm5CChWVqtqmrWvne0W">
+					<name>Prozess_Digitalisierung_PREMIS.xml</name>
+					<originalName>Prozess_Digitalisierung_PREMIS.xml</originalName>
+					<pruefalgorithmus>MD5</pruefalgorithmus>
+					<pruefsumme>21d8e90afdefd2c43386ca1d1658cab0</pruefsumme>
+				</datei>
+			</ordner>
+		</ordner>
+	</inhaltsverzeichnis>
+</paket>
+`
+)
+
+func testSIP(t *testing.T, dir *fs.Dir) sip.SIP {
+	t.Helper()
+	s, err := sip.New(dir.Path())
+	if err != nil {
+		t.Fatalf("sip: New(): %v", err)
+	}
+	return s
+}
+
 func TestVerifyManifest(t *testing.T) {
 	t.Parallel()
-
-	digitizedAIP := fs.NewDir(t, "Test_Digitized_AIP",
-		fs.WithDir("additional",
-			fs.WithFile("UpdatedAreldaMetadata.xml", manifest),
-		),
-		fs.WithDir("content",
-			fs.WithDir("content",
-				fs.WithDir("d_0000001",
-					fs.WithFile("00000001.jp2", ""),
-					fs.WithFile("00000001_PREMIS.xml", ""),
-					fs.WithFile("00000002.jp2", ""),
-					fs.WithFile("00000002_PREMIS.xml", ""),
-					fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
-				),
-			),
-			fs.WithDir("header",
-				fs.WithDir("old",
-					fs.WithDir("SIP",
-						fs.WithFile("metadata.xml", ""),
-					),
-				),
-			),
-		),
-	)
-	testSIP, err := sip.New(digitizedAIP.Path())
-	assert.NilError(t, err)
-
-	missingFile := fs.NewDir(t, "Test_Missing_File",
-		fs.WithDir("additional",
-			fs.WithFile("UpdatedAreldaMetadata.xml", manifest),
-		),
-		fs.WithDir("content",
-			fs.WithDir("content",
-				fs.WithDir("d_0000001",
-					// fs.WithFile("00000001.jp2", ""),
-					fs.WithFile("00000001_PREMIS.xml", ""),
-					fs.WithFile("00000002.jp2", ""),
-					fs.WithFile("00000002_PREMIS.xml", ""),
-					fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
-				),
-			),
-			fs.WithDir("header",
-				fs.WithDir("old",
-					fs.WithDir("SIP",
-						fs.WithFile("metadata.xml", ""),
-					),
-				),
-			),
-		),
-	)
-	missingFileSIP, err := sip.New(missingFile.Path())
-	assert.NilError(t, err)
-
-	extraFile := fs.NewDir(t, "Test_Extra_File",
-		fs.WithDir("additional",
-			fs.WithFile("UpdatedAreldaMetadata.xml", manifest),
-		),
-		fs.WithDir("content",
-			fs.WithDir("content",
-				fs.WithDir("d_0000001",
-					fs.WithFile("extra_file.txt", "I'm an extra file."),
-					fs.WithFile("00000001.jp2", ""),
-					fs.WithFile("00000001_PREMIS.xml", ""),
-					fs.WithFile("00000002.jp2", ""),
-					fs.WithFile("00000002_PREMIS.xml", ""),
-					fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
-				),
-			),
-			fs.WithDir("header",
-				fs.WithDir("old",
-					fs.WithDir("SIP",
-						fs.WithFile("metadata.xml", ""),
-					),
-				),
-			),
-		),
-	)
-	extraFileSIP, err := sip.New(extraFile.Path())
-	assert.NilError(t, err)
 
 	tests := []struct {
 		name    string
 		params  activities.VerifyManifestParams
-		result  activities.VerifyManifestResult
+		want    activities.VerifyManifestResult
 		wantErr string
 	}{
 		{
-			name: "Verifies an accurate manifest",
+			name: "Verifies a digitized AIP manifest",
 			params: activities.VerifyManifestParams{
-				SIP: testSIP,
+				SIP: testSIP(
+					t,
+					fs.NewDir(t, "Test_Digitized_AIP",
+						fs.WithDir("additional",
+							fs.WithFile("UpdatedAreldaMetadata.xml", aipManifest),
+						),
+						fs.WithDir("content",
+							fs.WithDir("content",
+								fs.WithDir("d_0000001",
+									fs.WithFile("00000001.jp2", ""),
+									fs.WithFile("00000001_PREMIS.xml", ""),
+									fs.WithFile("00000002.jp2", ""),
+									fs.WithFile("00000002_PREMIS.xml", ""),
+									fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
+								),
+							),
+							fs.WithDir("header",
+								fs.WithDir("old",
+									fs.WithDir("SIP",
+										fs.WithFile("metadata.xml", ""),
+									),
+								),
+								fs.WithDir("xsd",
+									fs.WithFile("arelda.xsd", ""),
+								),
+							),
+						),
+					),
+				),
 			},
-			result: activities.VerifyManifestResult{},
+			want: activities.VerifyManifestResult{},
+		},
+		{
+			name: "Verifies a digitized SIP manifest",
+			params: activities.VerifyManifestParams{
+				SIP: testSIP(
+					t,
+					fs.NewDir(t, "Test_Digitized_SIP",
+						fs.WithDir("content",
+							fs.WithDir("d_0000001",
+								fs.WithFile("00000001.jp2", ""),
+								fs.WithFile("00000001_PREMIS.xml", ""),
+								fs.WithFile("00000002.jp2", ""),
+								fs.WithFile("00000002_PREMIS.xml", ""),
+								fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
+							),
+						),
+						fs.WithDir("header",
+							fs.WithDir("xsd",
+								fs.WithFile("arelda.xsd", ""),
+							),
+							fs.WithFile("metadata.xml", sipManifest),
+						),
+					),
+				),
+			},
+			want: activities.VerifyManifestResult{},
 		},
 		{
 			name: "Returns a list of missing files",
 			params: activities.VerifyManifestParams{
-				SIP: missingFileSIP,
-			},
-			result: activities.VerifyManifestResult{
-				Failures: []string{
-					fmt.Sprintf(
-						"Missing file: %s",
-						filepath.Join("d_0000001", "00000001.jp2"),
+				SIP: testSIP(
+					t,
+					fs.NewDir(t, "Test_Missing_Files",
+						fs.WithDir("additional",
+							fs.WithFile("UpdatedAreldaMetadata.xml", aipManifest),
+						),
+						fs.WithDir("content",
+							fs.WithDir("content",
+								fs.WithDir("d_0000001",
+									// fs.WithFile("00000001.jp2", ""),
+									fs.WithFile("00000001_PREMIS.xml", ""),
+									fs.WithFile("00000002.jp2", ""),
+									fs.WithFile("00000002_PREMIS.xml", ""),
+									fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
+								),
+							),
+							fs.WithDir("header",
+								fs.WithDir("old",
+									fs.WithDir("SIP",
+										fs.WithFile("metadata.xml", ""),
+									),
+								),
+							),
+						),
 					),
+				),
+			},
+			want: activities.VerifyManifestResult{
+				Failures: []string{
+					"Missing file: content/content/d_0000001/00000001.jp2",
+					"Missing file: content/header/xsd/arelda.xsd",
 				},
 			},
 		},
 		{
 			name: "Returns a list of extra files",
 			params: activities.VerifyManifestParams{
-				SIP: extraFileSIP,
-			},
-			result: activities.VerifyManifestResult{
-				Failures: []string{
-					fmt.Sprintf(
-						"Unexpected file: %s",
-						filepath.Join("d_0000001", "extra_file.txt"),
+				SIP: testSIP(
+					t,
+					fs.NewDir(t, "Test_Extra_Files",
+						fs.WithDir("additional",
+							fs.WithFile("UpdatedAreldaMetadata.xml", aipManifest),
+						),
+						fs.WithDir("content",
+							fs.WithDir("content",
+								fs.WithDir("d_0000001",
+									fs.WithFile("extra_file.txt", "I'm an extra file."),
+									fs.WithFile("00000001.jp2", ""),
+									fs.WithFile("00000001_PREMIS.xml", ""),
+									fs.WithFile("00000002.jp2", ""),
+									fs.WithFile("00000002_PREMIS.xml", ""),
+									fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
+								),
+							),
+							fs.WithDir("header",
+								fs.WithDir("old",
+									fs.WithDir("SIP",
+										fs.WithFile("metadata.xml", ""),
+									),
+								),
+								fs.WithDir("xsd",
+									fs.WithFile("arelda.xsd", ""),
+									fs.WithFile("extra.xsd", ""),
+								),
+							),
+						),
 					),
+				),
+			},
+			want: activities.VerifyManifestResult{
+				Failures: []string{
+					"Unexpected file: content/content/d_0000001/extra_file.txt",
+					"Unexpected file: content/header/xsd/extra.xsd",
 				},
 			},
 		},
@@ -240,7 +338,7 @@ func TestVerifyManifest(t *testing.T) {
 
 			var res activities.VerifyManifestResult
 			future.Get(&res)
-			assert.DeepEqual(t, res, tt.result)
+			assert.DeepEqual(t, res, tt.want)
 		})
 	}
 }

--- a/internal/premis/premis.go
+++ b/internal/premis/premis.go
@@ -197,7 +197,12 @@ func AppendEventXMLForEachObject(doc *etree.Document, eventSummary EventSummary,
 	return nil
 }
 
-func appendEventXMLForObjects(PREMISEl *etree.Element, eventSummary EventSummary, agent Agent, objectEls []*etree.Element) {
+func appendEventXMLForObjects(
+	PREMISEl *etree.Element,
+	eventSummary EventSummary,
+	agent Agent,
+	objectEls []*etree.Element,
+) {
 	for _, objectEl := range objectEls {
 		// Define PREMIS event.
 		event := eventFromEventSummaryAndAgent(eventSummary, agent)
@@ -414,7 +419,7 @@ func FilesWithinDirectory(contentPath string) ([]string, error) {
 	return subpaths, nil
 }
 
-func OriginalNameForSubpath(contentPath string, subpath string) string {
+func OriginalNameForSubpath(contentPath, subpath string) string {
 	transferDirName := filepath.Base(filepath.Dir(filepath.Dir(contentPath)))
 
 	if filepath.Base(subpath) == "Prozess_Digitalisierung_PREMIS.xml" {


### PR DESCRIPTION
Refs #35

- Add the SIP "header" directory to the files checked against the manifest
- Add an exception to ignore the "header/metadata.xml" file when it's not included in the manifest (digitized SIP, born digital)
- Add a unit test that verifies a digitized SIP manifest