### PR TITLE
Use manifest file id as PREMIS objectIdentifier

### DIFF
--- a/internal/activities/add_premis_objects_test.go
+++ b/internal/activities/add_premis_objects_test.go
@@ -1,6 +1,8 @@
 package activities_test
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	temporalsdk_activity "go.temporal.io/sdk/activity"
@@ -9,91 +11,73 @@ import (
 	"gotest.tools/v3/fs"
 
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/activities"
-	"github.com/artefactual-sdps/preprocessing-sfa/internal/enums"
-	"github.com/artefactual-sdps/preprocessing-sfa/internal/premis"
-	"github.com/artefactual-sdps/preprocessing-sfa/internal/sip"
 )
 
 func TestAddPREMISObjects(t *testing.T) {
 	t.Parallel()
 
 	// Normally populated files (for execution expected to work).
-	ContentFilesNormal := fs.NewDir(t, "",
-		fs.WithDir("content",
+	contentFilesNormal := fs.NewDir(t, "",
+		fs.WithDir("digitized_Vecteur_SIP",
+			fs.WithDir("header",
+				fs.WithDir("xsd",
+					fs.WithFile("arelda.xsd", ""),
+				),
+				fs.WithFile("metadata.xml", sipManifest),
+			),
 			fs.WithDir("content",
 				fs.WithDir("d_0000001",
 					fs.WithFile("00000001.jp2", ""),
 					fs.WithFile("00000001_PREMIS.xml", ""),
+					fs.WithFile("00000002.jp2", ""),
+					fs.WithFile("00000002_PREMIS.xml", ""),
+					fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
 				),
 			),
 		),
 	)
 
-	PREMISFilePathNormal := ContentFilesNormal.Join("metadata", "premis.xml")
+	premisFilePathNormal := contentFilesNormal.Join("digitized_Vecteur_SIP", "metadata", "premis.xml")
 
 	// No files (for execution expected to work).
-	ContentNoFiles := fs.NewDir(t, "",
-		fs.WithDir("content",
+	contentNoFiles := fs.NewDir(t, "",
+		fs.WithDir("digitized_Vecteur_SIP",
 			fs.WithDir("content",
-				fs.WithDir("d_0000001"),
+				fs.WithDir("content",
+					fs.WithDir("d_0000001"),
+				),
 			),
 		),
 	)
 
-	PREMISFilePathNoFiles := ContentNoFiles.Join("metadata", "premis.xml")
-
-	// Non-existent paths (for execution expected to fail).
-	ContentNonExistent := fs.NewDir(t, "",
-		fs.WithDir("content",
-			fs.WithDir("content",
-				fs.WithDir("d_0000001"),
-			),
-		),
-	)
-
-	PREMISFilePathNonExistent := ContentNonExistent.Join("metadata", "premis.xml")
-
-	ContentNonExistent.Remove()
+	premisFilePathNoFiles := contentNoFiles.Join("digitized_Vecteur_SIP", "metadata", "premis.xml")
 
 	tests := []struct {
-		name    string
-		params  activities.AddPREMISObjectsParams
-		result  activities.AddPREMISObjectsResult
-		wantErr string
+		name       string
+		params     activities.AddPREMISObjectsParams
+		result     activities.AddPREMISObjectsResult
+		wantPREMIS string
+		wantErr    string
 	}{
 		{
 			name: "Add PREMIS objects for normal content",
 			params: activities.AddPREMISObjectsParams{
-				SIP: sip.SIP{
-					Type:        enums.SIPTypeDigitizedAIP,
-					ContentPath: ContentFilesNormal.Path(),
-				},
-				PREMISFilePath: PREMISFilePathNormal,
+				SIP:            testSIP(t, contentFilesNormal.Join("digitized_Vecteur_SIP")),
+				PREMISFilePath: premisFilePathNormal,
 			},
 			result: activities.AddPREMISObjectsResult{},
 		},
 		{
-			name: "Add PREMIS objects for no content",
+			name: "Error when manifest is missing",
 			params: activities.AddPREMISObjectsParams{
-				SIP: sip.SIP{
-					Type:        enums.SIPTypeDigitizedAIP,
-					ContentPath: ContentNoFiles.Path(),
-				},
-				PREMISFilePath: PREMISFilePathNoFiles,
+				SIP:            testSIP(t, contentNoFiles.Join("digitized_Vecteur_SIP")),
+				PREMISFilePath: premisFilePathNoFiles,
 			},
 			result: activities.AddPREMISObjectsResult{},
-		},
-		{
-			name: "Add PREMIS objects for bad path",
-			params: activities.AddPREMISObjectsParams{
-				SIP: sip.SIP{
-					Type:        enums.SIPTypeDigitizedAIP,
-					ContentPath: ContentNonExistent.Path(),
-				},
-				PREMISFilePath: PREMISFilePathNonExistent,
-			},
-			result:  activities.AddPREMISObjectsResult{},
-			wantErr: "no such file or directory",
+			wantErr: fmt.Sprintf(
+				"open manifest file: open %s: no such file or directory",
+				contentNoFiles.Join("digitized_Vecteur_SIP", "header", "metadata.xml"),
+			),
 		},
 	}
 	for _, tt := range tests {
@@ -119,21 +103,87 @@ func TestAddPREMISObjects(t *testing.T) {
 
 				return
 			}
-
 			assert.NilError(t, err)
 
 			future.Get(&res)
-			assert.NilError(t, err)
 			assert.DeepEqual(t, res, tt.result)
 
-			// If the content directory has files, make sure that PREMIS file can be parsed.
-			contentFiles, err := premis.FilesWithinDirectory(tt.params.SIP.ContentPath)
+			b, err := os.ReadFile(tt.params.PREMISFilePath)
 			assert.NilError(t, err)
-
-			if len(contentFiles) > 0 {
-				_, err = premis.ParseFile(tt.params.PREMISFilePath)
-				assert.NilError(t, err)
-			}
+			assert.Equal(t, string(b), `<?xml version="1.0" encoding="UTF-8"?>
+<premis:premis xmlns:premis="http://www.loc.gov/premis/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/premis/v3 https://www.loc.gov/standards/premis/premis.xsd" version="3.0">
+  <premis:object xsi:type="premis:file">
+    <premis:objectIdentifier>
+      <premis:objectIdentifierType>local</premis:objectIdentifierType>
+      <premis:objectIdentifierValue>_zodSTSD0nv05CpOp6JoV3X</premis:objectIdentifierValue>
+    </premis:objectIdentifier>
+    <premis:objectCharacteristics>
+      <premis:format>
+        <premis:formatDesignation>
+          <premis:formatName/>
+        </premis:formatDesignation>
+      </premis:format>
+    </premis:objectCharacteristics>
+    <premis:originalName>data/objects/digitized_Vecteur_SIP/content/d_0000001/00000001.jp2</premis:originalName>
+  </premis:object>
+  <premis:object xsi:type="premis:file">
+    <premis:objectIdentifier>
+      <premis:objectIdentifierType>local</premis:objectIdentifierType>
+      <premis:objectIdentifierValue>_WuDmXAs5UDwKTGVLsCcZxa</premis:objectIdentifierValue>
+    </premis:objectIdentifier>
+    <premis:objectCharacteristics>
+      <premis:format>
+        <premis:formatDesignation>
+          <premis:formatName/>
+        </premis:formatDesignation>
+      </premis:format>
+    </premis:objectCharacteristics>
+    <premis:originalName>data/objects/digitized_Vecteur_SIP/content/d_0000001/00000001_PREMIS.xml</premis:originalName>
+  </premis:object>
+  <premis:object xsi:type="premis:file">
+    <premis:objectIdentifier>
+      <premis:objectIdentifierType>local</premis:objectIdentifierType>
+      <premis:objectIdentifierValue>_rlPKJX9ZcAl4ooc4IfoIkM</premis:objectIdentifierValue>
+    </premis:objectIdentifier>
+    <premis:objectCharacteristics>
+      <premis:format>
+        <premis:formatDesignation>
+          <premis:formatName/>
+        </premis:formatDesignation>
+      </premis:format>
+    </premis:objectCharacteristics>
+    <premis:originalName>data/objects/digitized_Vecteur_SIP/content/d_0000001/00000002.jp2</premis:originalName>
+  </premis:object>
+  <premis:object xsi:type="premis:file">
+    <premis:objectIdentifier>
+      <premis:objectIdentifierType>local</premis:objectIdentifierType>
+      <premis:objectIdentifierValue>_Ohk77y2DJa82RXqsWG4S90</premis:objectIdentifierValue>
+    </premis:objectIdentifier>
+    <premis:objectCharacteristics>
+      <premis:format>
+        <premis:formatDesignation>
+          <premis:formatName/>
+        </premis:formatDesignation>
+      </premis:format>
+    </premis:objectCharacteristics>
+    <premis:originalName>data/objects/digitized_Vecteur_SIP/content/d_0000001/00000002_PREMIS.xml</premis:originalName>
+  </premis:object>
+  <premis:object xsi:type="premis:file">
+    <premis:objectIdentifier>
+      <premis:objectIdentifierType>local</premis:objectIdentifierType>
+      <premis:objectIdentifierValue>_cQ6sm5CChWVqtqmrWvne0W</premis:objectIdentifierValue>
+    </premis:objectIdentifier>
+    <premis:objectCharacteristics>
+      <premis:format>
+        <premis:formatDesignation>
+          <premis:formatName/>
+        </premis:formatDesignation>
+      </premis:format>
+    </premis:objectCharacteristics>
+    <premis:originalName>data/metadata/Prozess_Digitalisierung_PREMIS_d_0000001.xml</premis:originalName>
+  </premis:object>
+</premis:premis>
+`)
 		})
 	}
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -125,7 +125,7 @@ var (
 			</ordner>
 		</inhaltsverzeichnis>
 	</paket>
-	`
+`
 )
 
 func TestFiles(t *testing.T) {
@@ -134,66 +134,93 @@ func TestFiles(t *testing.T) {
 	tests := []struct {
 		name    string
 		reader  io.Reader
-		want    map[string]*manifest.Checksum
+		want    map[string]*manifest.File
 		wantErr string
 	}{
 		{
 			name:   "Returns a digitized AIP file list",
 			reader: strings.NewReader(AIPManifest),
-			want: map[string]*manifest.Checksum{
+			want: map[string]*manifest.File{
 				"content/d_0000001/00000001.jp2": {
-					Algorithm: "MD5",
-					Hash:      "f7dc1f76a55cbdca0ae4a6dc8ae64644",
+					ID: "_miEf29GTkFR7ymi91IV4fO",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "f7dc1f76a55cbdca0ae4a6dc8ae64644",
+					},
 				},
 				"content/d_0000001/00000001_PREMIS.xml": {
-					Algorithm: "MD5",
-					Hash:      "1428a269ff4e5b4894793b68646984b7",
+					ID: "_SRpeVgb4xGImymb23OH1od",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "1428a269ff4e5b4894793b68646984b7",
+					},
 				},
 				"content/d_0000001/Prozess_Digitalisierung_PREMIS.xml": {
-					Algorithm: "MD5",
-					Hash:      "8067daaa900eba6dace69572eea8f8f3",
+					ID: "_fZzi3dX2jvrwakvY6jeJS8",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "8067daaa900eba6dace69572eea8f8f3",
+					},
 				},
 				"header/old/SIP/metadata.xml": {
-					Algorithm: "MD5",
-					Hash:      "43c533d499c572fca699e77e06295ba3",
+					ID: "OLD_SIP",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "43c533d499c572fca699e77e06295ba3",
+					},
 				},
 				"header/xsd/arelda.xsd": {
-					Algorithm: "MD5",
-					Hash:      "f8454632e1ebf97e0aa8d9527ce2641f",
+					ID: "_xAlSBc3dYcypUMvN8HzeN5",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "f8454632e1ebf97e0aa8d9527ce2641f",
+					},
 				},
 			},
 		},
 		{
 			name:   "Returns a digitized SIP file list",
 			reader: strings.NewReader(SIPManifest),
-			want: map[string]*manifest.Checksum{
+			want: map[string]*manifest.File{
 				"content/d_0000001/00000001.jp2": {
-					Algorithm: "MD5",
-					Hash:      "dc29291d0e2a18363d0efd2ec2fe81c9",
+					ID: "_zodSTSD0nv05CpOp6JoV3X",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "dc29291d0e2a18363d0efd2ec2fe81c9",
+					},
 				},
 				"content/d_0000001/00000001_PREMIS.xml": {
-					Algorithm: "MD5",
-					Hash:      "1d310772d26138a42eb2d6bebb637457",
+					ID: "_WuDmXAs5UDwKTGVLsCcZxa",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "1d310772d26138a42eb2d6bebb637457",
+					},
 				},
 				"content/d_0000001/Prozess_Digitalisierung_PREMIS.xml": {
-					Algorithm: "MD5",
-					Hash:      "21d8e90afdefd2c43386ca1d1658cab0",
+					ID: "_cQ6sm5CChWVqtqmrWvne0W",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "21d8e90afdefd2c43386ca1d1658cab0",
+					},
 				},
 				"header/xsd/arelda.xsd": {
-					Algorithm: "MD5",
-					Hash:      "f8454632e1ebf97e0aa8d9527ce2641f",
+					ID: "_ZSANrSklQ9HGn99yjlUumz",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "f8454632e1ebf97e0aa8d9527ce2641f",
+					},
 				},
 			},
 		},
 		{
 			name:   "Returns an empty list from an empty manifest",
 			reader: strings.NewReader(""),
-			want:   map[string]*manifest.Checksum{},
+			want:   map[string]*manifest.File{},
 		},
 		{
 			name:    "Errors on a missing closing tag",
 			reader:  strings.NewReader(`<datei id="_ZSANrSklQ9HGn99yjlUumz"><name>arelda.xsd</name>`),
-			want:    map[string]*manifest.Checksum{},
+			want:    map[string]*manifest.File{},
 			wantErr: "parse: XML syntax error on line 1: unexpected EOF",
 		},
 	}


### PR DESCRIPTION
Fixes #53.

- Parse manifest datei id attributes
- Use the datei id value as the PREMIS objectIdentifierValue