### PR TITLE
Write file IDs to an identifiers.json file

### DIFF
--- a/cmd/worker/workercmd/cmd.go
+++ b/cmd/worker/workercmd/cmd.go
@@ -2,6 +2,7 @@ package workercmd
 
 import (
 	"context"
+	"crypto/rand"
 
 	"github.com/artefactual-sdps/temporal-activities/bagcreate"
 	"github.com/go-logr/logr"
@@ -76,7 +77,7 @@ func (m *Main) Run(ctx context.Context) error {
 		temporalsdk_activity.RegisterOptions{Name: activities.ValidateFileFormatsName},
 	)
 	w.RegisterActivityWithOptions(
-		activities.NewAddPREMISObjects().Execute,
+		activities.NewAddPREMISObjects(rand.Reader).Execute,
 		temporalsdk_activity.RegisterOptions{Name: activities.AddPREMISObjectsName},
 	)
 	w.RegisterActivityWithOptions(
@@ -94,6 +95,10 @@ func (m *Main) Run(ctx context.Context) error {
 	w.RegisterActivityWithOptions(
 		activities.NewTransformSIP().Execute,
 		temporalsdk_activity.RegisterOptions{Name: activities.TransformSIPName},
+	)
+	w.RegisterActivityWithOptions(
+		activities.NewWriteIdentifierFile().Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.WriteIdentifierFileName},
 	)
 	w.RegisterActivityWithOptions(
 		bagcreate.New(m.cfg.Bagit).Execute,

--- a/internal/activities/transform_sip.go
+++ b/internal/activities/transform_sip.go
@@ -11,6 +11,7 @@ import (
 	"go.artefactual.dev/tools/fsutil"
 
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/enums"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/pips"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/sip"
 )
 
@@ -20,7 +21,9 @@ type TransformSIPParams struct {
 	SIP sip.SIP
 }
 
-type TransformSIPResult struct{}
+type TransformSIPResult struct {
+	PIP pips.PIP
+}
 
 type TransformSIP struct{}
 
@@ -107,5 +110,5 @@ func (a *TransformSIP) Execute(ctx context.Context, params *TransformSIPParams) 
 		return nil, err
 	}
 
-	return &TransformSIPResult{}, nil
+	return &TransformSIPResult{PIP: pips.NewFromSIP(params.SIP)}, nil
 }

--- a/internal/activities/write_identifier_file.go
+++ b/internal/activities/write_identifier_file.go
@@ -1,0 +1,90 @@
+package activities
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/identifiers"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/manifest"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/pips"
+)
+
+const WriteIdentifierFileName = "write-identifier-file"
+
+type (
+	WriteIdentifierFileActivity struct{}
+	WriteIdentifierFileParams   struct {
+		PIP pips.PIP
+	}
+	WriteIdentifierFileResult struct {
+		Path string
+	}
+)
+
+func NewWriteIdentifierFile() *WriteIdentifierFileActivity {
+	return &WriteIdentifierFileActivity{}
+}
+
+func (a *WriteIdentifierFileActivity) Execute(
+	ctx context.Context,
+	params *WriteIdentifierFileParams,
+) (*WriteIdentifierFileResult, error) {
+	path, err := a.write(params.PIP)
+	if err != nil {
+		return nil, fmt.Errorf("write identifier file: %v", err)
+	}
+
+	return &WriteIdentifierFileResult{Path: path}, nil
+}
+
+func (a *WriteIdentifierFileActivity) write(pip pips.PIP) (string, error) {
+	r, err := os.Open(pip.ManifestPath)
+	if err != nil {
+		return "", fmt.Errorf("open manifest: %v", err)
+	}
+	defer r.Close()
+
+	m, err := manifest.Files(r)
+	if err != nil {
+		return "", err
+	}
+
+	ids, err := identifiers.FromManifest(m)
+	if err != nil {
+		return "", fmt.Errorf("get manifest identifiers: %v", err)
+	}
+
+	b, err := json.MarshalIndent(pipIdentifiers(pip, ids), "", "    ")
+	if err != nil {
+		return "", fmt.Errorf("marshal identifiers: %v", err)
+	}
+
+	path := filepath.Join(pip.Path, "metadata", "identifiers.json")
+	if err := os.WriteFile(path, b, os.FileMode(0o644)); err != nil {
+		return "", fmt.Errorf("write identifiers.json: %v", err)
+	}
+
+	return path, nil
+}
+
+// pipIdentifiers takes a list of manifest file ids and converts the manifest
+// file paths to the restructured PIP file paths. Any files that are included
+// in the manifest but are not included in the PIP (e.g. XSD files) are removed
+// from the returned file list.
+func pipIdentifiers(pip pips.PIP, ids []identifiers.File) []identifiers.File {
+	r := make([]identifiers.File, 0, len(ids))
+
+	for _, id := range ids {
+		if p := pip.ConvertSIPPath(id.Path); p != "" {
+			id.Path = p
+			r = append(r, id)
+		}
+	}
+	slices.SortFunc(r, identifiers.Compare)
+
+	return r
+}

