### PR TITLE
Remove duplicate AIS activity registration

### DIFF
--- a/cmd/worker/aiscmd/cmd.go
+++ b/cmd/worker/aiscmd/cmd.go
@@ -58,9 +58,13 @@ func (m *Main) Run(ctx context.Context) error {
 	}
 	m.bucket = b
 
-	if err := ais.RegisterWorkflow(ctx, w, m.cfg, b); err != nil {
-		return fmt.Errorf("AIS: %w", err)
+	amssClient, err := ais.NewAMSSClient(m.cfg.AMSS)
+	if err != nil {
+		return fmt.Errorf("RegisterWorkflow: %w", err)
 	}
+
+	ais.RegisterWorkflow(w, m.cfg, amssClient)
+	ais.RegisterActivities(w, amssClient, m.bucket)
 
 	if err := w.Start(); err != nil {
 		m.logger.Error(err, "AIS worker failed to start.")

--- a/internal/ais/workflow_test.go
+++ b/internal/ais/workflow_test.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/artefactual-sdps/temporal-activities/archivezip"
 	"github.com/artefactual-sdps/temporal-activities/bucketupload"
-	"github.com/artefactual-sdps/temporal-activities/removepaths"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	temporalsdk_activity "go.temporal.io/sdk/activity"
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
 	temporalsdk_worker "go.temporal.io/sdk/worker"
 
@@ -32,36 +30,9 @@ func (s *TestSuite) setup(cfg *ais.Config) {
 	s.testDir = s.T().TempDir()
 	cfg.WorkingDir = s.testDir
 
-	s.registerActivities()
+	ais.RegisterActivities(s.env, nil, nil)
 
 	s.workflow = ais.NewWorkflow(*cfg, nil)
-}
-
-func (s *TestSuite) registerActivities() {
-	s.env.RegisterActivityWithOptions(
-		ais.NewFetchActivity(nil).Execute,
-		temporalsdk_activity.RegisterOptions{Name: ais.FetchActivityName},
-	)
-	s.env.RegisterActivityWithOptions(
-		ais.NewParseActivity().Execute,
-		temporalsdk_activity.RegisterOptions{Name: ais.ParseActivityName},
-	)
-	s.env.RegisterActivityWithOptions(
-		ais.NewCombineMDActivity().Execute,
-		temporalsdk_activity.RegisterOptions{Name: ais.CombineMDActivityName},
-	)
-	s.env.RegisterActivityWithOptions(
-		archivezip.New().Execute,
-		temporalsdk_activity.RegisterOptions{Name: archivezip.Name},
-	)
-	s.env.RegisterActivityWithOptions(
-		bucketupload.New(nil).Execute,
-		temporalsdk_activity.RegisterOptions{Name: bucketupload.Name},
-	)
-	s.env.RegisterActivityWithOptions(
-		removepaths.New().Execute,
-		temporalsdk_activity.RegisterOptions{Name: removepaths.Name},
-	)
 }
 
 func TestWorkflow(t *testing.T) {


### PR DESCRIPTION
Use the AIS `RegisterActivities()` function to register activities in the AIS workflow code and tests.