### PR TITLE
Simplify veraPDF validator creation

### DIFF
--- a/cmd/worker/workercmd/cmd.go
+++ b/cmd/worker/workercmd/cmd.go
@@ -97,7 +97,7 @@ func (m *Main) Run(ctx context.Context) error {
 		psvc = entclient.New(m.dbClient)
 	}
 
-	veraPDFValidator := fvalidate.NewVeraPDFValidator(m.cfg.FileValidate.VeraPDF.Path, fvalidate.RunCommand, m.logger)
+	veraPDFValidator := fvalidate.NewVeraPDFValidator(m.cfg.FileValidate.VeraPDF.Path)
 
 	veraPDFVersion, err := veraPDFValidator.Version()
 	if err != nil {

--- a/internal/fvalidate/errors.go
+++ b/internal/fvalidate/errors.go
@@ -1,0 +1,41 @@
+package fvalidate
+
+import "fmt"
+
+type SystemError struct {
+	validator string
+
+	// exitCode is the exit code returned by the system command.
+	exitCode int
+
+	// err is the underlying error returned by the system command.
+	err error
+
+	// message is a human-readable error message intended for the operator.
+	message string
+}
+
+func NewSystemError(validator string, exitCode int, err error, msg string) *SystemError {
+	return &SystemError{
+		validator: validator,
+		exitCode:  exitCode,
+		err:       err,
+		message:   msg,
+	}
+}
+
+func (e *SystemError) Validator() string {
+	return e.validator
+}
+
+func (e *SystemError) Error() string {
+	return fmt.Sprintf("system error: exit code %d: %s", e.exitCode, e.err)
+}
+
+func (e *SystemError) Unwrap() error {
+	return e.err
+}
+
+func (e *SystemError) Message() string {
+	return e.message
+}

--- a/internal/fvalidate/errors_test.go
+++ b/internal/fvalidate/errors_test.go
@@ -1,0 +1,21 @@
+package fvalidate_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/fvalidate"
+	"gotest.tools/v3/assert"
+)
+
+func TestSystemError(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("some error")
+	se := fvalidate.NewSystemError("veraPDF", 1, err, "PDF/A validation failed with an application error")
+
+	assert.Equal(t, se.Validator(), "veraPDF")
+	assert.Equal(t, se.Error(), "system error: exit code 1: some error")
+	assert.Equal(t, se.Unwrap(), err)
+	assert.Equal(t, se.Message(), "PDF/A validation failed with an application error")
+}

--- a/internal/workflow/preprocessing_test.go
+++ b/internal/workflow/preprocessing_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/artefactual-sdps/temporal-activities/bagvalidate"
 	"github.com/artefactual-sdps/temporal-activities/ffvalidate"
 	"github.com/artefactual-sdps/temporal-activities/xmlvalidate"
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
@@ -189,7 +188,7 @@ func (s *PreprocessingTestSuite) SetupTest(cfg *config.Configuration) {
 		temporalsdk_activity.RegisterOptions{Name: activities.AddPREMISEventName},
 	)
 
-	veraPDFValidator := fvalidate.NewVeraPDFValidator("", fvalidate.RunCommand, logr.Discard())
+	veraPDFValidator := fvalidate.NewVeraPDFValidator("")
 
 	s.env.RegisterActivityWithOptions(
 		activities.NewAddPREMISValidationEvent(veraPDFValidator).Execute,


### PR DESCRIPTION
This change was prompted by work on #152, but is mostly unrelated.

I've simplified the `NewVeraPDFValidator` constructor by removing the `runFunc` and `logger` parameters.

The `runFunc` parameter was solely used to avoid the dependency on the veraPDF Java executable in test, but didn't provide any assurance that the code would run correctly in production.

The `logger` parameter was used to log the exit code and STDERR when the veraPDF executable returned an unexpected error code. Rather than logging the veraPDF error data directly, the new code returns a custom `SystemError` that includes the validator name, exit code, STDERR message, and a human readable message intended for display in the Enduro UI.