--- a/internal/activities/write_identifier_file_test.go
+++ b/internal/activities/write_identifier_file_test.go
@@ -1,0 +1,196 @@
+package activities_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/activities"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/enums"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/pips"
+)
+
+func TestWriteIdentifierFile(t *testing.T) {
+	t.Parallel()
+
+	pipDigitizedSIP := pips.New(
+		fs.NewDir(t, "",
+			fs.WithDir("Test_Digitized_SIP",
+				fs.WithDir("metadata"),
+				fs.WithDir("objects",
+					fs.WithDir("Test_Digitized_SIP",
+						fs.WithDir("header",
+							fs.WithFile("metadata.xml", sipManifest),
+						),
+					),
+				),
+			),
+		).Join("Test_Digitized_SIP"),
+		enums.SIPTypeDigitizedSIP,
+	)
+
+	pipNoManifest := pips.New(fs.NewDir(t, "").Path(), enums.SIPTypeBornDigital)
+
+	pipEmptyManifest := pips.New(
+		fs.NewDir(t, "",
+			fs.WithDir("Test_digitized_SIP",
+				fs.WithDir("metadata"),
+				fs.WithDir("objects",
+					fs.WithDir("Test_digitized_SIP",
+						fs.WithDir("header",
+							fs.WithFile("metadata.xml", ""),
+						),
+					),
+				),
+			),
+		).Join("Test_digitized_SIP"),
+		enums.SIPTypeDigitizedSIP,
+	)
+
+	pipReadOnly := pips.New(
+		fs.NewDir(t, "",
+			fs.WithDir("Test_Digitized_SIP",
+				fs.WithDir("metadata", fs.WithMode(0o400)),
+				fs.WithDir("objects",
+					fs.WithDir("Test_Digitized_SIP",
+						fs.WithDir("header",
+							fs.WithFile("metadata.xml", sipManifest),
+						),
+					),
+				),
+			),
+		).Join("Test_Digitized_SIP"),
+		enums.SIPTypeDigitizedSIP,
+	)
+
+	tests := []struct {
+		name     string
+		params   activities.WriteIdentifierFileParams
+		wantJSON string
+		wantErr  string
+	}{
+		{
+			name: "Writes a digitized SIP identifier file",
+			params: activities.WriteIdentifierFileParams{
+				PIP: pipDigitizedSIP,
+			},
+			wantJSON: `[
+    {
+        "file": "metadata/Prozess_Digitalisierung_PREMIS_d_0000001.xml",
+        "identifiers": [
+            {
+                "identifier": "_cQ6sm5CChWVqtqmrWvne0W",
+                "identifierType": "local"
+            }
+        ]
+    },
+    {
+        "file": "objects/Test_Digitized_SIP/content/d_0000001/00000001.jp2",
+        "identifiers": [
+            {
+                "identifier": "_zodSTSD0nv05CpOp6JoV3X",
+                "identifierType": "local"
+            }
+        ]
+    },
+    {
+        "file": "objects/Test_Digitized_SIP/content/d_0000001/00000001_PREMIS.xml",
+        "identifiers": [
+            {
+                "identifier": "_WuDmXAs5UDwKTGVLsCcZxa",
+                "identifierType": "local"
+            }
+        ]
+    },
+    {
+        "file": "objects/Test_Digitized_SIP/content/d_0000001/00000002.jp2",
+        "identifiers": [
+            {
+                "identifier": "_rlPKJX9ZcAl4ooc4IfoIkM",
+                "identifierType": "local"
+            }
+        ]
+    },
+    {
+        "file": "objects/Test_Digitized_SIP/content/d_0000001/00000002_PREMIS.xml",
+        "identifiers": [
+            {
+                "identifier": "_Ohk77y2DJa82RXqsWG4S90",
+                "identifierType": "local"
+            }
+        ]
+    }
+]`,
+		},
+		{
+			name: "Errors when manifest is not readable",
+			params: activities.WriteIdentifierFileParams{
+				PIP: pipNoManifest,
+			},
+			wantErr: fmt.Sprintf(
+				"write identifier file: open manifest: open %s: no such file or directory",
+				pipNoManifest.ManifestPath,
+			),
+		},
+		{
+			name: "Errors when manifest is invalid",
+			params: activities.WriteIdentifierFileParams{
+				PIP: pipEmptyManifest,
+			},
+			wantErr: "write identifier file: get manifest identifiers: no files in manifest",
+		},
+		{
+			name: "Errors when metadata path is not writable",
+			params: activities.WriteIdentifierFileParams{
+				PIP: pipReadOnly,
+			},
+			wantErr: fmt.Sprintf(
+				"write identifier file: write identifiers.json: open %s: permission denied",
+				pipReadOnly.Path+"/metadata/identifiers.json",
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			env.RegisterActivityWithOptions(
+				activities.NewWriteIdentifierFile().Execute,
+				temporalsdk_activity.RegisterOptions{Name: activities.WriteIdentifierFileName},
+			)
+
+			future, err := env.ExecuteActivity(activities.WriteIdentifierFileName, tt.params)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Errorf("error is nil, expecting: %q", tt.wantErr)
+				} else {
+					assert.Error(
+						t,
+						err,
+						"activity error (type: write-identifier-file, scheduledEventID: 0, startedEventID: 0, identity: ): "+tt.wantErr,
+					)
+				}
+
+				return
+			}
+			assert.NilError(t, err)
+
+			var res activities.WriteIdentifierFileResult
+			future.Get(&res)
+			p := filepath.Join(tt.params.PIP.Path, "metadata", "identifiers.json")
+			assert.DeepEqual(t, res, activities.WriteIdentifierFileResult{Path: p})
+
+			b, err := os.ReadFile(p)
+			assert.NilError(t, err)
+			assert.Equal(t, string(b), tt.wantJSON)
+		})
+	}
+}

