### PR TITLE
Don't add inapplicable veraPDF PREMIS events (#122)

### DIFF
--- a/cmd/worker/workercmd/cmd.go
+++ b/cmd/worker/workercmd/cmd.go
@@ -105,7 +105,7 @@ func (m *Main) Run(ctx context.Context) error {
 		psvc = entclient.New(m.dbClient)
 	}
 
-	veraPDFValidator := fvalidate.NewVeraPDFValidator(m.cfg.FileValidate.VeraPDF.Path, m.logger)
+	veraPDFValidator := fvalidate.NewVeraPDFValidator(m.cfg.FileValidate.VeraPDF.Path, fvalidate.RunCommand, m.logger)
 
 	veraPDFVersion, err := veraPDFValidator.Version()
 	if err != nil {
@@ -171,6 +171,10 @@ func (m *Main) Run(ctx context.Context) error {
 	w.RegisterActivityWithOptions(
 		activities.NewAddPREMISAgent().Execute,
 		temporalsdk_activity.RegisterOptions{Name: activities.AddPREMISAgentName},
+	)
+	w.RegisterActivityWithOptions(
+		activities.NewAddPREMISValidationEvent(veraPDFValidator).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.AddPREMISValidationEventName},
 	)
 	w.RegisterActivityWithOptions(
 		xmlvalidate.New(xmlvalidate.NewXMLLintValidator()).Execute,

--- a/internal/activities/add_premis_validation_event.go
+++ b/internal/activities/add_premis_validation_event.go
@@ -1,0 +1,97 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+
+	"github.com/beevik/etree"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/fformat"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/fvalidate"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/premis"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/sip"
+)
+
+const AddPREMISValidationEventName = "add-premis-validation-event"
+
+type AddPREMISValidationEventParams struct {
+	SIP            sip.SIP
+	PREMISFilePath string
+	Agent          premis.Agent
+	Summary        premis.EventSummary
+}
+
+type AddPREMISValidationEventResult struct{}
+
+type AddPREMISValidationEventActivity struct {
+	validator fvalidate.Validator
+}
+
+func NewAddPREMISValidationEvent(validator fvalidate.Validator) *AddPREMISValidationEventActivity {
+	return &AddPREMISValidationEventActivity{
+		validator: validator,
+	}
+}
+
+func (md *AddPREMISValidationEventActivity) Execute(
+	ctx context.Context,
+	params *AddPREMISValidationEventParams,
+) (*AddPREMISValidationEventResult, error) {
+	// Load or initialize PREMIS XML.
+	doc, err := premis.ParseOrInitialize(params.PREMISFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	PREMISEl := doc.FindElement("/premis:premis")
+	if PREMISEl == nil {
+		return nil, fmt.Errorf("no root premis element found in document")
+	}
+
+	// Determine formats of SIP files.
+	fileformats, err := fformat.IdentifyFormats(ctx, fformat.NewSiegfriedEmbed(), params.SIP)
+	if err != nil {
+		return nil, fmt.Errorf("identifyFormats: %v", err)
+	}
+
+	// Determine which files should have been checked by the validator.
+	allowedIds := md.validator.FormatIDs()
+
+	for path, f := range fileformats {
+		if slices.Contains(allowedIds, f.ID) {
+			// Determine subpath.
+			subpath, err := filepath.Rel(params.SIP.ContentPath, path)
+			if err != nil {
+				return nil, err
+			}
+
+			// Find PREMIS object element using original name.
+			originalName := premis.OriginalNameForSubpath(params.SIP, subpath)
+
+			objectOriginalNameEl := doc.FindElement(
+				fmt.Sprintf("/premis:premis/premis:object/premis:originalName[text()='%s']", originalName),
+			)
+
+			if objectOriginalNameEl == nil {
+				return nil, fmt.Errorf("Element not found")
+			}
+
+			objectEl := objectOriginalNameEl.Parent()
+
+			// Append PREMIS event linked to from PREMIS object element.
+			var objectEls []*etree.Element
+			objectEls = append(objectEls, objectEl)
+			premis.AppendEventXMLForObjects(PREMISEl, params.Summary, params.Agent, objectEls)
+		}
+	}
+
+	// Write PREMIS.
+	err = doc.WriteToFile(params.PREMISFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AddPREMISValidationEventResult{}, nil
+}

--- a/internal/activities/add_premis_validation_event_test.go
+++ b/internal/activities/add_premis_validation_event_test.go
@@ -1,0 +1,199 @@
+package activities_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/activities"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/enums"
+	fake_fvalidate "github.com/artefactual-sdps/preprocessing-sfa/internal/fvalidate/fake"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/premis"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/sip"
+)
+
+const premisObjectContent = `<?xml version="1.0" encoding="UTF-8"?>
+<premis:premis xmlns:premis="http://www.loc.gov/premis/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/premis/v3 https://www.loc.gov/standards/premis/premis.xsd" version="3.0">
+  <premis:object xsi:type="premis:file">
+    <premis:objectIdentifier>
+      <premis:objectIdentifierType>uuid</premis:objectIdentifierType>
+      <premis:objectIdentifierValue>c74a85b7-919b-409e-8209-9c7ebe0e7945</premis:objectIdentifierValue>
+    </premis:objectIdentifier>
+    <premis:objectCharacteristics>
+      <premis:format>
+        <premis:formatDesignation>
+          <premis:formatName/>
+        </premis:formatDesignation>
+      </premis:format>
+    </premis:objectCharacteristics>
+    <premis:originalName>data/objects/content/file.json</premis:originalName>
+  </premis:object>
+</premis:premis>
+`
+
+func TestAddPREMISValidationEvent(t *testing.T) {
+	t.Parallel()
+
+	// Define PREMIS event summary to use in all tests.
+	eventSummary := premis.EventSummary{
+		Type:          "validation",
+		Detail:        "name=\"Validate SIP file formats\"",
+		OutcomeDetail: "File format complies with specification",
+	}
+
+	// Create test directory, and corresponding SIP object, with non-PREMIS XML.
+	badXMLDir := fs.NewDir(t, "",
+		fs.WithFile("premis.xml", "<xml></xml>"),
+	)
+
+	badXMLFilePath := filepath.Join(badXMLDir.Path(), "premis.xml")
+
+	badXMLSIP := sip.SIP{
+		Type:        enums.SIPTypeBornDigitalAIP,
+		ContentPath: badXMLDir.Path(),
+	}
+
+	// Create test directory, and corresponding SIP object, with empty PREMIS file.
+	emptyPREMISTestDir := fs.NewDir(t, "",
+		fs.WithFile("premis.xml", premis.EmptyXML),
+		fs.WithFile("file.json", "{}"),
+	)
+
+	emptyPREMISPath := filepath.Join(emptyPREMISTestDir.Path(), "premis.xml")
+
+	testSIP := sip.SIP{
+		Type:        enums.SIPTypeBornDigitalAIP,
+		ContentPath: emptyPREMISTestDir.Path(),
+	}
+
+	// Create test directory, and corresponding SIP object, with populated PREMIS file.
+	normalTestDir := fs.NewDir(t, "",
+		fs.WithDir("test_transfer",
+			fs.WithFile("file.json", "{}"),
+			fs.WithFile("premis.xml", premisObjectContent),
+		),
+	)
+
+	normalPREMISPath := filepath.Join(normalTestDir.Path(), "test_transfer", "premis.xml")
+
+	normalTestSIP := sip.SIP{
+		Type:        enums.SIPTypeBornDigitalAIP,
+		ContentPath: filepath.Join(normalTestDir.Path(), "test_transfer"),
+	}
+
+	// Creation of PREMIS file in non-existing directory (for execution expected to fail).
+	ContentNonExistent := fs.NewDir(t, "",
+		fs.WithDir("metadata"),
+	)
+
+	PREMISFilePathNonExistent := ContentNonExistent.Join("metadata", "premis.xml")
+
+	ContentNonExistent.Remove()
+
+	tests := []struct {
+		name      string
+		params    activities.AddPREMISValidationEventParams
+		result    activities.AddPREMISValidationEventResult
+		expectVld func(*fake_fvalidate.MockValidatorMockRecorder)
+		wantErr   string
+	}{
+		{
+			name: "Attempt to add PREMIS event to bad XML",
+			params: activities.AddPREMISValidationEventParams{
+				SIP:            badXMLSIP,
+				PREMISFilePath: badXMLFilePath,
+				Agent:          premis.AgentDefault(),
+				Summary:        eventSummary,
+			},
+			result:  activities.AddPREMISValidationEventResult{},
+			wantErr: "no root premis element found in document",
+		},
+		{
+			name: "Add PREMIS event for PREMIS object not yet in the XML",
+			params: activities.AddPREMISValidationEventParams{
+				SIP:            testSIP,
+				PREMISFilePath: emptyPREMISPath,
+				Agent:          premis.AgentDefault(),
+				Summary:        eventSummary,
+			},
+			result: activities.AddPREMISValidationEventResult{},
+			expectVld: func(m *fake_fvalidate.MockValidatorMockRecorder) {
+				m.FormatIDs().Return([]string{"fmt/354", "fmt/817"})
+			},
+			wantErr: "Element not found",
+		},
+		{
+			name: "Add PREMIS event for PREMIS object present in the XML",
+			params: activities.AddPREMISValidationEventParams{
+				SIP:            normalTestSIP,
+				PREMISFilePath: normalPREMISPath,
+				Agent:          premis.AgentDefault(),
+				Summary:        eventSummary,
+			},
+			result: activities.AddPREMISValidationEventResult{},
+			expectVld: func(m *fake_fvalidate.MockValidatorMockRecorder) {
+				m.FormatIDs().Return([]string{"fmt/354", "fmt/817"})
+			},
+		},
+		{
+			name: "Add PREMIS event for bad path",
+			params: activities.AddPREMISValidationEventParams{
+				SIP:            testSIP,
+				PREMISFilePath: PREMISFilePathNonExistent,
+				Agent:          premis.AgentDefault(),
+				Summary:        eventSummary,
+			},
+			result: activities.AddPREMISValidationEventResult{},
+			expectVld: func(m *fake_fvalidate.MockValidatorMockRecorder) {
+				m.FormatIDs().Return([]string{"fmt/354"})
+			},
+			wantErr: "no such file or directory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+
+			mockVdr := fake_fvalidate.NewMockValidator(ctrl)
+			if tt.expectVld != nil {
+				tt.expectVld(mockVdr.EXPECT())
+			}
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			env.RegisterActivityWithOptions(
+				activities.NewAddPREMISValidationEvent(mockVdr).Execute,
+				temporalsdk_activity.RegisterOptions{Name: activities.AddPREMISValidationEventName},
+			)
+
+			var res activities.AddPREMISValidationEventResult
+			future, err := env.ExecuteActivity(activities.AddPREMISValidationEventName, tt.params)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Errorf("error is nil, expecting: %q", tt.wantErr)
+				} else {
+					assert.ErrorContains(t, err, tt.wantErr)
+				}
+
+				return
+			}
+
+			assert.NilError(t, err)
+
+			future.Get(&res)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, res, tt.result)
+
+			_, err = premis.ParseFile(tt.params.PREMISFilePath)
+			assert.NilError(t, err)
+		})
+	}
+}

