### PR TITLE
Improve invalid character errors (#109)

### DIFF
--- a/internal/activities/validate_structure.go
+++ b/internal/activities/validate_structure.go
@@ -49,10 +49,6 @@ func (a *ValidateStructure) Execute(
 			return err
 		}
 
-		if !validateName(d.Name()) {
-			failures = append(failures, fmt.Sprintf("Name %q contains invalid character", relativePath))
-		}
-
 		if path != params.SIP.Path {
 			// Initialize this directory's total number of immediate children.
 			if d.IsDir() {
@@ -61,6 +57,14 @@ func (a *ValidateStructure) Execute(
 
 			// Add to parent's total number of immediate children.
 			paths[filepath.Dir(relativePath)] = paths[filepath.Dir(relativePath)] + 1
+		}
+
+		if !validateName(d.Name()) {
+			if relativePath == "." {
+				relativePath = filepath.Base(params.SIP.Path)
+			}
+
+			failures = append(failures, fmt.Sprintf("Name %q contains invalid character(s)", relativePath))
 		}
 
 		return nil

--- a/internal/activities/validate_structure_test.go
+++ b/internal/activities/validate_structure_test.go
@@ -122,7 +122,7 @@ func TestValidateStructure(t *testing.T) {
 	).Path())
 	assert.NilError(t, err)
 
-	badNamingSIP, err := sip.New(fs.NewDir(t, "",
+	badNamingSIP, err := sip.New(fs.NewDir(t, "bad#name",
 		fs.WithDir("content",
 			fs.WithDir("d_0000001",
 				fs.WithFile("content.txt", ""),
@@ -229,8 +229,9 @@ func TestValidateStructure(t *testing.T) {
 			params: activities.ValidateStructureParams{SIP: badNamingSIP},
 			want: activities.ValidateStructureResult{
 				Failures: []string{
-					"Name \"header/content!.txt\" contains invalid character",
-					"Name \"header/directory$\" contains invalid character",
+					fmt.Sprintf("Name %q contains invalid character(s)", filepath.Base(badNamingSIP.Path)),
+					"Name \"header/content!.txt\" contains invalid character(s)",
+					"Name \"header/directory$\" contains invalid character(s)",
 				},
 			},
 		},


### PR DESCRIPTION
Made invalid character, for top-level directory name, more user-friendly.