### PR TITLE
Tweak DigitizedSIP identification

### DIFF
--- a/internal/sip/sip.go
+++ b/internal/sip/sip.go
@@ -55,7 +55,7 @@ func New(path string) (SIP, error) {
 	if err != nil {
 		return s, fmt.Errorf("SIP: New: %v", err)
 	}
-	if len(f) > 0 && strings.Contains(s.Path, "Vecteur") {
+	if len(f) > 0 && strings.Contains(strings.ToLower(s.Path), "vecteur") {
 		return s.digitizedSIP(), nil
 	}
 

--- a/internal/sip/sip_test.go
+++ b/internal/sip/sip_test.go
@@ -27,6 +27,15 @@ func TestNew(t *testing.T) {
 		fs.WithDir("header"),
 	)
 
+	digitizedSIPCase := fs.NewDir(t, "SIP_20201201_vecteur",
+		fs.WithDir("content",
+			fs.WithDir("d_0000001",
+				fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
+			),
+		),
+		fs.WithDir("header"),
+	)
+
 	bornDigital := fs.NewDir(t, "",
 		fs.WithDir("content"),
 		fs.WithDir("header"),
@@ -68,6 +77,22 @@ func TestNew(t *testing.T) {
 				TopLevelPaths: []string{
 					digitizedSIP.Join("content"),
 					digitizedSIP.Join("header"),
+				},
+			},
+		},
+		{
+			name: "Creates a new digitized SIP (case-insensitive)",
+			path: digitizedSIPCase.Path(),
+			wantSIP: sip.SIP{
+				Type:         enums.SIPTypeDigitizedSIP,
+				Path:         digitizedSIPCase.Path(),
+				ContentPath:  digitizedSIPCase.Join("content"),
+				ManifestPath: digitizedSIPCase.Join("header", "metadata.xml"),
+				MetadataPath: digitizedSIPCase.Join("header", "metadata.xml"),
+				XSDPath:      digitizedSIPCase.Join("header", "xsd", "arelda.xsd"),
+				TopLevelPaths: []string{
+					digitizedSIPCase.Join("content"),
+					digitizedSIPCase.Join("header"),
 				},
 			},
 		},


### PR DESCRIPTION
Use case-insensitive match to find "vecteur" in the SIP path.

Refs #34.