--- a/internal/identifiers/identifiers.go
+++ b/internal/identifiers/identifiers.go
@@ -1,0 +1,54 @@
+package identifiers
+
+import (
+	"errors"
+	"slices"
+	"strings"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/manifest"
+)
+
+// Identifier represents a file identifier in an Archivematica
+// "identifiers.json" document.
+type Identifier struct {
+	Value string `json:"identifier"`
+	Type  string `json:"identifierType"`
+}
+
+// File represents a file and its associated identifiers in an Archivematica
+// "identifiers.json" document.
+type File struct {
+	Path        string       `json:"file"`
+	Identifiers []Identifier `json:"identifiers"`
+}
+
+// Compare returns an integer comparing two File paths lexicographically for
+// sorting purposes. The returned value matches the return values of
+// https://pkg.go.dev/strings#Compare.
+func Compare(a, b File) int {
+	return strings.Compare(a.Path, b.Path)
+}
+
+func FromManifest(m manifest.Manifest) ([]File, error) {
+	if len(m) == 0 {
+		return nil, errors.New("no files in manifest")
+	}
+
+	res := make([]File, len(m))
+	i := 0
+	for path, file := range m {
+		res[i] = File{
+			Path: path,
+			Identifiers: []Identifier{
+				{
+					Value: file.ID,
+					Type:  "local",
+				},
+			},
+		}
+		i++
+	}
+	slices.SortFunc(res, Compare)
+
+	return res, nil
+}

