### PR TITLE
Add file validator scope

### DIFF
--- a/internal/activities/validate_files_test.go
+++ b/internal/activities/validate_files_test.go
@@ -82,6 +82,7 @@ func TestValidateFiles(t *testing.T) {
 			params:   activities.ValidateFilesParams{SIP: digitizedAIP},
 			expectId: defaultIdentifierMock,
 			expectVld: func(m *fake_fvalidate.MockValidatorMockRecorder) {
+				m.Scope().Return(fvalidate.TargetTypeDir)
 				m.FormatIDs().Return([]string{"fmt/354"})
 				m.Validate(digitizedAIP.ContentPath).Return("", nil)
 			},
@@ -91,6 +92,7 @@ func TestValidateFiles(t *testing.T) {
 			params:   activities.ValidateFilesParams{SIP: digitizedAIP},
 			expectId: defaultIdentifierMock,
 			expectVld: func(m *fake_fvalidate.MockValidatorMockRecorder) {
+				m.Scope().Return(fvalidate.TargetTypeDir)
 				m.FormatIDs().Return([]string{"fmt/354"})
 				m.Validate(digitizedAIP.ContentPath).Return(
 					"One or more PDF/A files are invalid",
@@ -106,6 +108,7 @@ func TestValidateFiles(t *testing.T) {
 			params:   activities.ValidateFilesParams{SIP: digitizedAIP},
 			expectId: defaultIdentifierMock,
 			expectVld: func(m *fake_fvalidate.MockValidatorMockRecorder) {
+				m.Scope().Return(fvalidate.TargetTypeDir)
 				m.FormatIDs().Return([]string{"fmt/354"})
 				m.Validate(digitizedAIP.ContentPath).Return(
 					"",
@@ -119,6 +122,7 @@ func TestValidateFiles(t *testing.T) {
 			params:   activities.ValidateFilesParams{SIP: digitizedAIP},
 			expectId: defaultIdentifierMock,
 			expectVld: func(m *fake_fvalidate.MockValidatorMockRecorder) {
+				m.Scope().Return(fvalidate.TargetTypeDir)
 				m.FormatIDs().Return([]string{"fmt/354"})
 				m.Validate(digitizedAIP.ContentPath).Return(
 					"",
@@ -131,6 +135,15 @@ func TestValidateFiles(t *testing.T) {
 				)
 			},
 			wantErr: "PDF/A validation failed with an application error",
+		},
+		{
+			name:     "Error when validator scope is not supported",
+			params:   activities.ValidateFilesParams{SIP: digitizedAIP},
+			expectId: defaultIdentifierMock,
+			expectVld: func(m *fake_fvalidate.MockValidatorMockRecorder) {
+				m.Scope().Return(fvalidate.TargetTypeFile)
+			},
+			wantErr: "validateFiles: unsupported validator scope",
 		},
 		{
 			name:   "Skip validation when format identification fails",
@@ -156,6 +169,7 @@ func TestValidateFiles(t *testing.T) {
 				)
 			},
 			expectVld: func(m *fake_fvalidate.MockValidatorMockRecorder) {
+				m.Scope().Return(fvalidate.TargetTypeDir)
 				m.FormatIDs().Return([]string{"fmt/354"})
 			},
 		},

--- a/internal/fvalidate/errors_test.go
+++ b/internal/fvalidate/errors_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/artefactual-sdps/preprocessing-sfa/internal/fvalidate"
 	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/fvalidate"
 )
 
 func TestSystemError(t *testing.T) {

--- a/internal/fvalidate/fake/mock_validator.go
+++ b/internal/fvalidate/fake/mock_validator.go
@@ -12,6 +12,7 @@ package fake
 import (
 	reflect "reflect"
 
+	fvalidate "github.com/artefactual-sdps/preprocessing-sfa/internal/fvalidate"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -110,6 +111,44 @@ func (c *MockValidatorNameCall) Do(f func() string) *MockValidatorNameCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockValidatorNameCall) DoAndReturn(f func() string) *MockValidatorNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// Scope mocks base method.
+func (m *MockValidator) Scope() fvalidate.TargetType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Scope")
+	ret0, _ := ret[0].(fvalidate.TargetType)
+	return ret0
+}
+
+// Scope indicates an expected call of Scope.
+func (mr *MockValidatorMockRecorder) Scope() *MockValidatorScopeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scope", reflect.TypeOf((*MockValidator)(nil).Scope))
+	return &MockValidatorScopeCall{Call: call}
+}
+
+// MockValidatorScopeCall wrap *gomock.Call
+type MockValidatorScopeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockValidatorScopeCall) Return(arg0 fvalidate.TargetType) *MockValidatorScopeCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockValidatorScopeCall) Do(f func() fvalidate.TargetType) *MockValidatorScopeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockValidatorScopeCall) DoAndReturn(f func() fvalidate.TargetType) *MockValidatorScopeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/fvalidate/fvalidate.go
+++ b/internal/fvalidate/fvalidate.go
@@ -1,5 +1,12 @@
 package fvalidate
 
+type TargetType int
+
+const (
+	TargetTypeDir TargetType = iota
+	TargetTypeFile
+)
+
 // Validator provides an interface for validating a file's format.
 type Validator interface {
 	// FormatIDs lists the format IDs that the validator can validate.
@@ -8,7 +15,11 @@ type Validator interface {
 	// Name of the validator.
 	Name() string
 
-	// Validate validates the file at path.
+	// Scope of the validator, whether it targets an individual file or all the
+	// files in a directory.
+	Scope() TargetType
+
+	// Validate validates the file or directory at path.
 	Validate(path string) (string, error)
 
 	// Returns the version of a validator.

--- a/internal/fvalidate/verapdf_validator.go
+++ b/internal/fvalidate/verapdf_validator.go
@@ -26,13 +26,14 @@ var pdfaPUIDs = []string{
 }
 
 type veraPDFValidator struct {
-	cmd string
+	cmd   string
+	scope TargetType
 }
 
 var _ Validator = (*veraPDFValidator)(nil)
 
 func NewVeraPDFValidator(cmd string) *veraPDFValidator {
-	return &veraPDFValidator{cmd: cmd}
+	return &veraPDFValidator{cmd: cmd, scope: TargetTypeDir}
 }
 
 func (v *veraPDFValidator) FormatIDs() []string {
@@ -81,6 +82,10 @@ func (v *veraPDFValidator) Validate(path string) (string, error) {
 			"PDF/A validation failed with an application error",
 		)
 	}
+}
+
+func (v *veraPDFValidator) Scope() TargetType {
+	return v.scope
 }
 
 func (v *veraPDFValidator) Version() (string, error) {

--- a/internal/fvalidate/verapdf_validator_test.go
+++ b/internal/fvalidate/verapdf_validator_test.go
@@ -95,6 +95,13 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestScope(t *testing.T) {
+	t.Parallel()
+
+	v := fvalidate.NewVeraPDFValidator("")
+	assert.Equal(t, v.Scope(), fvalidate.TargetTypeDir)
+}
+
 func TestVersion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This was prompted by work on #152 but is mostly unrelated.

This change recognizes that veraPDFValidator operates on a directory, rather than an individual file, while allowing for future validators that operate on a single file.

The added `fvalidate.Scope()` method returns the intended scope of the `Validate()` method, either a single file or a directory of files.

The added 'veraPDFValidator.scope' property indicates that the validator operates on a directory of files.