### PR TITLE
Reduce APIS pollInterval values in dev

### DIFF
--- a/hack/kube/overlays/dev/preprocessing-secret.yaml
+++ b/hack/kube/overlays/dev/preprocessing-secret.yaml
@@ -32,7 +32,7 @@ stringData:
     enabled = true
     url = "http://apis-mock.enduro-sdps:8080"
     timeout = "10s"
-    pollInterval = "30s"
+    pollInterval = "1s"
     token = "mock-token"
 
     [apis.oidc]

--- a/hack/kube/overlays/enduro/preprocessing-secret.yaml
+++ b/hack/kube/overlays/enduro/preprocessing-secret.yaml
@@ -32,7 +32,7 @@ stringData:
     enabled = true
     url = "http://apis-mock.enduro-sdps:8080"
     timeout = "10s"
-    pollInterval = "30s"
+    pollInterval = "1s"
     token = "mock-token"
 
     [apis.oidc]


### PR DESCRIPTION
Reduce APIS pollInterval values from 30s to 1s in the kube overlays to reduce preprocessing workflow run times in development. Because the APIS mock server requires 3 polls to complete analysis this reduces the API poll activity time from ~1m30s to ~3s.