--- a/internal/identifiers/identifiers_test.go
+++ b/internal/identifiers/identifiers_test.go
@@ -1,0 +1,146 @@
+package identifiers_test
+
+import (
+	"slices"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/identifiers"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/manifest"
+)
+
+func TestSortFunc(t *testing.T) {
+	l := []identifiers.File{
+		{Path: "dir/a.txt"},
+		{Path: "dir/C.txt"},
+		{Path: "b.txt"},
+		{Path: "b.txt"},
+		{Path: "e.txt"},
+	}
+	slices.SortFunc(l, identifiers.Compare)
+	assert.DeepEqual(t, l, []identifiers.File{
+		{Path: "b.txt"},
+		{Path: "b.txt"},
+		{Path: "dir/C.txt"}, // Uppercase letters sort before lowercase.
+		{Path: "dir/a.txt"},
+		{Path: "e.txt"},
+	})
+}
+
+func TestFromManifest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		manifest manifest.Manifest
+		want     []identifiers.File
+		wantErr  string
+	}{
+		{
+			name: "Returns a digitized AIP identifier list",
+			manifest: manifest.Manifest{
+				"content/d_0000001/00000001.jp2": {
+					ID: "_miEf29GTkFR7ymi91IV4fO",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "f7dc1f76a55cbdca0ae4a6dc8ae64644",
+					},
+				},
+				"content/d_0000001/00000001_PREMIS.xml": {
+					ID: "_SRpeVgb4xGImymb23OH1od",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "1428a269ff4e5b4894793b68646984b7",
+					},
+				},
+				"content/d_0000001/Prozess_Digitalisierung_PREMIS.xml": {
+					ID: "_fZzi3dX2jvrwakvY6jeJS8",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "8067daaa900eba6dace69572eea8f8f3",
+					},
+				},
+				"header/old/SIP/metadata.xml": {
+					ID: "OLD_SIP",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "43c533d499c572fca699e77e06295ba3",
+					},
+				},
+				"header/xsd/arelda.xsd": {
+					ID: "_xAlSBc3dYcypUMvN8HzeN5",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "f8454632e1ebf97e0aa8d9527ce2641f",
+					},
+				},
+			},
+			want: []identifiers.File{
+				{
+					Path: "content/d_0000001/00000001.jp2",
+					Identifiers: []identifiers.Identifier{
+						{
+							Value: "_miEf29GTkFR7ymi91IV4fO",
+							Type:  "local",
+						},
+					},
+				},
+				{
+					Path: "content/d_0000001/00000001_PREMIS.xml",
+					Identifiers: []identifiers.Identifier{
+						{
+							Value: "_SRpeVgb4xGImymb23OH1od",
+							Type:  "local",
+						},
+					},
+				},
+				{
+					Path: "content/d_0000001/Prozess_Digitalisierung_PREMIS.xml",
+					Identifiers: []identifiers.Identifier{
+						{
+							Value: "_fZzi3dX2jvrwakvY6jeJS8",
+							Type:  "local",
+						},
+					},
+				},
+				{
+					Path: "header/old/SIP/metadata.xml",
+					Identifiers: []identifiers.Identifier{
+						{
+							Value: "OLD_SIP",
+							Type:  "local",
+						},
+					},
+				},
+				{
+					Path: "header/xsd/arelda.xsd",
+					Identifiers: []identifiers.Identifier{
+						{
+							Value: "_xAlSBc3dYcypUMvN8HzeN5",
+							Type:  "local",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "Errors when manifest is empty",
+			manifest: manifest.Manifest{},
+			wantErr:  "no files in manifest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := identifiers.FromManifest(tt.manifest)
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -125,7 +125,7 @@ var (
 			</ordner>
 		</inhaltsverzeichnis>
 	</paket>
-	`
+`
 )
 
 func TestFiles(t *testing.T) {
@@ -134,66 +134,93 @@ func TestFiles(t *testing.T) {
 	tests := []struct {
 		name    string
 		reader  io.Reader
-		want    map[string]*manifest.Checksum
+		want    manifest.Manifest
 		wantErr string
 	}{
 		{
 			name:   "Returns a digitized AIP file list",
 			reader: strings.NewReader(AIPManifest),
-			want: map[string]*manifest.Checksum{
+			want: manifest.Manifest{
 				"content/d_0000001/00000001.jp2": {
-					Algorithm: "MD5",
-					Hash:      "f7dc1f76a55cbdca0ae4a6dc8ae64644",
+					ID: "_miEf29GTkFR7ymi91IV4fO",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "f7dc1f76a55cbdca0ae4a6dc8ae64644",
+					},
 				},
 				"content/d_0000001/00000001_PREMIS.xml": {
-					Algorithm: "MD5",
-					Hash:      "1428a269ff4e5b4894793b68646984b7",
+					ID: "_SRpeVgb4xGImymb23OH1od",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "1428a269ff4e5b4894793b68646984b7",
+					},
 				},
 				"content/d_0000001/Prozess_Digitalisierung_PREMIS.xml": {
-					Algorithm: "MD5",
-					Hash:      "8067daaa900eba6dace69572eea8f8f3",
+					ID: "_fZzi3dX2jvrwakvY6jeJS8",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "8067daaa900eba6dace69572eea8f8f3",
+					},
 				},
 				"header/old/SIP/metadata.xml": {
-					Algorithm: "MD5",
-					Hash:      "43c533d499c572fca699e77e06295ba3",
+					ID: "OLD_SIP",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "43c533d499c572fca699e77e06295ba3",
+					},
 				},
 				"header/xsd/arelda.xsd": {
-					Algorithm: "MD5",
-					Hash:      "f8454632e1ebf97e0aa8d9527ce2641f",
+					ID: "_xAlSBc3dYcypUMvN8HzeN5",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "f8454632e1ebf97e0aa8d9527ce2641f",
+					},
 				},
 			},
 		},
 		{
 			name:   "Returns a digitized SIP file list",
 			reader: strings.NewReader(SIPManifest),
-			want: map[string]*manifest.Checksum{
+			want: manifest.Manifest{
 				"content/d_0000001/00000001.jp2": {
-					Algorithm: "MD5",
-					Hash:      "dc29291d0e2a18363d0efd2ec2fe81c9",
+					ID: "_zodSTSD0nv05CpOp6JoV3X",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "dc29291d0e2a18363d0efd2ec2fe81c9",
+					},
 				},
 				"content/d_0000001/00000001_PREMIS.xml": {
-					Algorithm: "MD5",
-					Hash:      "1d310772d26138a42eb2d6bebb637457",
+					ID: "_WuDmXAs5UDwKTGVLsCcZxa",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "1d310772d26138a42eb2d6bebb637457",
+					},
 				},
 				"content/d_0000001/Prozess_Digitalisierung_PREMIS.xml": {
-					Algorithm: "MD5",
-					Hash:      "21d8e90afdefd2c43386ca1d1658cab0",
+					ID: "_cQ6sm5CChWVqtqmrWvne0W",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "21d8e90afdefd2c43386ca1d1658cab0",
+					},
 				},
 				"header/xsd/arelda.xsd": {
-					Algorithm: "MD5",
-					Hash:      "f8454632e1ebf97e0aa8d9527ce2641f",
+					ID: "_ZSANrSklQ9HGn99yjlUumz",
+					Checksum: manifest.Checksum{
+						Algorithm: "MD5",
+						Hash:      "f8454632e1ebf97e0aa8d9527ce2641f",
+					},
 				},
 			},
 		},
 		{
 			name:   "Returns an empty list from an empty manifest",
 			reader: strings.NewReader(""),
-			want:   map[string]*manifest.Checksum{},
+			want:   manifest.Manifest{},
 		},
 		{
 			name:    "Errors on a missing closing tag",
 			reader:  strings.NewReader(`<datei id="_ZSANrSklQ9HGn99yjlUumz"><name>arelda.xsd</name>`),
-			want:    map[string]*manifest.Checksum{},
+			want:    manifest.Manifest{},
 			wantErr: "parse: XML syntax error on line 1: unexpected EOF",
 		},
 	}

