### PR TITLE
Add govulncheck to bine tools

### DIFF
--- a/.bine.json
+++ b/.bine.json
@@ -37,6 +37,11 @@
       "asset_pattern": "{name}_{version}_{goos}_{goarch}.tar.gz"
     },
     {
+      "name": "govulncheck",
+      "go_package": "golang.org/x/vuln/cmd/govulncheck",
+      "version": "latest"
+    },
+    {
       "name": "mockgen",
       "go_package": "go.uber.org/mock/mockgen",
       "version": "0.6.0"

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,11 @@ gosec: tool-gosec
 	go tool bine upgrade gosec
 	gosec $(GOSEC_VERBOSITY) -exclude-dir=hack ./...
 
+govulncheck: # @HELP Run govulncheck security scanner.
+govulncheck: tool-govulncheck
+	go tool bine upgrade govulncheck
+	govulncheck $(GOVULNCHECK_FLAGS) ./...
+
 help: # @HELP Print this message.
 	echo "TARGETS:"
 	grep -hE '^.*:.*?# *@HELP' $(MAKEFILE_LIST) | sort | \


### PR DESCRIPTION
- Add govulncheck to bine tools to make it easier to run the latest version against the code
- Add a `make govulncheck` target to run the bine binary