### PR TITLE
WIP: Relate preprocessing and AIS workflows

### DIFF
--- a/cmd/worker/workercmd/cmd.go
+++ b/cmd/worker/workercmd/cmd.go
@@ -58,7 +58,7 @@ func (m *Main) Run(ctx context.Context) error {
 	m.temporalWorker = w
 
 	w.RegisterWorkflowWithOptions(
-		workflow.NewPreprocessingWorkflow(m.cfg.SharedPath).Execute,
+		workflow.NewPreprocessingWorkflow(m.cfg.SharedPath, workflow.GenUUID).Execute,
 		temporalsdk_workflow.RegisterOptions{Name: m.cfg.Temporal.WorkflowName},
 	)
 

--- a/internal/ais/workflow.go
+++ b/internal/ais/workflow.go
@@ -19,7 +19,8 @@ import (
 )
 
 type WorkflowParams struct {
-	AIPUUID string
+	AIPUUID         string
+	PreprocessingID string
 }
 
 type WorkflowResult struct {

--- a/internal/workflow/preprocessing_test.go
+++ b/internal/workflow/preprocessing_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/artefactual-sdps/temporal-activities/bagcreate"
 	"github.com/artefactual-sdps/temporal-activities/ffvalidate"
 	"github.com/artefactual-sdps/temporal-activities/xmlvalidate"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
 	temporalsdk_worker "go.temporal.io/sdk/worker"
+	temporalsdk_workflow "go.temporal.io/sdk/workflow"
 	"gotest.tools/v3/fs"
 
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/activities"
@@ -118,6 +120,10 @@ type PreprocessingTestSuite struct {
 	testDir  string
 }
 
+func genUUID(ctx temporalsdk_workflow.Context) (uuid.UUID, error) {
+	return uuid.MustParse("146182ff-9923-4869-bca1-0bbc0f822025"), nil
+}
+
 func (s *PreprocessingTestSuite) SetupTest(cfg *config.Configuration) {
 	s.env = s.NewTestWorkflowEnvironment()
 	s.env.SetStartTime(testTime)
@@ -171,7 +177,7 @@ func (s *PreprocessingTestSuite) SetupTest(cfg *config.Configuration) {
 		temporalsdk_activity.RegisterOptions{Name: bagcreate.Name},
 	)
 
-	s.workflow = workflow.NewPreprocessingWorkflow(s.testDir)
+	s.workflow = workflow.NewPreprocessingWorkflow(s.testDir, genUUID)
 }
 
 func (s *PreprocessingTestSuite) digitizedAIP(path string) sip.SIP {
@@ -443,6 +449,7 @@ func (s *PreprocessingTestSuite) TestPreprocessingWorkflowSuccess() {
 					CompletedAt: testTime,
 				},
 			},
+			PreprocessingID: "146182ff-9923-4869-bca1-0bbc0f822025",
 		},
 		&result,
 	)
@@ -485,6 +492,7 @@ func (s *PreprocessingTestSuite) TestPreprocessingWorkflowIdentifySIPFails() {
 					CompletedAt: testTime,
 				},
 			},
+			PreprocessingID: "146182ff-9923-4869-bca1-0bbc0f822025",
 		},
 		&result,
 	)
@@ -624,6 +632,7 @@ file format fmt/11 not allowed: "fake/path/to/sip/file2.png"`,
 					CompletedAt: testTime,
 				},
 			},
+			PreprocessingID: "146182ff-9923-4869-bca1-0bbc0f822025",
 		},
 		&result,
 	)

--- a/internal/workflow/uuid.go
+++ b/internal/workflow/uuid.go
@@ -1,0 +1,14 @@
+package workflow
+
+import (
+	"github.com/google/uuid"
+	temporalsdk_workflow "go.temporal.io/sdk/workflow"
+)
+
+func GenUUID(ctx temporalsdk_workflow.Context) (uuid.UUID, error) {
+	var id uuid.UUID
+	gen := func(ctx temporalsdk_workflow.Context) interface{} { return uuid.New() }
+	enc := temporalsdk_workflow.SideEffect(ctx, gen)
+	err := enc.Get(&id)
+	return id, err
+}

--- a/internal/workflow/uuid_test.go
+++ b/internal/workflow/uuid_test.go
@@ -1,0 +1,27 @@
+package workflow_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/workflow"
+)
+
+func TestGenUUID(t *testing.T) {
+	t.Parallel()
+
+	testSuite := &temporalsdk_testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+
+	env.ExecuteWorkflow(workflow.GenUUID)
+
+	var id uuid.UUID
+	err := env.GetWorkflowResult(&id)
+	assert.NilError(t, err)
+
+	assert.NilError(t, env.GetWorkflowError())
+	assert.Assert(t, id != uuid.Nil)
+}


### PR DESCRIPTION
Related to https://github.com/artefactual-sdps/enduro/pull/1087 and https://github.com/artefactual-sdps/enduro/issues/886.

- Generate a UUID in the preprocessing workflow and add it to the result.
- Receive preprocessing UUID in AIS workflow.
- TODO:
  - Preprocessing: send metadata file to AIS bucket.
  - AIS: fetch metadata file from AIS bucket.
  - AIS: remove METS parsing code.
  - AIS: remove metadata file download from AMSS.
  - AIS: remove metadata file from AIS bucket when the bundle has been stored.