--- a/internal/pips/pips.go
+++ b/internal/pips/pips.go
@@ -1,0 +1,61 @@
+package pips
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/enums"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/sip"
+)
+
+type PIP struct {
+	// Type is the type of SIP (DigitizedAIP, DigitizedSIP, BornDigital).
+	Type enums.SIPType
+
+	// Path is the filepath of the PIP directory.
+	Path string
+
+	// ManifestPath is the filepath of the SIP manifest —
+	// "UpdatedAreldaMetadata.xml" for digitized AIPs, "metadata.xml" for all
+	// other SIP types.
+	ManifestPath string
+}
+
+func New(path string, t enums.SIPType) PIP {
+	p := PIP{Path: path, Type: t}
+	if p.Type == enums.SIPTypeDigitizedAIP {
+		p.ManifestPath = filepath.Join(path, "metadata", "UpdatedAreldaMetadata.xml")
+	} else {
+		p.ManifestPath = filepath.Join(path, "objects", p.Name(), "header", "metadata.xml")
+	}
+
+	return p
+}
+
+func NewFromSIP(sip sip.SIP) PIP {
+	return New(sip.Path, sip.Type)
+}
+
+func (p PIP) Name() string {
+	return filepath.Base(p.Path)
+}
+
+func (p PIP) ConvertSIPPath(path string) string {
+	switch {
+	case filepath.Base(path) == "Prozess_Digitalisierung_PREMIS.xml":
+		parent := filepath.Base(filepath.Dir(path))
+		return filepath.Join(
+			"metadata",
+			fmt.Sprintf("Prozess_Digitalisierung_PREMIS_%s.xml", parent),
+		)
+	case filepath.Base(path) == "metadata.xml":
+		return filepath.Join("objects", p.Name(), "header", "metadata.xml")
+	case filepath.Base(path) == "UpdatedAreldaMetadata.xml":
+		return filepath.Join("metadata", "UpdatedAreldaMetadata.xml")
+	case strings.HasPrefix(path, "content"):
+		return filepath.Join("objects", p.Name(), path)
+	default:
+		return ""
+	}
+}