--- a/internal/fformat/fformat_test.go
+++ b/internal/fformat/fformat_test.go
@@ -1,0 +1,38 @@
+package fformat_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/enums"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/fformat"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/sip"
+)
+
+func TestIdentifyFormats(t *testing.T) {
+	t.Parallel()
+
+	testDir := fs.NewDir(t, "",
+		fs.WithFile("something.txt", "text"),
+		fs.WithFile("else.json", "{}"),
+	)
+
+	testSIP := sip.SIP{
+		Type:        enums.SIPTypeBornDigitalAIP,
+		ContentPath: testDir.Path(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fileformats, err := fformat.IdentifyFormats(ctx, fformat.NewSiegfriedEmbed(), testSIP)
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(fileformats), 2)
+	assert.Equal(t, fileformats[filepath.Join(testDir.Path(), "something.txt")].ID, "x-fmt/111")
+	assert.Equal(t, fileformats[filepath.Join(testDir.Path(), "else.json")].ID, "fmt/817")
+}

--- a/internal/fvalidate/verapdf_validator.go
+++ b/internal/fvalidate/verapdf_validator.go
@@ -28,14 +28,17 @@ var pdfaPUIDs = []string{
 }
 
 type veraPDFValidator struct {
-	cmd    string
-	logger logr.Logger
+	cmd     string
+	runFunc runFunction
+	logger  logr.Logger
 }
+
+type runFunction func(name string, args ...string) (string, error)
 
 var _ Validator = (*veraPDFValidator)(nil)
 
-func NewVeraPDFValidator(cmd string, logger logr.Logger) *veraPDFValidator {
-	return &veraPDFValidator{cmd: cmd, logger: logger}
+func NewVeraPDFValidator(cmd string, runFunc runFunction, logger logr.Logger) *veraPDFValidator {
+	return &veraPDFValidator{cmd: cmd, runFunc: runFunc, logger: logger}
 }
 
 func (v *veraPDFValidator) FormatIDs() []string {
@@ -95,15 +98,13 @@ func RunCommand(name string, args ...string) (string, error) {
 	return string(output), nil
 }
 
-var Run = RunCommand
-
 func (v *veraPDFValidator) Version() (string, error) {
 	// If the veraPDF cmd path is not set then skip returning the version.
 	if v.cmd == "" {
 		return "", nil
 	}
 
-	output, err := Run(v.cmd, "--version")
+	output, err := v.runFunc(v.cmd, "--version")
 	if err != nil {
 		return "", err
 	}

--- a/internal/fvalidate/verapdf_validator_test.go
+++ b/internal/fvalidate/verapdf_validator_test.go
@@ -14,7 +14,7 @@ import (
 func TestFormatIDs(t *testing.T) {
 	t.Parallel()
 
-	v := fvalidate.NewVeraPDFValidator("", logr.Discard())
+	v := fvalidate.NewVeraPDFValidator("", fvalidate.RunCommand, logr.Discard())
 	got := v.FormatIDs()
 
 	assert.DeepEqual(t, got, []string{
@@ -35,7 +35,7 @@ func TestFormatIDs(t *testing.T) {
 func TestName(t *testing.T) {
 	t.Parallel()
 
-	v := fvalidate.NewVeraPDFValidator("", logr.Discard())
+	v := fvalidate.NewVeraPDFValidator("", fvalidate.RunCommand, logr.Discard())
 	got := v.Name()
 
 	assert.Equal(t, got, "veraPDF")
@@ -77,7 +77,7 @@ func TestValidate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			v := fvalidate.NewVeraPDFValidator(tt.cmd, logr.Discard())
+			v := fvalidate.NewVeraPDFValidator(tt.cmd, fvalidate.RunCommand, logr.Discard())
 			td := t.TempDir()
 			got, err := v.Validate(tt.path(td))
 			if tt.wantErr != nil {
@@ -97,15 +97,11 @@ func TestValidate(t *testing.T) {
 }
 
 func TestVeraPDFVersion(t *testing.T) {
-	defer func() {
-		fvalidate.Run = fvalidate.RunCommand
-	}()
-
-	fvalidate.Run = func(string, ...string) (string, error) {
+	runFunc := func(string, ...string) (string, error) {
 		return "veraPDF 1.1\nSome more text", nil
 	}
 
-	v := fvalidate.NewVeraPDFValidator("veraPDF", logr.Discard())
+	v := fvalidate.NewVeraPDFValidator("veraPDF", runFunc, logr.Discard())
 	version, err := v.Version()
 
 	assert.NilError(t, err)
@@ -113,15 +109,11 @@ func TestVeraPDFVersion(t *testing.T) {
 }
 
 func TestVeraPDFVersionError(t *testing.T) {
-	defer func() {
-		fvalidate.Run = fvalidate.RunCommand
-	}()
-
-	fvalidate.Run = func(string, ...string) (string, error) {
+	runFunc := func(string, ...string) (string, error) {
 		return "", fmt.Errorf("exit status 1")
 	}
 
-	v := fvalidate.NewVeraPDFValidator("badcommand", logr.Discard())
+	v := fvalidate.NewVeraPDFValidator("badcommand", runFunc, logr.Discard())
 	version, err := v.Version()
 
 	assert.Error(t, err, "exit status 1")

--- a/internal/premis/premis.go
+++ b/internal/premis/premis.go
@@ -149,12 +149,12 @@ func AppendEventXMLForEachObject(doc *etree.Document, eventSummary EventSummary,
 
 	// Add events for each existing object.
 	objectEls := PREMISEl.FindElements("//premis:object")
-	appendEventXMLForObjects(PREMISEl, eventSummary, agent, objectEls)
+	AppendEventXMLForObjects(PREMISEl, eventSummary, agent, objectEls)
 
 	return nil
 }
 
-func appendEventXMLForObjects(
+func AppendEventXMLForObjects(
 	PREMISEl *etree.Element,
 	eventSummary EventSummary,
 	agent Agent,

--- a/internal/workflow/preprocessing.go
+++ b/internal/workflow/preprocessing.go
@@ -608,13 +608,17 @@ func writePREMISFile(ctx temporalsdk_workflow.Context, sip sip.SIP, veraPDFVersi
 
 	e = temporalsdk_workflow.ExecuteActivity(
 		withFilesysActOpts(ctx),
-		activities.AddPREMISEventName,
-		&activities.AddPREMISEventParams{
+		activities.AddPREMISValidationEventName,
+		&activities.AddPREMISValidationEventParams{
+			SIP:            sip,
 			PREMISFilePath: path,
 			Agent:          veraPDFAgent,
-			Type:           "validation",
-			Detail:         "name=\"Validate SIP file formats\"",
-			OutcomeDetail:  "File format complies with specification",
+			Summary: premis.EventSummary{
+				Type:          "validation",
+				Detail:        "name=\"Validate SIP file formats\"",
+				Outcome:       "valid",
+				OutcomeDetail: "File format complies with specification",
+			},
 		},
 	).Get(ctx, &addPREMISEvent)
 	if e != nil {


### PR DESCRIPTION
File validators only check certain types of files. Added activity to only add PREMIS events for files that have actually been checked by a validator.