### PR TITLE
Don't rename Prozess_Digitalisierung_PREMIS.xml

### DIFF
--- a/internal/activities/add_premis_objects_test.go
+++ b/internal/activities/add_premis_objects_test.go
@@ -182,7 +182,7 @@ func TestAddPREMISObjects(t *testing.T) {
         </premis:formatDesignation>
       </premis:format>
     </premis:objectCharacteristics>
-    <premis:originalName>data/metadata/Prozess_Digitalisierung_PREMIS_d_0000001.xml</premis:originalName>
+    <premis:originalName>data/metadata/Prozess_Digitalisierung_PREMIS.xml</premis:originalName>
   </premis:object>
 </premis:premis>
 `)

--- a/internal/activities/transform_sip_test.go
+++ b/internal/activities/transform_sip_test.go
@@ -23,7 +23,7 @@ func TestTransformSIP(t *testing.T) {
 		fmode = os.FileMode(0o600)
 	)
 
-	digitizedAIPPath := fs.NewDir(t, "",
+	digitizedAIPPath := fs.NewDir(t, "Vecteur_Digitized_AIP",
 		fs.WithDir("additional",
 			fs.WithFile("UpdatedAreldaMetadata.xml", ""),
 		),
@@ -32,7 +32,6 @@ func TestTransformSIP(t *testing.T) {
 				fs.WithDir("d_0000001",
 					fs.WithFile("00000001.jp2", ""),
 					fs.WithFile("00000001_PREMIS.xml", ""),
-					fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
 				),
 			),
 			fs.WithDir("header",
@@ -48,7 +47,7 @@ func TestTransformSIP(t *testing.T) {
 		),
 	).Path()
 
-	digitizedSIPPath := fs.NewDir(t, "Test_Digitized_SIP",
+	digitizedSIPPath := fs.NewDir(t, "Vecteur_Digitized_SIP",
 		fs.WithDir("content",
 			fs.WithDir("d_0000001",
 				fs.WithFile("00000001.jp2", ""),
@@ -84,7 +83,6 @@ func TestTransformSIP(t *testing.T) {
 			),
 		),
 		fs.WithDir("metadata", fs.WithMode(dmode),
-			fs.WithFile("Prozess_Digitalisierung_PREMIS_d_0000001.xml", "", fs.WithMode(fmode)),
 			fs.WithFile("UpdatedAreldaMetadata.xml", "", fs.WithMode(fmode)),
 		),
 	)
@@ -104,11 +102,11 @@ func TestTransformSIP(t *testing.T) {
 			),
 		),
 		fs.WithDir("metadata", fs.WithMode(dmode),
-			fs.WithFile("Prozess_Digitalisierung_PREMIS_d_0000001.xml", "", fs.WithMode(fmode)),
+			fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", "", fs.WithMode(fmode)),
 		),
 	)
 
-	missingMetadataSIP, err := sip.New(fs.NewDir(t, "",
+	missingMetadataSIP, err := sip.New(fs.NewDir(t, "MissingMD_Vecteur_SIP",
 		fs.WithDir("content",
 			fs.WithDir("d_0000001",
 				fs.WithFile("00000001.jp2", ""),
@@ -118,7 +116,8 @@ func TestTransformSIP(t *testing.T) {
 		),
 	).Path())
 	assert.NilError(t, err)
-	missingContentSIP, err := sip.New(fs.NewDir(t, "",
+
+	missingContentSIP, err := sip.New(fs.NewDir(t, "Missing_Content_SIP",
 		fs.WithDir("header",
 			fs.WithFile("metadata.xml", ""),
 		),
@@ -142,7 +141,7 @@ func TestTransformSIP(t *testing.T) {
 			wantSIP: expectedDigitizedSIP,
 		},
 		{
-			name:   "Fails with a SIP missing the metadata file",
+			name:   "Fails when the metadata file is missing",
 			params: activities.TransformSIPParams{SIP: missingMetadataSIP},
 			wantErr: fmt.Sprintf(
 				"rename %s/header/metadata.xml %s/objects/%s/header/metadata.xml: no such file or directory",
@@ -152,11 +151,13 @@ func TestTransformSIP(t *testing.T) {
 			),
 		},
 		{
-			name:   "Fails with a SIP missing the content directory",
+			name:   "Fails when the content directory is missing",
 			params: activities.TransformSIPParams{SIP: missingContentSIP},
 			wantErr: fmt.Sprintf(
-				"lstat %s/content: no such file or directory",
+				"rename %s/content %s/objects/%s/content: no such file or directory (type: LinkError, retryable: true): no such file or directory",
 				missingContentSIP.Path,
+				missingContentSIP.Path,
+				filepath.Base(missingContentSIP.Path),
 			),
 		},
 	}

--- a/internal/activities/validate_structure.go
+++ b/internal/activities/validate_structure.go
@@ -74,6 +74,18 @@ func (a *ValidateStructure) Execute(
 		failures = append(failures, extras...)
 	}
 
+	// Check that digitized SIPs only have one dossier in the content dir.
+	if params.SIP.Type == enums.SIPTypeDigitizedSIP {
+		entries, err := os.ReadDir(params.SIP.ContentPath)
+		if err != nil {
+			return nil, fmt.Errorf("ValidateStructure: check for unexpected dossiers: %v", err)
+		}
+
+		if len(entries) > 1 {
+			failures = append(failures, "More than one dossier in the content directory")
+		}
+	}
+
 	return &ValidateStructureResult{Failures: failures}, nil
 }
 

--- a/internal/activities/validate_structure_test.go
+++ b/internal/activities/validate_structure_test.go
@@ -40,7 +40,11 @@ func TestValidateStructure(t *testing.T) {
 
 	digitizedSIP, err := sip.New(fs.NewDir(t, "",
 		fs.WithDir("content",
-			fs.WithDir("d_0000001"),
+			fs.WithDir("d_0000001",
+				fs.WithFile("00000001.jp2", ""),
+				fs.WithFile("00000001_PREMIS.xml", ""),
+				fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
+			),
 		),
 		fs.WithDir("header",
 			fs.WithFile("metadata.xml", ""),
@@ -71,6 +75,33 @@ func TestValidateStructure(t *testing.T) {
 
 	missingPiecesAIP, err := sip.New(fs.NewDir(t, "",
 		fs.WithDir("additional"),
+	).Path())
+	assert.NilError(t, err)
+
+	digitizedSIPExtraDossiers, err := sip.New(fs.NewDir(t, "",
+		fs.WithDir("content",
+			fs.WithDir("d_0000001",
+				fs.WithFile("00000001.jp2", ""),
+				fs.WithFile("00000001_PREMIS.xml", ""),
+				fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
+			),
+			fs.WithDir("d_0000002",
+				fs.WithFile("00000002.jp2", ""),
+				fs.WithFile("00000002_PREMIS.xml", ""),
+				fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
+			),
+			fs.WithDir("d_0000003",
+				fs.WithFile("00000003.jp2", ""),
+				fs.WithFile("00000003_PREMIS.xml", ""),
+				fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", ""),
+			),
+		),
+		fs.WithDir("header",
+			fs.WithFile("metadata.xml", ""),
+			fs.WithDir("xsd",
+				fs.WithFile("arelda.xsd", ""),
+			),
+		),
 	).Path())
 	assert.NilError(t, err)
 
@@ -119,6 +150,13 @@ func TestValidateStructure(t *testing.T) {
 					"metadata.xml is missing",
 					"UpdatedAreldaMetadata.xml is missing",
 				},
+			},
+		},
+		{
+			name:   "Returns a failure when a digitized SIP has more than one dossier",
+			params: activities.ValidateStructureParams{SIP: digitizedSIPExtraDossiers},
+			want: activities.ValidateStructureResult{
+				Failures: []string{"More than one dossier in the content directory"},
 			},
 		},
 	}

--- a/internal/activities/write_identifier_file_test.go
+++ b/internal/activities/write_identifier_file_test.go
@@ -82,7 +82,7 @@ func TestWriteIdentifierFile(t *testing.T) {
 			},
 			wantJSON: `[
     {
-        "file": "metadata/Prozess_Digitalisierung_PREMIS_d_0000001.xml",
+        "file": "metadata/Prozess_Digitalisierung_PREMIS.xml",
         "identifiers": [
             {
                 "identifier": "_cQ6sm5CChWVqtqmrWvne0W",

--- a/internal/pips/pips.go
+++ b/internal/pips/pips.go
@@ -1,7 +1,6 @@
 package pips
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -42,20 +41,16 @@ func (p PIP) Name() string {
 }
 
 func (p PIP) ConvertSIPPath(path string) string {
-	switch {
-	case filepath.Base(path) == "Prozess_Digitalisierung_PREMIS.xml":
-		parent := filepath.Base(filepath.Dir(path))
-		return filepath.Join(
-			"metadata",
-			fmt.Sprintf("Prozess_Digitalisierung_PREMIS_%s.xml", parent),
-		)
-	case filepath.Base(path) == "metadata.xml":
-		return filepath.Join("objects", p.Name(), "header", "metadata.xml")
-	case filepath.Base(path) == "UpdatedAreldaMetadata.xml":
-		return filepath.Join("metadata", "UpdatedAreldaMetadata.xml")
-	case strings.HasPrefix(path, "content"):
-		return filepath.Join("objects", p.Name(), path)
-	default:
-		return ""
+	switch name := filepath.Base(path); name {
+	case "Prozess_Digitalisierung_PREMIS.xml", "UpdatedAreldaMetadata.xml":
+		return filepath.Join("metadata", name)
+	case "metadata.xml":
+		return filepath.Join("objects", p.Name(), "header", name)
 	}
+
+	if strings.HasPrefix(path, "content") {
+		return filepath.Join("objects", p.Name(), path)
+	}
+
+	return ""
 }

--- a/internal/pips/pips_test.go
+++ b/internal/pips/pips_test.go
@@ -84,7 +84,7 @@ func TestConvertSIPPath(t *testing.T) {
 	p := pips.New("/path/to/SIP_20201201_Vecteur", enums.SIPTypeDigitizedSIP)
 	assert.Equal(t,
 		p.ConvertSIPPath("content/d_0000001/Prozess_Digitalisierung_PREMIS.xml"),
-		"metadata/Prozess_Digitalisierung_PREMIS_d_0000001.xml",
+		"metadata/Prozess_Digitalisierung_PREMIS.xml",
 	)
 	assert.Equal(t,
 		p.ConvertSIPPath("header/metadata.xml"),

--- a/internal/premis/premis.go
+++ b/internal/premis/premis.go
@@ -377,12 +377,10 @@ func FilesWithinDirectory(contentPath string) ([]string, error) {
 }
 
 func OriginalNameForSubpath(sip sip.SIP, subpath string) string {
-	// Handle one file differently (as it gets renamed latest in TransformSIP).
+	// Prozess_Digitalisierung_PREMIS.xml is moved to the metadata directory.
 	if filepath.Base(subpath) == "Prozess_Digitalisierung_PREMIS.xml" {
-		parentDirName := filepath.Base(filepath.Dir(subpath))
-		filename := fmt.Sprintf("Prozess_Digitalisierung_PREMIS_%s.xml", parentDirName)
-		return filepath.Join("data", "metadata", filename)
-	} else {
-		return filepath.Join("data", "objects", filepath.Base(sip.Path), "content", subpath)
+		return filepath.Join("data", "metadata", "Prozess_Digitalisierung_PREMIS.xml")
 	}
+
+	return filepath.Join("data", "objects", sip.Name(), "content", subpath)
 }

--- a/internal/premis/premis_test.go
+++ b/internal/premis/premis_test.go
@@ -348,5 +348,5 @@ func TestOriginalNameForSubpath(t *testing.T) {
 	)
 
 	assert.Equal(t, metadataOriginalName,
-		"data/metadata/Prozess_Digitalisierung_PREMIS_d_0000001.xml")
+		"data/metadata/Prozess_Digitalisierung_PREMIS.xml")
 }

--- a/internal/sip/sip.go
+++ b/internal/sip/sip.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/enums"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/fsutil"
@@ -55,7 +54,7 @@ func New(path string) (SIP, error) {
 	if err != nil {
 		return s, fmt.Errorf("SIP: New: %v", err)
 	}
-	if len(f) > 0 && strings.Contains(strings.ToLower(s.Path), "vecteur") {
+	if len(f) > 0 {
 		return s.digitizedSIP(), nil
 	}
 


### PR DESCRIPTION
Fixes #58

Digitized (Vecteur) SIPs are the only type of SIP that contain a Prozess_Digitalisierung_PREMIS.xml file, and they will only ever contain a single dossier.  Because digitized SIPs only have a single dossier that contains a single Prozess_Digitalisierung_PREMIS.xml file there's no need to rename the file in the PIP to avoid name clashes.

Changes:
- Update the SIP identification logic - if a SIP has a Prozess_Digitalisierung_PREMIS.xml file then it must be a digitized SIP
- Add a SIP validation check to confirm that digitized SIPs only contain a single dossier
- Remove the SIP transformation code that renamed the Prozess_Digitalisierung_PREMIS.xml file