--- a/internal/pips/pips_test.go
+++ b/internal/pips/pips_test.go
@@ -1,0 +1,106 @@
+package pips_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/enums"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/pips"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/sip"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	type params struct {
+		path    string
+		sipType enums.SIPType
+	}
+	type test struct {
+		name string
+		args params
+		want pips.PIP
+	}
+	for _, tt := range []test{
+		{
+			name: "Returns a digitized SIP PIP",
+			args: params{
+				path:    "/path/to/SIP_20201201_Vecteur",
+				sipType: enums.SIPTypeDigitizedSIP,
+			},
+			want: pips.PIP{
+				Path:         "/path/to/SIP_20201201_Vecteur",
+				Type:         enums.SIPTypeDigitizedSIP,
+				ManifestPath: "/path/to/SIP_20201201_Vecteur/objects/SIP_20201201_Vecteur/header/metadata.xml",
+			},
+		},
+		{
+			name: "Returns a digitized AIP PIP",
+			args: params{
+				path:    "/path/to/digitized_AIP_012345",
+				sipType: enums.SIPTypeDigitizedAIP,
+			},
+			want: pips.PIP{
+				Path:         "/path/to/digitized_AIP_012345",
+				Type:         enums.SIPTypeDigitizedAIP,
+				ManifestPath: "/path/to/digitized_AIP_012345/metadata/UpdatedAreldaMetadata.xml",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := pips.New(tt.args.path, tt.args.sipType)
+			assert.DeepEqual(t, p, tt.want)
+		})
+	}
+}
+
+func TestNewFromSIP(t *testing.T) {
+	t.Parallel()
+
+	s := sip.SIP{
+		Path: "/path/to/born_digital_AIP_12345",
+		Type: enums.SIPTypeBornDigital,
+	}
+	assert.DeepEqual(t, pips.NewFromSIP(s), pips.PIP{
+		Path:         "/path/to/born_digital_AIP_12345",
+		Type:         enums.SIPTypeBornDigital,
+		ManifestPath: "/path/to/born_digital_AIP_12345/objects/born_digital_AIP_12345/header/metadata.xml",
+	})
+}
+
+func TestName(t *testing.T) {
+	t.Parallel()
+
+	p := pips.New("/path/to/SIP_20201201_Vecteur", enums.SIPTypeDigitizedSIP)
+	assert.Equal(t, p.Name(), "SIP_20201201_Vecteur")
+}
+
+func TestConvertSIPPath(t *testing.T) {
+	t.Parallel()
+
+	p := pips.New("/path/to/SIP_20201201_Vecteur", enums.SIPTypeDigitizedSIP)
+	assert.Equal(t,
+		p.ConvertSIPPath("content/d_0000001/Prozess_Digitalisierung_PREMIS.xml"),
+		"metadata/Prozess_Digitalisierung_PREMIS_d_0000001.xml",
+	)
+	assert.Equal(t,
+		p.ConvertSIPPath("header/metadata.xml"),
+		"objects/SIP_20201201_Vecteur/header/metadata.xml",
+	)
+	assert.Equal(t,
+		p.ConvertSIPPath("header/old/SIP/metadata.xml"),
+		"objects/SIP_20201201_Vecteur/header/metadata.xml",
+	)
+	assert.Equal(t,
+		p.ConvertSIPPath("additional/UpdatedAreldaMetadata.xml"),
+		"metadata/UpdatedAreldaMetadata.xml",
+	)
+	assert.Equal(t,
+		p.ConvertSIPPath("content/d_0000001/00000001.jp2"),
+		"objects/SIP_20201201_Vecteur/content/d_0000001/00000001.jp2",
+	)
+	assert.Equal(t, p.ConvertSIPPath("header/xsd/arelda.xsd"), "")
+}

