### PR TITLE
Remove SIP path from SIP metadata validation

### DIFF
--- a/internal/workflow/preprocessing.go
+++ b/internal/workflow/preprocessing.go
@@ -219,11 +219,10 @@ func (w *PreprocessingWorkflow) Execute(
 	}
 
 	if validateMetadata.Failures != nil {
-		escapedFailures := make([]string, len(validateMetadata.Failures))
-		for _, f := range validateMetadata.Failures {
-			escapedFailures = append(escapedFailures, strings.ReplaceAll(f, identifySIP.SIP.Path, ""))
+		for idx, f := range validateMetadata.Failures {
+			validateMetadata.Failures[idx] = strings.ReplaceAll(f, identifySIP.SIP.Path+"/", "")
 		}
-		result.validationError(ctx, ev, "metadata validation has failed", escapedFailures)
+		result.validationError(ctx, ev, "metadata validation has failed", validateMetadata.Failures)
 	} else {
 		ev.Succeed(ctx, "Metadata validation successful")
 	}

--- a/internal/workflow/preprocessing.go
+++ b/internal/workflow/preprocessing.go
@@ -219,7 +219,11 @@ func (w *PreprocessingWorkflow) Execute(
 	}
 
 	if validateMetadata.Failures != nil {
-		result.validationError(ctx, ev, "metadata validation has failed", validateMetadata.Failures)
+		escapedFailures := make([]string, len(validateMetadata.Failures))
+		for _, f := range validateMetadata.Failures {
+			escapedFailures = append(escapedFailures, strings.ReplaceAll(f, identifySIP.SIP.Path, ""))
+		}
+		result.validationError(ctx, ev, "metadata validation has failed", escapedFailures)
 	} else {
 		ev.Succeed(ctx, "Metadata validation successful")
 	}

--- a/internal/workflow/preprocessing_test.go
+++ b/internal/workflow/preprocessing_test.go
@@ -549,7 +549,7 @@ func (s *PreprocessingTestSuite) TestPreprocessingWorkflowValidationFails() {
 	).Return(
 		&xmlvalidate.Result{
 			Failures: []string{
-				`fake/path/to/sip/additional/UpdatedAreldaMetadata.xml does not match expected metadata requirements`,
+				`/additional/UpdatedAreldaMetadata.xml does not match expected metadata requirements`,
 			},
 		}, nil,
 	)
@@ -613,7 +613,7 @@ file format fmt/11 not allowed: "fake/path/to/sip/file2.png"`,
 				},
 				{
 					Name:        "Validate SIP metadata",
-					Message:     "Content error: metadata validation has failed:\nfake/path/to/sip/additional/UpdatedAreldaMetadata.xml does not match expected metadata requirements",
+					Message:     "Content error: metadata validation has failed:\n\n/additional/UpdatedAreldaMetadata.xml does not match expected metadata requirements",
 					Outcome:     enums.EventOutcomeValidationFailure,
 					StartedAt:   testTime,
 					CompletedAt: testTime,

--- a/internal/workflow/preprocessing_test.go
+++ b/internal/workflow/preprocessing_test.go
@@ -549,7 +549,7 @@ func (s *PreprocessingTestSuite) TestPreprocessingWorkflowValidationFails() {
 	).Return(
 		&xmlvalidate.Result{
 			Failures: []string{
-				`/additional/UpdatedAreldaMetadata.xml does not match expected metadata requirements`,
+				`additional/UpdatedAreldaMetadata.xml does not match expected metadata requirements`,
 			},
 		}, nil,
 	)
@@ -613,7 +613,7 @@ file format fmt/11 not allowed: "fake/path/to/sip/file2.png"`,
 				},
 				{
 					Name:        "Validate SIP metadata",
-					Message:     "Content error: metadata validation has failed:\n\n/additional/UpdatedAreldaMetadata.xml does not match expected metadata requirements",
+					Message:     "Content error: metadata validation has failed:\nadditional/UpdatedAreldaMetadata.xml does not match expected metadata requirements",
 					Outcome:     enums.EventOutcomeValidationFailure,
 					StartedAt:   testTime,
 					CompletedAt: testTime,


### PR DESCRIPTION
This MR will remove the absolute path from the `Validate SIP metadata activity`. 

Continuation of: https://github.com/artefactual-sdps/preprocessing-sfa/issues/59#issuecomment-2460199726

Previously:   
![image](https://github.com/user-attachments/assets/35de7503-3be9-4b21-b733-c8959bc75c4b)

Now:   
![image](https://github.com/user-attachments/assets/d1e7ebf0-2e30-4b04-9e47-1ad334409abd)
