### PR TITLE
Get veraPDF version dynamically

### DIFF
--- a/internal/fvalidate/fake/mock_validator.go
+++ b/internal/fvalidate/fake/mock_validator.go
@@ -152,3 +152,42 @@ func (c *MockValidatorValidateCall) DoAndReturn(f func(string) (string, error)) 
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// Version mocks base method.
+func (m *MockValidator) Version() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Version")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Version indicates an expected call of Version.
+func (mr *MockValidatorMockRecorder) Version() *MockValidatorVersionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockValidator)(nil).Version))
+	return &MockValidatorVersionCall{Call: call}
+}
+
+// MockValidatorVersionCall wrap *gomock.Call
+type MockValidatorVersionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockValidatorVersionCall) Return(arg0 string, arg1 error) *MockValidatorVersionCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockValidatorVersionCall) Do(f func() (string, error)) *MockValidatorVersionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockValidatorVersionCall) DoAndReturn(f func() (string, error)) *MockValidatorVersionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/internal/fvalidate/fvalidate.go
+++ b/internal/fvalidate/fvalidate.go
@@ -10,4 +10,7 @@ type Validator interface {
 
 	// Validate validates the file at path.
 	Validate(path string) (string, error)
+
+	// Returns the version of a validator.
+	Version() (string, error)
 }

--- a/internal/workflow/preprocessing_test.go
+++ b/internal/workflow/preprocessing_test.go
@@ -206,7 +206,7 @@ func (s *PreprocessingTestSuite) SetupTest(cfg *config.Configuration) {
 		temporalsdk_activity.RegisterOptions{Name: bagcreate.Name},
 	)
 
-	s.workflow = workflow.NewPreprocessingWorkflow(s.testDir, cfg.CheckDuplicates, nil)
+	s.workflow = workflow.NewPreprocessingWorkflow(s.testDir, cfg.CheckDuplicates, "VeraPDF 1.1.1", nil)
 }
 
 func (s *PreprocessingTestSuite) digitizedAIP(path string) sip.SIP {
@@ -424,7 +424,7 @@ func (s *PreprocessingTestSuite) TestPreprocessingWorkflowSuccess() {
 			PREMISFilePath: premisFilePath,
 			Agent: premis.Agent{
 				Type:    "software",
-				Name:    "VeraPDF 1.26.2",
+				Name:    "VeraPDF 1.1.1",
 				IdType:  "url",
 				IdValue: "https://verapdf.org",
 			},
@@ -466,7 +466,7 @@ func (s *PreprocessingTestSuite) TestPreprocessingWorkflowSuccess() {
 			PREMISFilePath: premisFilePath,
 			Agent: premis.Agent{
 				Type:    "software",
-				Name:    "VeraPDF 1.26.2",
+				Name:    "VeraPDF 1.1.1",
 				IdType:  "url",
 				IdValue: "https://verapdf.org",
 			},


### PR DESCRIPTION
Execute the veraPDF command, when starting the worker, to get the current veraPDF version so it can be used when recording PREMIS events.