--- a/internal/sip/sip.go
+++ b/internal/sip/sip.go
@@ -97,3 +97,7 @@ func (s SIP) bornDigital() SIP {
 
 	return s
 }
+
+func (s SIP) Name() string {
+	return filepath.Base(s.Path)
+}

--- a/internal/sip/sip_test.go
+++ b/internal/sip/sip_test.go
@@ -13,7 +13,7 @@ import (
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	digitizedAIP := fs.NewDir(t, "",
+	digitizedAIP := fs.NewDir(t, "Test-AIP-Digitization",
 		fs.WithDir("content"),
 		fs.WithDir("additional"),
 	)
@@ -137,4 +137,14 @@ func TestNew(t *testing.T) {
 			assert.DeepEqual(t, s, tt.wantSIP)
 		})
 	}
+}
+
+func TestName(t *testing.T) {
+	t.Parallel()
+
+	s := sip.SIP{
+		Type: enums.SIPTypeDigitizedSIP,
+		Path: "/path/to/SIP_20201201_Vecteur",
+	}
+	assert.Equal(t, s.Name(), "SIP_20201201_Vecteur")
 }


### PR DESCRIPTION
Fixes #53.

- Parse manifest datei "id" attributes
- Write the "id" values to an "identifiers.json" file in the metadata directory of the SIP
- Archivematica will add the file IDs from the identifiers.json file to the PREMIS object data in the METS file