### PR TITLE
Update APIS spec, mock server, client and activities

### DIFF
--- a/apis/openapi3.json
+++ b/apis/openapi3.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "APIS API",
     "description": "This is the API definition of APIS (archive plan analysis and import service)",
@@ -11,7 +11,7 @@
     "version": "v1"
   },
   "paths": {
-    "/api/Healthz": {
+    "/api/healthz": {
       "get": {
         "tags": [
           "Healthz"
@@ -61,7 +61,7 @@
         }
       }
     },
-    "/api/ImportTasks": {
+    "/api/importtasks": {
       "post": {
         "tags": [
           "ImportTasks"
@@ -122,7 +122,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateImportTaskResponse"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -142,7 +142,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateImportTaskResponse"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -152,7 +152,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateImportTaskResponse"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -160,17 +160,17 @@
         }
       }
     },
-    "/api/ImportTasks/{id}/status": {
+    "/api/importtasks/{id}/status": {
       "get": {
         "tags": [
           "ImportTasks"
         ],
-        "summary": "Query the status of an ongoing analysis or import",
+        "summary": "Query the status of an ongoing analysis (import task).",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "The id of the import task to query",
+            "description": "The id of the import task to query.",
             "required": true,
             "schema": {
               "type": "string"
@@ -187,21 +187,52 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
-        }
+        },
+        "description": "This endpoint returns the status of the import task analysis phase only.\r\nFor import run progress and results, use the import run status endpoint."
       }
     },
-    "/api/ImportTasks/{id}": {
-      "patch": {
+    "/api/importtasks/{id}/cancel": {
+      "post": {
         "tags": [
           "ImportTasks"
         ],
-        "summary": "Updates the status of an existing import task.",
+        "summary": "Cancels an existing import task.",
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the import task to be updated.",
+            "description": "The unique identifier of the import task to cancel.",
             "required": true,
             "schema": {
               "type": "string"
@@ -209,7 +240,7 @@
           }
         ],
         "requestBody": {
-          "description": "The request containing the new status and related details for the import task. Only the status Evelix.Apis.Contract.Common.Entities.CodeValues.ImportTaskStatus.Abgebrochen is allowed.",
+          "description": "Optional cancellation details including reason.",
           "content": {
             "application/json": {
               "schema": {
@@ -229,28 +260,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "The import task was successfully updated.",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportTaskDto"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportTaskDto"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportTaskDto"
-                }
-              }
-            }
-          },
           "409": {
-            "description": "The requested status transition is not allowed.",
+            "description": "The import task cannot be cancelled in its current state.",
             "content": {
               "text/plain": {
                 "schema": {
@@ -288,11 +299,54 @@
                 }
               }
             }
+          },
+          "204": {
+            "description": "The import task was successfully cancelled."
+          },
+          "401": {
+            "description": "The user is not authorized.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
     },
-    "/api/ImportTasks/{id}/importRuns": {
+    "/api/importtasks/{id}/importruns": {
       "post": {
         "tags": [
           "ImportTasks"
@@ -314,17 +368,22 @@
             "multipart/form-data": {
               "schema": {
                 "required": [
-                  "file"
+                  "file",
+                  "username"
                 ],
                 "type": "object",
                 "properties": {
                   "file": {
                     "type": "string",
-                    "description": "The METS file required for the import.\r\n(To be decided: Or a zip file containing the METS and the metadata.xml file?))",
+                    "description": "The METS file required for the import.",
                     "format": "binary"
                   },
                   "importBehaviour": {
                     "$ref": "#/components/schemas/ImportBehaviourType"
+                  },
+                  "username": {
+                    "type": "string",
+                    "description": "The username that is logged as the creator of the import task. Can be the email for example."
                   }
                 }
               },
@@ -333,6 +392,9 @@
                   "style": "form"
                 },
                 "importBehaviour": {
+                  "style": "form"
+                },
+                "username": {
                   "style": "form"
                 }
               }
@@ -365,17 +427,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -443,7 +505,7 @@
         }
       }
     },
-    "/api/ImportTasks/{id}/importRuns/{runId}/status": {
+    "/api/importtasks/{id}/importruns/{runId}/status": {
       "get": {
         "tags": [
           "ImportTasks"
@@ -453,6 +515,7 @@
           {
             "name": "id",
             "in": "path",
+            "description": "The import task identifier.",
             "required": true,
             "schema": {
               "type": "string"
@@ -461,6 +524,7 @@
           {
             "name": "runId",
             "in": "path",
+            "description": "The import run identifier.",
             "required": true,
             "schema": {
               "type": "string"
@@ -527,154 +591,34 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
-        }
+        },
+        "description": "If the import has started in ACTApro (TaskId is present), the status is fetched from ACTApro.\r\nOtherwise, the local status from the database is returned."
       }
     }
   },
   "components": {
     "schemas": {
-      "AnalysisRecordDto": {
-        "type": "object",
-        "properties": {
-          "analysisRecordId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "rowVersion": {
-            "type": "string",
-            "format": "byte"
-          },
-          "importTaskId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "comparisonDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "targetPrimaryKey": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "docKey": {
-            "type": "string",
-            "nullable": true
-          },
-          "referenceCode": {
-            "type": "string",
-            "nullable": true
-          },
-          "level": {
-            "type": "string",
-            "nullable": true
-          },
-          "sourcePrimaryKey": {
-            "type": "string",
-            "nullable": true
-          },
-          "positionNumber": {
-            "type": "string"
-          },
-          "sourceTitle": {
-            "type": "string"
-          },
-          "destinationTitle": {
-            "type": "string",
-            "nullable": true
-          },
-          "sourceField1": {
-            "type": "string",
-            "nullable": true
-          },
-          "destinationField1": {
-            "type": "string",
-            "nullable": true
-          },
-          "sourceField2": {
-            "type": "string",
-            "nullable": true
-          },
-          "destinationField2": {
-            "type": "string",
-            "nullable": true
-          },
-          "sourceField3": {
-            "type": "string",
-            "nullable": true
-          },
-          "destinationField3": {
-            "type": "string",
-            "nullable": true
-          },
-          "sourceField4": {
-            "type": "string",
-            "nullable": true
-          },
-          "destinationField4": {
-            "type": "string",
-            "nullable": true
-          },
-          "sourceField5": {
-            "type": "string",
-            "nullable": true
-          },
-          "destinationField5": {
-            "type": "string",
-            "nullable": true
-          },
-          "titleIsDifferent": {
-            "type": "boolean"
-          },
-          "field1IsDifferent": {
-            "type": "boolean"
-          },
-          "field2IsDifferent": {
-            "type": "boolean"
-          },
-          "field3IsDifferent": {
-            "type": "boolean"
-          },
-          "field4IsDifferent": {
-            "type": "boolean"
-          },
-          "field5IsDifferent": {
-            "type": "boolean"
-          },
-          "status": {
-            "type": "string",
-            "nullable": true
-          },
-          "errorMessage": {
-            "type": "string",
-            "nullable": true
-          },
-          "containerDocKey": {
-            "type": "string",
-            "nullable": true
-          },
-          "createdBy": {
-            "type": "string"
-          },
-          "createdOn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedOn": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "importTask": {
-            "$ref": "#/components/schemas/ImportTaskDto"
-          }
-        },
-        "additionalProperties": false
-      },
       "AnalysisResult": {
         "enum": [
           "AlleGleich",
@@ -692,198 +636,49 @@
         ]
       },
       "CancelImportTaskRequest": {
-        "required": [
-          "status"
-        ],
         "type": "object",
         "properties": {
-          "status": {
-            "$ref": "#/components/schemas/ImportTaskStatus"
+          "reason": {
+            "type": "string",
+            "description": "Optional reason for canceling the import task.",
+            "nullable": true
+          },
+          "cancelledBy": {
+            "type": "string",
+            "description": "The user who initiated the cancellation.",
+            "nullable": true
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "Request to cancel an import task."
       },
       "CreateImportRunResponse": {
         "type": "object",
         "properties": {
-          "success": {
-            "type": "boolean",
-            "description": "Gets a value indicating whether the creation of the import run was successful."
-          },
-          "importTaskId": {
-            "type": "string",
-            "description": "Gets the identifier of the import task associated with the response."
-          },
           "importRunId": {
             "type": "string",
-            "description": "Gets the unique identifier for the created import run.",
-            "nullable": true
-          },
-          "error": {
-            "type": "string",
-            "description": "Gets or initializes the error message associated with the result of the import run creation.",
-            "nullable": true
+            "description": "Gets the unique identifier for the created import run."
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "required": [
+          "importRunId"
+        ],
+        "description": "Response returned when an import run is successfully created."
       },
       "CreateImportTaskResponse": {
         "type": "object",
         "properties": {
-          "success": {
-            "type": "boolean",
-            "description": "Gets a value indicating whether the creation of the import task was successful."
-          },
-          "error": {
-            "type": "string",
-            "description": "Gets or initializes the error message associated with the result of the import task creation.",
-            "nullable": true
-          },
-          "id": {
-            "type": "string",
-            "description": "Gets the unique identifier for the created import task.",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "DefaultValueDto": {
-        "type": "object",
-        "properties": {
-          "defaultValueId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "rowVersion": {
-            "type": "string",
-            "format": "byte"
-          },
           "importTaskId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "accessionDocKey": {
-            "type": "string"
-          },
-          "accessionIdName": {
-            "type": "string"
-          },
-          "insertNodeDocKey": {
-            "type": "string"
-          },
-          "insertNodeIdName": {
-            "type": "string"
-          },
-          "status": {
             "type": "string",
-            "nullable": true
-          },
-          "protectionBaseDate": {
-            "type": "string",
-            "nullable": true
-          },
-          "protectionCategory": {
-            "type": "string",
-            "nullable": true
-          },
-          "protectionDuration": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "metadataCanBePublished": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "accessibility": {
-            "type": "string",
-            "nullable": true
-          },
-          "usability": {
-            "type": "string",
-            "nullable": true
-          },
-          "permissionType": {
-            "type": "string",
-            "nullable": true
-          },
-          "createdBy": {
-            "type": "string"
-          },
-          "createdOn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedOn": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "importTask": {
-            "$ref": "#/components/schemas/ImportTaskDto"
+            "description": "Gets the unique identifier for the created import task."
           }
         },
-        "additionalProperties": false
-      },
-      "DocumentDto": {
-        "type": "object",
-        "properties": {
-          "documentId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "rowVersion": {
-            "type": "string",
-            "format": "byte"
-          },
-          "importTaskId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "fileName": {
-            "type": "string"
-          },
-          "dataBlob": {
-            "type": "string",
-            "format": "byte"
-          },
-          "uploadDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "xmlSourceType": {
-            "type": "string",
-            "nullable": true
-          },
-          "fileSize": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "createdBy": {
-            "type": "string"
-          },
-          "createdOn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedOn": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "importTask": {
-            "$ref": "#/components/schemas/ImportTaskDto"
-          }
-        },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "required": [
+          "importTaskId"
+        ],
+        "description": "Response returned when an import task is successfully created."
       },
       "HealthCheckResult": {
         "required": [
@@ -943,76 +738,6 @@
           ""
         ]
       },
-      "ImportDto": {
-        "type": "object",
-        "properties": {
-          "importId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "rowVersion": {
-            "type": "string",
-            "format": "byte"
-          },
-          "taskId": {
-            "type": "string"
-          },
-          "importTaskId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "status": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "processedDocumentCount": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "totalDocumentCount": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "importDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "importFileBlob": {
-            "type": "string",
-            "format": "byte",
-            "nullable": true
-          },
-          "isSuccessful": {
-            "type": "boolean"
-          },
-          "createdBy": {
-            "type": "string"
-          },
-          "createdOn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedOn": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "importTask": {
-            "$ref": "#/components/schemas/ImportTaskDto"
-          }
-        },
-        "additionalProperties": false
-      },
       "ImportResult": {
         "enum": [
           "Erfolgreich",
@@ -1028,114 +753,36 @@
       "ImportRunStatusResponse": {
         "type": "object",
         "properties": {
-          "importTaskId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "importRunId": {
-            "type": "string"
-          },
           "status": {
-            "type": "string"
+            "$ref": "#/components/schemas/ImportStatus"
           },
           "progressPercent": {
             "type": "integer",
             "format": "int32",
-            "nullable": true
+            "nullable": true,
+            "description": "The progress of the import run in percent (0-100), if available."
           },
-          "error": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "ImportTaskDto": {
-        "type": "object",
-        "properties": {
-          "importTaskId": {
+          "importResult": {
+            "$ref": "#/components/schemas/ImportResult"
+          },
+          "processedDocumentCount": {
             "type": "integer",
-            "format": "int32"
-          },
-          "rowVersion": {
-            "type": "string",
-            "format": "byte"
-          },
-          "taskType": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string",
-            "nullable": true
-          },
-          "noAutomaticImport": {
-            "type": "boolean"
-          },
-          "requiresContainers": {
-            "type": "boolean"
-          },
-          "status": {
-            "type": "string"
-          },
-          "analysisErrorMessage": {
-            "type": "string",
-            "nullable": true
-          },
-          "analysisResult": {
-            "type": "string",
-            "nullable": true
-          },
-          "analysisProgressInPercent": {
-            "type": "integer",
+            "description": "How many records were processed during the import.",
             "format": "int32",
             "nullable": true
           },
-          "importResult": {
-            "type": "string",
+          "totalDocumentCount": {
+            "type": "integer",
+            "description": "The total number of records to be processed during the import.",
+            "format": "int32",
             "nullable": true
-          },
-          "createdBy": {
-            "type": "string"
-          },
-          "createdOn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedOn": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "analysisRecords": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AnalysisRecordDto"
-            }
-          },
-          "defaultValues": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DefaultValueDto"
-            }
-          },
-          "documents": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DocumentDto"
-            }
-          },
-          "imports": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ImportDto"
-            }
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "required": [
+          "status"
+        ],
+        "description": "Response containing the status of an import run."
       },
       "ImportTaskStatus": {
         "enum": [
@@ -1178,26 +825,14 @@
           "importResult": {
             "$ref": "#/components/schemas/ImportResult"
           },
-          "importProgressInPercent": {
-            "type": "integer",
-            "description": "During the import, this indicates the progress in percent.",
-            "format": "int32",
-            "nullable": true
-          },
-          "processedDocumentCount": {
-            "type": "integer",
-            "description": "How many records were processed by the import",
-            "format": "int32",
-            "nullable": true
-          },
-          "totalDocumentCount": {
-            "type": "integer",
-            "description": "The total number of records that should have been processed by the import",
-            "format": "int32",
+          "analysisErrorMessage": {
+            "type": "string",
+            "description": "If there was an error during the analysis, this contains the error message.",
             "nullable": true
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "Response containing the status of an import task (analysis phase)."
       },
       "ProblemDetails": {
         "type": "object",
@@ -1242,41 +877,33 @@
           ""
         ]
       },
-      "ValidationProblemDetails": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "nullable": true
-          },
-          "title": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "detail": {
-            "type": "string",
-            "nullable": true
-          },
-          "instance": {
-            "type": "string",
-            "nullable": true
-          },
-          "errors": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "additionalProperties": { }
+      "ImportStatus": {
+        "enum": [
+          "RequestStart",
+          "RequestCancel",
+          "Started",
+          "Failed",
+          "Canceled",
+          "Completed",
+          "UndoStarted",
+          "UndoCompleted",
+          "Created",
+          "Preparing"
+        ],
+        "type": "string",
+        "description": "Enum values:\r\n- `RequestStart`\r\n- `RequestCancel`\r\n- `Started`\r\n- `Failed`\r\n- `Canceled`\r\n- `Completed`\r\n- `UndoStarted`\r\n- `UndoCompleted`\r\n- `Created`\r\n- `Preparing`",
+        "x-enumDescriptions": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ]
       }
     },
     "securitySchemes": {

--- a/apis/openapi3.json
+++ b/apis/openapi3.json
@@ -61,291 +61,6 @@
         }
       }
     },
-    "/api/importtasks": {
-      "post": {
-        "tags": [
-          "ImportTasks"
-        ],
-        "summary": "Creates a new import task.",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "required": [
-                  "file",
-                  "sipType",
-                  "username"
-                ],
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "description": "The metadata.xml file according to eCH-0160",
-                    "format": "binary"
-                  },
-                  "sipType": {
-                    "$ref": "#/components/schemas/SipType"
-                  },
-                  "username": {
-                    "type": "string",
-                    "description": "The username that is logged as the creator of the import task. Can be the email for example."
-                  }
-                }
-              },
-              "encoding": {
-                "file": {
-                  "style": "form"
-                },
-                "sipType": {
-                  "style": "form"
-                },
-                "username": {
-                  "style": "form"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateImportTaskResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "Unsupported Media Type",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/importtasks/{id}/status": {
-      "get": {
-        "tags": [
-          "ImportTasks"
-        ],
-        "summary": "Query the status of an ongoing analysis (import task).",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The id of the import task to query.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportTaskStatusResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "description": "This endpoint returns the status of the import task analysis phase only.\r\nFor import run progress and results, use the import run status endpoint."
-      }
-    },
-    "/api/importtasks/{id}/cancel": {
-      "post": {
-        "tags": [
-          "ImportTasks"
-        ],
-        "summary": "Cancels an existing import task.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The unique identifier of the import task to cancel.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "Optional cancellation details including reason.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CancelImportTaskRequest"
-              }
-            },
-            "text/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CancelImportTaskRequest"
-              }
-            },
-            "application/*+json": {
-              "schema": {
-                "$ref": "#/components/schemas/CancelImportTaskRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "409": {
-            "description": "The import task cannot be cancelled in its current state.",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The specified import task was not found.",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "204": {
-            "description": "The import task was successfully cancelled."
-          },
-          "401": {
-            "description": "The user is not authorized.",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/importtasks/{id}/importruns": {
       "post": {
         "tags": [
@@ -505,12 +220,112 @@
         }
       }
     },
+    "/api/importtasks": {
+      "post": {
+        "tags": [
+          "ImportTasks"
+        ],
+        "summary": "Creates a new import task.",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "file",
+                  "sipType",
+                  "username"
+                ],
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "description": "The metadata.xml file according to eCH-0160",
+                    "format": "binary"
+                  },
+                  "sipType": {
+                    "$ref": "#/components/schemas/SipType"
+                  },
+                  "username": {
+                    "type": "string",
+                    "description": "The username that is logged as the creator of the import task. Can be the email for example."
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "style": "form"
+                },
+                "sipType": {
+                  "style": "form"
+                },
+                "username": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateImportTaskResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/importtasks/{id}/importruns/{runId}/status": {
       "get": {
         "tags": [
           "ImportTasks"
         ],
         "summary": "Gets the status of a specific import run.",
+        "description": "If the import has started in ACTApro (TaskId is present), the status is fetched from ACTApro.\r\nOtherwise, the local status from the database is returned.",
         "parameters": [
           {
             "name": "id",
@@ -612,8 +427,193 @@
               }
             }
           }
+        }
+      }
+    },
+    "/api/importtasks/{id}/status": {
+      "get": {
+        "tags": [
+          "ImportTasks"
+        ],
+        "summary": "Query the status of an ongoing analysis (import task).",
+        "description": "This endpoint returns the status of the import task analysis phase only.\r\nFor import run progress and results, use the import run status endpoint.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the import task to query.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportTaskStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/importtasks/{id}/cancel": {
+      "post": {
+        "tags": [
+          "ImportTasks"
+        ],
+        "summary": "Cancels an existing import task.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the import task to cancel.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Optional cancellation details including reason.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelImportTaskRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelImportTaskRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelImportTaskRequest"
+              }
+            }
+          }
         },
-        "description": "If the import has started in ACTApro (TaskId is present), the status is fetched from ACTApro.\r\nOtherwise, the local status from the database is returned."
+        "responses": {
+          "204": {
+            "description": "The import task was successfully cancelled."
+          },
+          "401": {
+            "description": "The user is not authorized.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The specified import task was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The import task cannot be cancelled in its current state.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -653,6 +653,9 @@
         "description": "Request to cancel an import task."
       },
       "CreateImportRunResponse": {
+        "required": [
+          "importRunId"
+        ],
         "type": "object",
         "properties": {
           "importRunId": {
@@ -661,12 +664,12 @@
           }
         },
         "additionalProperties": false,
-        "required": [
-          "importRunId"
-        ],
         "description": "Response returned when an import run is successfully created."
       },
       "CreateImportTaskResponse": {
+        "required": [
+          "importTaskId"
+        ],
         "type": "object",
         "properties": {
           "importTaskId": {
@@ -675,9 +678,6 @@
           }
         },
         "additionalProperties": false,
-        "required": [
-          "importTaskId"
-        ],
         "description": "Response returned when an import task is successfully created."
       },
       "HealthCheckResult": {
@@ -687,6 +687,11 @@
         ],
         "type": "object",
         "properties": {
+          "durationMs": {
+            "type": "number",
+            "description": "How much time passed in querying the service status",
+            "format": "double"
+          },
           "name": {
             "type": "string",
             "description": "The name of the service"
@@ -694,11 +699,6 @@
           "status": {
             "type": "string",
             "description": "The current status of the service"
-          },
-          "durationMs": {
-            "type": "number",
-            "description": "How much time passed in querying the service status",
-            "format": "double"
           }
         },
         "additionalProperties": false,
@@ -710,10 +710,6 @@
         ],
         "type": "object",
         "properties": {
-          "status": {
-            "type": "string",
-            "description": "The overall status"
-          },
           "checks": {
             "type": "array",
             "items": {
@@ -721,6 +717,10 @@
             },
             "description": "A list with services and it's health statuses",
             "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "description": "The overall status"
           }
         },
         "additionalProperties": false,
@@ -751,6 +751,9 @@
         ]
       },
       "ImportRunStatusResponse": {
+        "required": [
+          "status"
+        ],
         "type": "object",
         "properties": {
           "status": {
@@ -758,9 +761,9 @@
           },
           "progressPercent": {
             "type": "integer",
+            "description": "The progress of the import run in percent (0-100), if available.",
             "format": "int32",
-            "nullable": true,
-            "description": "The progress of the import run in percent (0-100), if available."
+            "nullable": true
           },
           "importResult": {
             "$ref": "#/components/schemas/ImportResult"
@@ -779,10 +782,35 @@
           }
         },
         "additionalProperties": false,
-        "required": [
-          "status"
-        ],
         "description": "Response containing the status of an import run."
+      },
+      "ImportStatus": {
+        "enum": [
+          "RequestStart",
+          "RequestCancel",
+          "Started",
+          "Failed",
+          "Canceled",
+          "Completed",
+          "UndoStarted",
+          "UndoCompleted",
+          "Created",
+          "Preparing"
+        ],
+        "type": "string",
+        "description": "Enum values:\r\n- `RequestStart`\r\n- `RequestCancel`\r\n- `Started`\r\n- `Failed`\r\n- `Canceled`\r\n- `Completed`\r\n- `UndoStarted`\r\n- `UndoCompleted`\r\n- `Created`\r\n- `Preparing`",
+        "x-enumDescriptions": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ]
       },
       "ImportTaskStatus": {
         "enum": [
@@ -822,13 +850,13 @@
             "format": "int32",
             "nullable": true
           },
-          "importResult": {
-            "$ref": "#/components/schemas/ImportResult"
-          },
           "analysisErrorMessage": {
             "type": "string",
             "description": "If there was an error during the analysis, this contains the error message.",
             "nullable": true
+          },
+          "importResult": {
+            "$ref": "#/components/schemas/ImportResult"
           }
         },
         "additionalProperties": false,
@@ -871,34 +899,6 @@
         "type": "string",
         "description": "Enum values:\r\n- `DigitizedAIP`\r\n- `DigitizedSIP`\r\n- `BornDigitalAIP`\r\n- `BornDigitalSIP`",
         "x-enumDescriptions": [
-          "",
-          "",
-          "",
-          ""
-        ]
-      },
-      "ImportStatus": {
-        "enum": [
-          "RequestStart",
-          "RequestCancel",
-          "Started",
-          "Failed",
-          "Canceled",
-          "Completed",
-          "UndoStarted",
-          "UndoCompleted",
-          "Created",
-          "Preparing"
-        ],
-        "type": "string",
-        "description": "Enum values:\r\n- `RequestStart`\r\n- `RequestCancel`\r\n- `Started`\r\n- `Failed`\r\n- `Canceled`\r\n- `Completed`\r\n- `UndoStarted`\r\n- `UndoCompleted`\r\n- `Created`\r\n- `Preparing`",
-        "x-enumDescriptions": [
-          "",
-          "",
-          "",
-          "",
-          "",
-          "",
           "",
           "",
           "",

--- a/hack/apis-mock/internal/gen/generate.go
+++ b/hack/apis-mock/internal/gen/generate.go
@@ -1,3 +1,3 @@
 package gen
 
-//go:generate go run github.com/ogen-go/ogen/cmd/ogen@v1.20.0 --config ogen.yml --target . --package gen --clean ../../../apis/openapi3.json
+//go:generate go run github.com/ogen-go/ogen/cmd/ogen@v1.20.0 --config ogen.yml --target . --package gen --clean ../../../../apis/openapi3.json

--- a/hack/apis-mock/internal/gen/oas_handlers_gen.go
+++ b/hack/apis-mock/internal/gen/oas_handlers_gen.go
@@ -32,17 +32,17 @@ func (c *codeRecorder) Unwrap() http.ResponseWriter {
 	return c.ResponseWriter
 }
 
-// handleAPIHealthzGetRequest handles GET /api/Healthz operation.
+// handleAPIHealthzGetRequest handles GET /api/healthz operation.
 //
 // Get health status information.
 //
-// GET /api/Healthz
+// GET /api/healthz
 func (s *Server) handleAPIHealthzGetRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
 	statusWriter := &codeRecorder{ResponseWriter: w}
 	w = statusWriter
 	otelAttrs := []attribute.KeyValue{
 		semconv.HTTPRequestMethodKey.String("GET"),
-		semconv.HTTPRouteKey.String("/api/Healthz"),
+		semconv.HTTPRouteKey.String("/api/healthz"),
 	}
 	// Add attributes from config.
 	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
@@ -203,24 +203,23 @@ func (s *Server) handleAPIHealthzGetRequest(args [0]string, argsEscaped bool, w 
 	}
 }
 
-// handleAPIImportTasksIDImportRunsPostRequest handles POST /api/ImportTasks/{id}/importRuns operation.
+// handleAPIImporttasksIDCancelPostRequest handles POST /api/importtasks/{id}/cancel operation.
 //
-// Starts a new import run for the given import task.
-// Creates a new import execution ("run") resource.
+// Cancels an existing import task.
 //
-// POST /api/ImportTasks/{id}/importRuns
-func (s *Server) handleAPIImportTasksIDImportRunsPostRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+// POST /api/importtasks/{id}/cancel
+func (s *Server) handleAPIImporttasksIDCancelPostRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
 	statusWriter := &codeRecorder{ResponseWriter: w}
 	w = statusWriter
 	otelAttrs := []attribute.KeyValue{
 		semconv.HTTPRequestMethodKey.String("POST"),
-		semconv.HTTPRouteKey.String("/api/ImportTasks/{id}/importRuns"),
+		semconv.HTTPRouteKey.String("/api/importtasks/{id}/cancel"),
 	}
 	// Add attributes from config.
 	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
-	ctx, span := s.cfg.Tracer.Start(r.Context(), APIImportTasksIDImportRunsPostOperation,
+	ctx, span := s.cfg.Tracer.Start(r.Context(), APIImporttasksIDCancelPostOperation,
 		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
@@ -275,7 +274,7 @@ func (s *Server) handleAPIImportTasksIDImportRunsPostRequest(args [1]string, arg
 		}
 		err          error
 		opErrContext = ogenerrors.OperationContext{
-			Name: APIImportTasksIDImportRunsPostOperation,
+			Name: APIImporttasksIDCancelPostOperation,
 			ID:   "",
 		}
 	)
@@ -283,7 +282,7 @@ func (s *Server) handleAPIImportTasksIDImportRunsPostRequest(args [1]string, arg
 		type bitset = [1]uint8
 		var satisfied bitset
 		{
-			sctx, ok, err := s.securitySmart(ctx, APIImportTasksIDImportRunsPostOperation, r)
+			sctx, ok, err := s.securitySmart(ctx, APIImporttasksIDCancelPostOperation, r)
 			if err != nil {
 				err = &ogenerrors.SecurityError{
 					OperationContext: opErrContext,
@@ -323,7 +322,7 @@ func (s *Server) handleAPIImportTasksIDImportRunsPostRequest(args [1]string, arg
 			return
 		}
 	}
-	params, err := decodeAPIImportTasksIDImportRunsPostParams(args, argsEscaped, r)
+	params, err := decodeAPIImporttasksIDCancelPostParams(args, argsEscaped, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
 			OperationContext: opErrContext,
@@ -335,7 +334,7 @@ func (s *Server) handleAPIImportTasksIDImportRunsPostRequest(args [1]string, arg
 	}
 
 	var rawBody []byte
-	request, rawBody, close, err := s.decodeAPIImportTasksIDImportRunsPostRequest(r)
+	request, rawBody, close, err := s.decodeAPIImporttasksIDCancelPostRequest(r)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
 			OperationContext: opErrContext,
@@ -351,12 +350,12 @@ func (s *Server) handleAPIImportTasksIDImportRunsPostRequest(args [1]string, arg
 		}
 	}()
 
-	var response APIImportTasksIDImportRunsPostRes
+	var response APIImporttasksIDCancelPostRes
 	if m := s.cfg.Middleware; m != nil {
 		mreq := middleware.Request{
 			Context:          ctx,
-			OperationName:    APIImportTasksIDImportRunsPostOperation,
-			OperationSummary: "Starts a new import run for the given import task.\r\nCreates a new import execution (\"run\") resource.",
+			OperationName:    APIImporttasksIDCancelPostOperation,
+			OperationSummary: "Cancels an existing import task.",
 			OperationID:      "",
 			Body:             request,
 			RawBody:          rawBody,
@@ -370,9 +369,9 @@ func (s *Server) handleAPIImportTasksIDImportRunsPostRequest(args [1]string, arg
 		}
 
 		type (
-			Request  = OptAPIImportTasksIDImportRunsPostReq
-			Params   = APIImportTasksIDImportRunsPostParams
-			Response = APIImportTasksIDImportRunsPostRes
+			Request  = APIImporttasksIDCancelPostReq
+			Params   = APIImporttasksIDCancelPostParams
+			Response = APIImporttasksIDCancelPostRes
 		)
 		response, err = middleware.HookMiddleware[
 			Request,
@@ -381,14 +380,14 @@ func (s *Server) handleAPIImportTasksIDImportRunsPostRequest(args [1]string, arg
 		](
 			m,
 			mreq,
-			unpackAPIImportTasksIDImportRunsPostParams,
+			unpackAPIImporttasksIDCancelPostParams,
 			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				response, err = s.h.APIImportTasksIDImportRunsPost(ctx, request, params)
+				response, err = s.h.APIImporttasksIDCancelPost(ctx, request, params)
 				return response, err
 			},
 		)
 	} else {
-		response, err = s.h.APIImportTasksIDImportRunsPost(ctx, request, params)
+		response, err = s.h.APIImporttasksIDCancelPost(ctx, request, params)
 	}
 	if err != nil {
 		defer recordError("Internal", err)
@@ -396,7 +395,7 @@ func (s *Server) handleAPIImportTasksIDImportRunsPostRequest(args [1]string, arg
 		return
 	}
 
-	if err := encodeAPIImportTasksIDImportRunsPostResponse(response, w, span); err != nil {
+	if err := encodeAPIImporttasksIDCancelPostResponse(response, w, span); err != nil {
 		defer recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)
@@ -405,23 +404,24 @@ func (s *Server) handleAPIImportTasksIDImportRunsPostRequest(args [1]string, arg
 	}
 }
 
-// handleAPIImportTasksIDImportRunsRunIdStatusGetRequest handles GET /api/ImportTasks/{id}/importRuns/{runId}/status operation.
+// handleAPIImporttasksIDImportrunsPostRequest handles POST /api/importtasks/{id}/importruns operation.
 //
-// Gets the status of a specific import run.
+// Starts a new import run for the given import task.
+// Creates a new import execution ("run") resource.
 //
-// GET /api/ImportTasks/{id}/importRuns/{runId}/status
-func (s *Server) handleAPIImportTasksIDImportRunsRunIdStatusGetRequest(args [2]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+// POST /api/importtasks/{id}/importruns
+func (s *Server) handleAPIImporttasksIDImportrunsPostRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
 	statusWriter := &codeRecorder{ResponseWriter: w}
 	w = statusWriter
 	otelAttrs := []attribute.KeyValue{
-		semconv.HTTPRequestMethodKey.String("GET"),
-		semconv.HTTPRouteKey.String("/api/ImportTasks/{id}/importRuns/{runId}/status"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/api/importtasks/{id}/importruns"),
 	}
 	// Add attributes from config.
 	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
-	ctx, span := s.cfg.Tracer.Start(r.Context(), APIImportTasksIDImportRunsRunIdStatusGetOperation,
+	ctx, span := s.cfg.Tracer.Start(r.Context(), APIImporttasksIDImportrunsPostOperation,
 		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
@@ -476,7 +476,7 @@ func (s *Server) handleAPIImportTasksIDImportRunsRunIdStatusGetRequest(args [2]s
 		}
 		err          error
 		opErrContext = ogenerrors.OperationContext{
-			Name: APIImportTasksIDImportRunsRunIdStatusGetOperation,
+			Name: APIImporttasksIDImportrunsPostOperation,
 			ID:   "",
 		}
 	)
@@ -484,7 +484,7 @@ func (s *Server) handleAPIImportTasksIDImportRunsRunIdStatusGetRequest(args [2]s
 		type bitset = [1]uint8
 		var satisfied bitset
 		{
-			sctx, ok, err := s.securitySmart(ctx, APIImportTasksIDImportRunsRunIdStatusGetOperation, r)
+			sctx, ok, err := s.securitySmart(ctx, APIImporttasksIDImportrunsPostOperation, r)
 			if err != nil {
 				err = &ogenerrors.SecurityError{
 					OperationContext: opErrContext,
@@ -524,7 +524,209 @@ func (s *Server) handleAPIImportTasksIDImportRunsRunIdStatusGetRequest(args [2]s
 			return
 		}
 	}
-	params, err := decodeAPIImportTasksIDImportRunsRunIdStatusGetParams(args, argsEscaped, r)
+	params, err := decodeAPIImporttasksIDImportrunsPostParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var rawBody []byte
+	request, rawBody, close, err := s.decodeAPIImporttasksIDImportrunsPostRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response APIImporttasksIDImportrunsPostRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    APIImporttasksIDImportrunsPostOperation,
+			OperationSummary: "Starts a new import run for the given import task.\r\nCreates a new import execution (\"run\") resource.",
+			OperationID:      "",
+			Body:             request,
+			RawBody:          rawBody,
+			Params: middleware.Parameters{
+				{
+					Name: "id",
+					In:   "path",
+				}: params.ID,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = OptAPIImporttasksIDImportrunsPostReq
+			Params   = APIImporttasksIDImportrunsPostParams
+			Response = APIImporttasksIDImportrunsPostRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackAPIImporttasksIDImportrunsPostParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.APIImporttasksIDImportrunsPost(ctx, request, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.APIImporttasksIDImportrunsPost(ctx, request, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeAPIImporttasksIDImportrunsPostResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleAPIImporttasksIDImportrunsRunIdStatusGetRequest handles GET /api/importtasks/{id}/importruns/{runId}/status operation.
+//
+// If the import has started in ACTApro (TaskId is present), the status is fetched from ACTApro.
+// Otherwise, the local status from the database is returned.
+//
+// GET /api/importtasks/{id}/importruns/{runId}/status
+func (s *Server) handleAPIImporttasksIDImportrunsRunIdStatusGetRequest(args [2]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/api/importtasks/{id}/importruns/{runId}/status"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), APIImporttasksIDImportrunsRunIdStatusGetOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(codeAttr)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: APIImporttasksIDImportrunsRunIdStatusGetOperation,
+			ID:   "",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securitySmart(ctx, APIImporttasksIDImportrunsRunIdStatusGetOperation, r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "Smart",
+					Err:              err,
+				}
+				defer recordError("Security:Smart", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+	params, err := decodeAPIImporttasksIDImportrunsRunIdStatusGetParams(args, argsEscaped, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
 			OperationContext: opErrContext,
@@ -537,11 +739,11 @@ func (s *Server) handleAPIImportTasksIDImportRunsRunIdStatusGetRequest(args [2]s
 
 	var rawBody []byte
 
-	var response APIImportTasksIDImportRunsRunIdStatusGetRes
+	var response APIImporttasksIDImportrunsRunIdStatusGetRes
 	if m := s.cfg.Middleware; m != nil {
 		mreq := middleware.Request{
 			Context:          ctx,
-			OperationName:    APIImportTasksIDImportRunsRunIdStatusGetOperation,
+			OperationName:    APIImporttasksIDImportrunsRunIdStatusGetOperation,
 			OperationSummary: "Gets the status of a specific import run.",
 			OperationID:      "",
 			Body:             nil,
@@ -561,8 +763,8 @@ func (s *Server) handleAPIImportTasksIDImportRunsRunIdStatusGetRequest(args [2]s
 
 		type (
 			Request  = struct{}
-			Params   = APIImportTasksIDImportRunsRunIdStatusGetParams
-			Response = APIImportTasksIDImportRunsRunIdStatusGetRes
+			Params   = APIImporttasksIDImportrunsRunIdStatusGetParams
+			Response = APIImporttasksIDImportrunsRunIdStatusGetRes
 		)
 		response, err = middleware.HookMiddleware[
 			Request,
@@ -571,14 +773,14 @@ func (s *Server) handleAPIImportTasksIDImportRunsRunIdStatusGetRequest(args [2]s
 		](
 			m,
 			mreq,
-			unpackAPIImportTasksIDImportRunsRunIdStatusGetParams,
+			unpackAPIImporttasksIDImportrunsRunIdStatusGetParams,
 			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				response, err = s.h.APIImportTasksIDImportRunsRunIdStatusGet(ctx, params)
+				response, err = s.h.APIImporttasksIDImportrunsRunIdStatusGet(ctx, params)
 				return response, err
 			},
 		)
 	} else {
-		response, err = s.h.APIImportTasksIDImportRunsRunIdStatusGet(ctx, params)
+		response, err = s.h.APIImporttasksIDImportrunsRunIdStatusGet(ctx, params)
 	}
 	if err != nil {
 		defer recordError("Internal", err)
@@ -586,7 +788,7 @@ func (s *Server) handleAPIImportTasksIDImportRunsRunIdStatusGetRequest(args [2]s
 		return
 	}
 
-	if err := encodeAPIImportTasksIDImportRunsRunIdStatusGetResponse(response, w, span); err != nil {
+	if err := encodeAPIImporttasksIDImportrunsRunIdStatusGetResponse(response, w, span); err != nil {
 		defer recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)
@@ -595,224 +797,24 @@ func (s *Server) handleAPIImportTasksIDImportRunsRunIdStatusGetRequest(args [2]s
 	}
 }
 
-// handleAPIImportTasksIDPatchRequest handles PATCH /api/ImportTasks/{id} operation.
+// handleAPIImporttasksIDStatusGetRequest handles GET /api/importtasks/{id}/status operation.
 //
-// Updates the status of an existing import task.
+// This endpoint returns the status of the import task analysis phase only.
+// For import run progress and results, use the import run status endpoint.
 //
-// PATCH /api/ImportTasks/{id}
-func (s *Server) handleAPIImportTasksIDPatchRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
-	statusWriter := &codeRecorder{ResponseWriter: w}
-	w = statusWriter
-	otelAttrs := []attribute.KeyValue{
-		semconv.HTTPRequestMethodKey.String("PATCH"),
-		semconv.HTTPRouteKey.String("/api/ImportTasks/{id}"),
-	}
-	// Add attributes from config.
-	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
-
-	// Start a span for this request.
-	ctx, span := s.cfg.Tracer.Start(r.Context(), APIImportTasksIDPatchOperation,
-		trace.WithAttributes(otelAttrs...),
-		serverSpanKind,
-	)
-	defer span.End()
-
-	// Add Labeler to context.
-	labeler := &Labeler{attrs: otelAttrs}
-	ctx = contextWithLabeler(ctx, labeler)
-
-	// Run stopwatch.
-	startTime := time.Now()
-	defer func() {
-		elapsedDuration := time.Since(startTime)
-
-		attrSet := labeler.AttributeSet()
-		attrs := attrSet.ToSlice()
-		code := statusWriter.status
-		if code != 0 {
-			codeAttr := semconv.HTTPResponseStatusCode(code)
-			attrs = append(attrs, codeAttr)
-			span.SetAttributes(codeAttr)
-		}
-		attrOpt := metric.WithAttributes(attrs...)
-
-		// Increment request counter.
-		s.requests.Add(ctx, 1, attrOpt)
-
-		// Use floating point division here for higher precision (instead of Millisecond method).
-		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
-	}()
-
-	var (
-		recordError = func(stage string, err error) {
-			span.RecordError(err)
-
-			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
-			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
-			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
-			// max redirects exceeded), in which case status MUST be set to Error.
-			code := statusWriter.status
-			if code < 100 || code >= 500 {
-				span.SetStatus(codes.Error, stage)
-			}
-
-			attrSet := labeler.AttributeSet()
-			attrs := attrSet.ToSlice()
-			if code != 0 {
-				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
-			}
-
-			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
-		}
-		err          error
-		opErrContext = ogenerrors.OperationContext{
-			Name: APIImportTasksIDPatchOperation,
-			ID:   "",
-		}
-	)
-	{
-		type bitset = [1]uint8
-		var satisfied bitset
-		{
-			sctx, ok, err := s.securitySmart(ctx, APIImportTasksIDPatchOperation, r)
-			if err != nil {
-				err = &ogenerrors.SecurityError{
-					OperationContext: opErrContext,
-					Security:         "Smart",
-					Err:              err,
-				}
-				defer recordError("Security:Smart", err)
-				s.cfg.ErrorHandler(ctx, w, r, err)
-				return
-			}
-			if ok {
-				satisfied[0] |= 1 << 0
-				ctx = sctx
-			}
-		}
-
-		if ok := func() bool {
-		nextRequirement:
-			for _, requirement := range []bitset{
-				{0b00000001},
-			} {
-				for i, mask := range requirement {
-					if satisfied[i]&mask != mask {
-						continue nextRequirement
-					}
-				}
-				return true
-			}
-			return false
-		}(); !ok {
-			err = &ogenerrors.SecurityError{
-				OperationContext: opErrContext,
-				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
-			}
-			defer recordError("Security", err)
-			s.cfg.ErrorHandler(ctx, w, r, err)
-			return
-		}
-	}
-	params, err := decodeAPIImportTasksIDPatchParams(args, argsEscaped, r)
-	if err != nil {
-		err = &ogenerrors.DecodeParamsError{
-			OperationContext: opErrContext,
-			Err:              err,
-		}
-		defer recordError("DecodeParams", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-
-	var rawBody []byte
-	request, rawBody, close, err := s.decodeAPIImportTasksIDPatchRequest(r)
-	if err != nil {
-		err = &ogenerrors.DecodeRequestError{
-			OperationContext: opErrContext,
-			Err:              err,
-		}
-		defer recordError("DecodeRequest", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-	defer func() {
-		if err := close(); err != nil {
-			recordError("CloseRequest", err)
-		}
-	}()
-
-	var response APIImportTasksIDPatchRes
-	if m := s.cfg.Middleware; m != nil {
-		mreq := middleware.Request{
-			Context:          ctx,
-			OperationName:    APIImportTasksIDPatchOperation,
-			OperationSummary: "Updates the status of an existing import task.",
-			OperationID:      "",
-			Body:             request,
-			RawBody:          rawBody,
-			Params: middleware.Parameters{
-				{
-					Name: "id",
-					In:   "path",
-				}: params.ID,
-			},
-			Raw: r,
-		}
-
-		type (
-			Request  = APIImportTasksIDPatchReq
-			Params   = APIImportTasksIDPatchParams
-			Response = APIImportTasksIDPatchRes
-		)
-		response, err = middleware.HookMiddleware[
-			Request,
-			Params,
-			Response,
-		](
-			m,
-			mreq,
-			unpackAPIImportTasksIDPatchParams,
-			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				response, err = s.h.APIImportTasksIDPatch(ctx, request, params)
-				return response, err
-			},
-		)
-	} else {
-		response, err = s.h.APIImportTasksIDPatch(ctx, request, params)
-	}
-	if err != nil {
-		defer recordError("Internal", err)
-		s.cfg.ErrorHandler(ctx, w, r, err)
-		return
-	}
-
-	if err := encodeAPIImportTasksIDPatchResponse(response, w, span); err != nil {
-		defer recordError("EncodeResponse", err)
-		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
-			s.cfg.ErrorHandler(ctx, w, r, err)
-		}
-		return
-	}
-}
-
-// handleAPIImportTasksIDStatusGetRequest handles GET /api/ImportTasks/{id}/status operation.
-//
-// Query the status of an ongoing analysis or import.
-//
-// GET /api/ImportTasks/{id}/status
-func (s *Server) handleAPIImportTasksIDStatusGetRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+// GET /api/importtasks/{id}/status
+func (s *Server) handleAPIImporttasksIDStatusGetRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
 	statusWriter := &codeRecorder{ResponseWriter: w}
 	w = statusWriter
 	otelAttrs := []attribute.KeyValue{
 		semconv.HTTPRequestMethodKey.String("GET"),
-		semconv.HTTPRouteKey.String("/api/ImportTasks/{id}/status"),
+		semconv.HTTPRouteKey.String("/api/importtasks/{id}/status"),
 	}
 	// Add attributes from config.
 	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
-	ctx, span := s.cfg.Tracer.Start(r.Context(), APIImportTasksIDStatusGetOperation,
+	ctx, span := s.cfg.Tracer.Start(r.Context(), APIImporttasksIDStatusGetOperation,
 		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
@@ -867,7 +869,7 @@ func (s *Server) handleAPIImportTasksIDStatusGetRequest(args [1]string, argsEsca
 		}
 		err          error
 		opErrContext = ogenerrors.OperationContext{
-			Name: APIImportTasksIDStatusGetOperation,
+			Name: APIImporttasksIDStatusGetOperation,
 			ID:   "",
 		}
 	)
@@ -875,7 +877,7 @@ func (s *Server) handleAPIImportTasksIDStatusGetRequest(args [1]string, argsEsca
 		type bitset = [1]uint8
 		var satisfied bitset
 		{
-			sctx, ok, err := s.securitySmart(ctx, APIImportTasksIDStatusGetOperation, r)
+			sctx, ok, err := s.securitySmart(ctx, APIImporttasksIDStatusGetOperation, r)
 			if err != nil {
 				err = &ogenerrors.SecurityError{
 					OperationContext: opErrContext,
@@ -915,7 +917,7 @@ func (s *Server) handleAPIImportTasksIDStatusGetRequest(args [1]string, argsEsca
 			return
 		}
 	}
-	params, err := decodeAPIImportTasksIDStatusGetParams(args, argsEscaped, r)
+	params, err := decodeAPIImporttasksIDStatusGetParams(args, argsEscaped, r)
 	if err != nil {
 		err = &ogenerrors.DecodeParamsError{
 			OperationContext: opErrContext,
@@ -928,12 +930,12 @@ func (s *Server) handleAPIImportTasksIDStatusGetRequest(args [1]string, argsEsca
 
 	var rawBody []byte
 
-	var response *ImportTaskStatusResponse
+	var response APIImporttasksIDStatusGetRes
 	if m := s.cfg.Middleware; m != nil {
 		mreq := middleware.Request{
 			Context:          ctx,
-			OperationName:    APIImportTasksIDStatusGetOperation,
-			OperationSummary: "Query the status of an ongoing analysis or import",
+			OperationName:    APIImporttasksIDStatusGetOperation,
+			OperationSummary: "Query the status of an ongoing analysis (import task).",
 			OperationID:      "",
 			Body:             nil,
 			RawBody:          rawBody,
@@ -948,8 +950,8 @@ func (s *Server) handleAPIImportTasksIDStatusGetRequest(args [1]string, argsEsca
 
 		type (
 			Request  = struct{}
-			Params   = APIImportTasksIDStatusGetParams
-			Response = *ImportTaskStatusResponse
+			Params   = APIImporttasksIDStatusGetParams
+			Response = APIImporttasksIDStatusGetRes
 		)
 		response, err = middleware.HookMiddleware[
 			Request,
@@ -958,14 +960,14 @@ func (s *Server) handleAPIImportTasksIDStatusGetRequest(args [1]string, argsEsca
 		](
 			m,
 			mreq,
-			unpackAPIImportTasksIDStatusGetParams,
+			unpackAPIImporttasksIDStatusGetParams,
 			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				response, err = s.h.APIImportTasksIDStatusGet(ctx, params)
+				response, err = s.h.APIImporttasksIDStatusGet(ctx, params)
 				return response, err
 			},
 		)
 	} else {
-		response, err = s.h.APIImportTasksIDStatusGet(ctx, params)
+		response, err = s.h.APIImporttasksIDStatusGet(ctx, params)
 	}
 	if err != nil {
 		defer recordError("Internal", err)
@@ -973,7 +975,7 @@ func (s *Server) handleAPIImportTasksIDStatusGetRequest(args [1]string, argsEsca
 		return
 	}
 
-	if err := encodeAPIImportTasksIDStatusGetResponse(response, w, span); err != nil {
+	if err := encodeAPIImporttasksIDStatusGetResponse(response, w, span); err != nil {
 		defer recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)
@@ -982,23 +984,23 @@ func (s *Server) handleAPIImportTasksIDStatusGetRequest(args [1]string, argsEsca
 	}
 }
 
-// handleAPIImportTasksPostRequest handles POST /api/ImportTasks operation.
+// handleAPIImporttasksPostRequest handles POST /api/importtasks operation.
 //
 // Creates a new import task.
 //
-// POST /api/ImportTasks
-func (s *Server) handleAPIImportTasksPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+// POST /api/importtasks
+func (s *Server) handleAPIImporttasksPostRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
 	statusWriter := &codeRecorder{ResponseWriter: w}
 	w = statusWriter
 	otelAttrs := []attribute.KeyValue{
 		semconv.HTTPRequestMethodKey.String("POST"),
-		semconv.HTTPRouteKey.String("/api/ImportTasks"),
+		semconv.HTTPRouteKey.String("/api/importtasks"),
 	}
 	// Add attributes from config.
 	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
-	ctx, span := s.cfg.Tracer.Start(r.Context(), APIImportTasksPostOperation,
+	ctx, span := s.cfg.Tracer.Start(r.Context(), APIImporttasksPostOperation,
 		trace.WithAttributes(otelAttrs...),
 		serverSpanKind,
 	)
@@ -1053,7 +1055,7 @@ func (s *Server) handleAPIImportTasksPostRequest(args [0]string, argsEscaped boo
 		}
 		err          error
 		opErrContext = ogenerrors.OperationContext{
-			Name: APIImportTasksPostOperation,
+			Name: APIImporttasksPostOperation,
 			ID:   "",
 		}
 	)
@@ -1061,7 +1063,7 @@ func (s *Server) handleAPIImportTasksPostRequest(args [0]string, argsEscaped boo
 		type bitset = [1]uint8
 		var satisfied bitset
 		{
-			sctx, ok, err := s.securitySmart(ctx, APIImportTasksPostOperation, r)
+			sctx, ok, err := s.securitySmart(ctx, APIImporttasksPostOperation, r)
 			if err != nil {
 				err = &ogenerrors.SecurityError{
 					OperationContext: opErrContext,
@@ -1103,7 +1105,7 @@ func (s *Server) handleAPIImportTasksPostRequest(args [0]string, argsEscaped boo
 	}
 
 	var rawBody []byte
-	request, rawBody, close, err := s.decodeAPIImportTasksPostRequest(r)
+	request, rawBody, close, err := s.decodeAPIImporttasksPostRequest(r)
 	if err != nil {
 		err = &ogenerrors.DecodeRequestError{
 			OperationContext: opErrContext,
@@ -1119,11 +1121,11 @@ func (s *Server) handleAPIImportTasksPostRequest(args [0]string, argsEscaped boo
 		}
 	}()
 
-	var response APIImportTasksPostRes
+	var response APIImporttasksPostRes
 	if m := s.cfg.Middleware; m != nil {
 		mreq := middleware.Request{
 			Context:          ctx,
-			OperationName:    APIImportTasksPostOperation,
+			OperationName:    APIImporttasksPostOperation,
 			OperationSummary: "Creates a new import task.",
 			OperationID:      "",
 			Body:             request,
@@ -1133,9 +1135,9 @@ func (s *Server) handleAPIImportTasksPostRequest(args [0]string, argsEscaped boo
 		}
 
 		type (
-			Request  = OptAPIImportTasksPostReq
+			Request  = OptAPIImporttasksPostReq
 			Params   = struct{}
-			Response = APIImportTasksPostRes
+			Response = APIImporttasksPostRes
 		)
 		response, err = middleware.HookMiddleware[
 			Request,
@@ -1146,12 +1148,12 @@ func (s *Server) handleAPIImportTasksPostRequest(args [0]string, argsEscaped boo
 			mreq,
 			nil,
 			func(ctx context.Context, request Request, params Params) (response Response, err error) {
-				response, err = s.h.APIImportTasksPost(ctx, request)
+				response, err = s.h.APIImporttasksPost(ctx, request)
 				return response, err
 			},
 		)
 	} else {
-		response, err = s.h.APIImportTasksPost(ctx, request)
+		response, err = s.h.APIImporttasksPost(ctx, request)
 	}
 	if err != nil {
 		defer recordError("Internal", err)
@@ -1159,7 +1161,7 @@ func (s *Server) handleAPIImportTasksPostRequest(args [0]string, argsEscaped boo
 		return
 	}
 
-	if err := encodeAPIImportTasksPostResponse(response, w, span); err != nil {
+	if err := encodeAPIImporttasksPostResponse(response, w, span); err != nil {
 		defer recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)

--- a/hack/apis-mock/internal/gen/oas_interfaces_gen.go
+++ b/hack/apis-mock/internal/gen/oas_interfaces_gen.go
@@ -5,22 +5,26 @@ type APIHealthzGetRes interface {
 	aPIHealthzGetRes()
 }
 
-type APIImportTasksIDImportRunsPostRes interface {
-	aPIImportTasksIDImportRunsPostRes()
+type APIImporttasksIDCancelPostReq interface {
+	aPIImporttasksIDCancelPostReq()
 }
 
-type APIImportTasksIDImportRunsRunIdStatusGetRes interface {
-	aPIImportTasksIDImportRunsRunIdStatusGetRes()
+type APIImporttasksIDCancelPostRes interface {
+	aPIImporttasksIDCancelPostRes()
 }
 
-type APIImportTasksIDPatchReq interface {
-	aPIImportTasksIDPatchReq()
+type APIImporttasksIDImportrunsPostRes interface {
+	aPIImporttasksIDImportrunsPostRes()
 }
 
-type APIImportTasksIDPatchRes interface {
-	aPIImportTasksIDPatchRes()
+type APIImporttasksIDImportrunsRunIdStatusGetRes interface {
+	aPIImporttasksIDImportrunsRunIdStatusGetRes()
 }
 
-type APIImportTasksPostRes interface {
-	aPIImportTasksPostRes()
+type APIImporttasksIDStatusGetRes interface {
+	aPIImporttasksIDStatusGetRes()
+}
+
+type APIImporttasksPostRes interface {
+	aPIImporttasksPostRes()
 }

--- a/hack/apis-mock/internal/gen/oas_json_gen.go
+++ b/hack/apis-mock/internal/gen/oas_json_gen.go
@@ -5,11 +5,9 @@ package gen
 import (
 	"math/bits"
 	"strconv"
-	"time"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
-	"github.com/ogen-go/ogen/json"
 	"github.com/ogen-go/ogen/validate"
 )
 
@@ -89,17 +87,17 @@ func (s *APIHealthzGetServiceUnavailable) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDImportRunsPostNotFound as json.
-func (s *APIImportTasksIDImportRunsPostNotFound) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDCancelPostConflict as json.
+func (s *APIImporttasksIDCancelPostConflict) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDImportRunsPostNotFound from json.
-func (s *APIImportTasksIDImportRunsPostNotFound) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDCancelPostConflict from json.
+func (s *APIImporttasksIDCancelPostConflict) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDImportRunsPostNotFound to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDCancelPostConflict to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -110,34 +108,34 @@ func (s *APIImportTasksIDImportRunsPostNotFound) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDImportRunsPostNotFound(unwrapped)
+	*s = APIImporttasksIDCancelPostConflict(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDImportRunsPostNotFound) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDCancelPostConflict) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDImportRunsPostNotFound) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDCancelPostConflict) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDImportRunsPostUnauthorized as json.
-func (s *APIImportTasksIDImportRunsPostUnauthorized) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDCancelPostInternalServerError as json.
+func (s *APIImporttasksIDCancelPostInternalServerError) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDImportRunsPostUnauthorized from json.
-func (s *APIImportTasksIDImportRunsPostUnauthorized) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDCancelPostInternalServerError from json.
+func (s *APIImporttasksIDCancelPostInternalServerError) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDImportRunsPostUnauthorized to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDCancelPostInternalServerError to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -148,34 +146,34 @@ func (s *APIImportTasksIDImportRunsPostUnauthorized) Decode(d *jx.Decoder) error
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDImportRunsPostUnauthorized(unwrapped)
+	*s = APIImporttasksIDCancelPostInternalServerError(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDImportRunsPostUnauthorized) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDCancelPostInternalServerError) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDImportRunsPostUnauthorized) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDCancelPostInternalServerError) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDImportRunsPostUnsupportedMediaType as json.
-func (s *APIImportTasksIDImportRunsPostUnsupportedMediaType) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDCancelPostNotFound as json.
+func (s *APIImporttasksIDCancelPostNotFound) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDImportRunsPostUnsupportedMediaType from json.
-func (s *APIImportTasksIDImportRunsPostUnsupportedMediaType) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDCancelPostNotFound from json.
+func (s *APIImporttasksIDCancelPostNotFound) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDImportRunsPostUnsupportedMediaType to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDCancelPostNotFound to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -186,34 +184,34 @@ func (s *APIImportTasksIDImportRunsPostUnsupportedMediaType) Decode(d *jx.Decode
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDImportRunsPostUnsupportedMediaType(unwrapped)
+	*s = APIImporttasksIDCancelPostNotFound(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDImportRunsPostUnsupportedMediaType) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDCancelPostNotFound) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDImportRunsPostUnsupportedMediaType) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDCancelPostNotFound) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDImportRunsRunIdStatusGetNotFound as json.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetNotFound) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDCancelPostUnauthorized as json.
+func (s *APIImporttasksIDCancelPostUnauthorized) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDImportRunsRunIdStatusGetNotFound from json.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetNotFound) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDCancelPostUnauthorized from json.
+func (s *APIImporttasksIDCancelPostUnauthorized) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDImportRunsRunIdStatusGetNotFound to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDCancelPostUnauthorized to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -224,34 +222,34 @@ func (s *APIImportTasksIDImportRunsRunIdStatusGetNotFound) Decode(d *jx.Decoder)
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDImportRunsRunIdStatusGetNotFound(unwrapped)
+	*s = APIImporttasksIDCancelPostUnauthorized(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetNotFound) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDCancelPostUnauthorized) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetNotFound) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDCancelPostUnauthorized) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDImportRunsRunIdStatusGetUnauthorized as json.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDImportrunsPostBadRequest as json.
+func (s *APIImporttasksIDImportrunsPostBadRequest) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDImportRunsRunIdStatusGetUnauthorized from json.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsPostBadRequest from json.
+func (s *APIImporttasksIDImportrunsPostBadRequest) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDImportRunsRunIdStatusGetUnauthorized to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsPostBadRequest to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -262,34 +260,34 @@ func (s *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) Decode(d *jx.Deco
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDImportRunsRunIdStatusGetUnauthorized(unwrapped)
+	*s = APIImporttasksIDImportrunsPostBadRequest(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsPostBadRequest) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsPostBadRequest) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDPatchConflict as json.
-func (s *APIImportTasksIDPatchConflict) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDImportrunsPostNotFound as json.
+func (s *APIImporttasksIDImportrunsPostNotFound) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDPatchConflict from json.
-func (s *APIImportTasksIDPatchConflict) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsPostNotFound from json.
+func (s *APIImporttasksIDImportrunsPostNotFound) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDPatchConflict to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsPostNotFound to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -300,34 +298,34 @@ func (s *APIImportTasksIDPatchConflict) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDPatchConflict(unwrapped)
+	*s = APIImporttasksIDImportrunsPostNotFound(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDPatchConflict) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsPostNotFound) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDPatchConflict) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsPostNotFound) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDPatchNotFound as json.
-func (s *APIImportTasksIDPatchNotFound) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDImportrunsPostUnauthorized as json.
+func (s *APIImporttasksIDImportrunsPostUnauthorized) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDPatchNotFound from json.
-func (s *APIImportTasksIDPatchNotFound) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsPostUnauthorized from json.
+func (s *APIImporttasksIDImportrunsPostUnauthorized) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDPatchNotFound to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsPostUnauthorized to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -338,36 +336,36 @@ func (s *APIImportTasksIDPatchNotFound) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDPatchNotFound(unwrapped)
+	*s = APIImporttasksIDImportrunsPostUnauthorized(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDPatchNotFound) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsPostUnauthorized) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDPatchNotFound) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsPostUnauthorized) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksPostBadRequest as json.
-func (s *APIImportTasksPostBadRequest) Encode(e *jx.Encoder) {
-	unwrapped := (*CreateImportTaskResponse)(s)
+// Encode encodes APIImporttasksIDImportrunsPostUnsupportedMediaType as json.
+func (s *APIImporttasksIDImportrunsPostUnsupportedMediaType) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksPostBadRequest from json.
-func (s *APIImportTasksPostBadRequest) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsPostUnsupportedMediaType from json.
+func (s *APIImporttasksIDImportrunsPostUnsupportedMediaType) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksPostBadRequest to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsPostUnsupportedMediaType to nil")
 	}
-	var unwrapped CreateImportTaskResponse
+	var unwrapped ProblemDetails
 	if err := func() error {
 		if err := unwrapped.Decode(d); err != nil {
 			return err
@@ -376,36 +374,36 @@ func (s *APIImportTasksPostBadRequest) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksPostBadRequest(unwrapped)
+	*s = APIImporttasksIDImportrunsPostUnsupportedMediaType(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksPostBadRequest) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsPostUnsupportedMediaType) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksPostBadRequest) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsPostUnsupportedMediaType) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksPostCreated as json.
-func (s *APIImportTasksPostCreated) Encode(e *jx.Encoder) {
-	unwrapped := (*CreateImportTaskResponse)(s)
+// Encode encodes APIImporttasksIDImportrunsRunIdStatusGetInternalServerError as json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksPostCreated from json.
-func (s *APIImportTasksPostCreated) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsRunIdStatusGetInternalServerError from json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetInternalServerError) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksPostCreated to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsRunIdStatusGetInternalServerError to nil")
 	}
-	var unwrapped CreateImportTaskResponse
+	var unwrapped ProblemDetails
 	if err := func() error {
 		if err := unwrapped.Decode(d); err != nil {
 			return err
@@ -414,36 +412,36 @@ func (s *APIImportTasksPostCreated) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksPostCreated(unwrapped)
+	*s = APIImporttasksIDImportrunsRunIdStatusGetInternalServerError(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksPostCreated) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetInternalServerError) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksPostCreated) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetInternalServerError) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksPostInternalServerError as json.
-func (s *APIImportTasksPostInternalServerError) Encode(e *jx.Encoder) {
-	unwrapped := (*CreateImportTaskResponse)(s)
+// Encode encodes APIImporttasksIDImportrunsRunIdStatusGetNotFound as json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetNotFound) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksPostInternalServerError from json.
-func (s *APIImportTasksPostInternalServerError) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsRunIdStatusGetNotFound from json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetNotFound) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksPostInternalServerError to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsRunIdStatusGetNotFound to nil")
 	}
-	var unwrapped CreateImportTaskResponse
+	var unwrapped ProblemDetails
 	if err := func() error {
 		if err := unwrapped.Decode(d); err != nil {
 			return err
@@ -452,36 +450,36 @@ func (s *APIImportTasksPostInternalServerError) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksPostInternalServerError(unwrapped)
+	*s = APIImporttasksIDImportrunsRunIdStatusGetNotFound(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksPostInternalServerError) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetNotFound) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksPostInternalServerError) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetNotFound) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksPostUnsupportedMediaType as json.
-func (s *APIImportTasksPostUnsupportedMediaType) Encode(e *jx.Encoder) {
-	unwrapped := (*CreateImportTaskResponse)(s)
+// Encode encodes APIImporttasksIDImportrunsRunIdStatusGetUnauthorized as json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksPostUnsupportedMediaType from json.
-func (s *APIImportTasksPostUnsupportedMediaType) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsRunIdStatusGetUnauthorized from json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetUnauthorized) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksPostUnsupportedMediaType to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsRunIdStatusGetUnauthorized to nil")
 	}
-	var unwrapped CreateImportTaskResponse
+	var unwrapped ProblemDetails
 	if err := func() error {
 		if err := unwrapped.Decode(d); err != nil {
 			return err
@@ -490,676 +488,285 @@ func (s *APIImportTasksPostUnsupportedMediaType) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksPostUnsupportedMediaType(unwrapped)
+	*s = APIImporttasksIDImportrunsRunIdStatusGetUnauthorized(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksPostUnsupportedMediaType) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetUnauthorized) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksPostUnsupportedMediaType) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetUnauthorized) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode implements json.Marshaler.
-func (s *AnalysisRecordDto) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
+// Encode encodes APIImporttasksIDStatusGetInternalServerError as json.
+func (s *APIImporttasksIDStatusGetInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
 }
 
-// encodeFields encodes fields.
-func (s *AnalysisRecordDto) encodeFields(e *jx.Encoder) {
-	{
-		if s.AnalysisRecordId.Set {
-			e.FieldStart("analysisRecordId")
-			s.AnalysisRecordId.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("rowVersion")
-		e.Base64(s.RowVersion)
-	}
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.ComparisonDate.Set {
-			e.FieldStart("comparisonDate")
-			s.ComparisonDate.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.TargetPrimaryKey.Set {
-			e.FieldStart("targetPrimaryKey")
-			s.TargetPrimaryKey.Encode(e)
-		}
-	}
-	{
-		if s.DocKey.Set {
-			e.FieldStart("docKey")
-			s.DocKey.Encode(e)
-		}
-	}
-	{
-		if s.ReferenceCode.Set {
-			e.FieldStart("referenceCode")
-			s.ReferenceCode.Encode(e)
-		}
-	}
-	{
-		if s.Level.Set {
-			e.FieldStart("level")
-			s.Level.Encode(e)
-		}
-	}
-	{
-		if s.SourcePrimaryKey.Set {
-			e.FieldStart("sourcePrimaryKey")
-			s.SourcePrimaryKey.Encode(e)
-		}
-	}
-	{
-		if s.PositionNumber.Set {
-			e.FieldStart("positionNumber")
-			s.PositionNumber.Encode(e)
-		}
-	}
-	{
-		if s.SourceTitle.Set {
-			e.FieldStart("sourceTitle")
-			s.SourceTitle.Encode(e)
-		}
-	}
-	{
-		if s.DestinationTitle.Set {
-			e.FieldStart("destinationTitle")
-			s.DestinationTitle.Encode(e)
-		}
-	}
-	{
-		if s.SourceField1.Set {
-			e.FieldStart("sourceField1")
-			s.SourceField1.Encode(e)
-		}
-	}
-	{
-		if s.DestinationField1.Set {
-			e.FieldStart("destinationField1")
-			s.DestinationField1.Encode(e)
-		}
-	}
-	{
-		if s.SourceField2.Set {
-			e.FieldStart("sourceField2")
-			s.SourceField2.Encode(e)
-		}
-	}
-	{
-		if s.DestinationField2.Set {
-			e.FieldStart("destinationField2")
-			s.DestinationField2.Encode(e)
-		}
-	}
-	{
-		if s.SourceField3.Set {
-			e.FieldStart("sourceField3")
-			s.SourceField3.Encode(e)
-		}
-	}
-	{
-		if s.DestinationField3.Set {
-			e.FieldStart("destinationField3")
-			s.DestinationField3.Encode(e)
-		}
-	}
-	{
-		if s.SourceField4.Set {
-			e.FieldStart("sourceField4")
-			s.SourceField4.Encode(e)
-		}
-	}
-	{
-		if s.DestinationField4.Set {
-			e.FieldStart("destinationField4")
-			s.DestinationField4.Encode(e)
-		}
-	}
-	{
-		if s.SourceField5.Set {
-			e.FieldStart("sourceField5")
-			s.SourceField5.Encode(e)
-		}
-	}
-	{
-		if s.DestinationField5.Set {
-			e.FieldStart("destinationField5")
-			s.DestinationField5.Encode(e)
-		}
-	}
-	{
-		if s.TitleIsDifferent.Set {
-			e.FieldStart("titleIsDifferent")
-			s.TitleIsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Field1IsDifferent.Set {
-			e.FieldStart("field1IsDifferent")
-			s.Field1IsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Field2IsDifferent.Set {
-			e.FieldStart("field2IsDifferent")
-			s.Field2IsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Field3IsDifferent.Set {
-			e.FieldStart("field3IsDifferent")
-			s.Field3IsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Field4IsDifferent.Set {
-			e.FieldStart("field4IsDifferent")
-			s.Field4IsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Field5IsDifferent.Set {
-			e.FieldStart("field5IsDifferent")
-			s.Field5IsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
-	}
-	{
-		if s.ErrorMessage.Set {
-			e.FieldStart("errorMessage")
-			s.ErrorMessage.Encode(e)
-		}
-	}
-	{
-		if s.ContainerDocKey.Set {
-			e.FieldStart("containerDocKey")
-			s.ContainerDocKey.Encode(e)
-		}
-	}
-	{
-		if s.CreatedBy.Set {
-			e.FieldStart("createdBy")
-			s.CreatedBy.Encode(e)
-		}
-	}
-	{
-		if s.CreatedOn.Set {
-			e.FieldStart("createdOn")
-			s.CreatedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ModifiedBy.Set {
-			e.FieldStart("modifiedBy")
-			s.ModifiedBy.Encode(e)
-		}
-	}
-	{
-		if s.ModifiedOn.Set {
-			e.FieldStart("modifiedOn")
-			s.ModifiedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ImportTask.Set {
-			e.FieldStart("importTask")
-			s.ImportTask.Encode(e)
-		}
-	}
-}
-
-var jsonFieldsNameOfAnalysisRecordDto = [36]string{
-	0:  "analysisRecordId",
-	1:  "rowVersion",
-	2:  "importTaskId",
-	3:  "comparisonDate",
-	4:  "targetPrimaryKey",
-	5:  "docKey",
-	6:  "referenceCode",
-	7:  "level",
-	8:  "sourcePrimaryKey",
-	9:  "positionNumber",
-	10: "sourceTitle",
-	11: "destinationTitle",
-	12: "sourceField1",
-	13: "destinationField1",
-	14: "sourceField2",
-	15: "destinationField2",
-	16: "sourceField3",
-	17: "destinationField3",
-	18: "sourceField4",
-	19: "destinationField4",
-	20: "sourceField5",
-	21: "destinationField5",
-	22: "titleIsDifferent",
-	23: "field1IsDifferent",
-	24: "field2IsDifferent",
-	25: "field3IsDifferent",
-	26: "field4IsDifferent",
-	27: "field5IsDifferent",
-	28: "status",
-	29: "errorMessage",
-	30: "containerDocKey",
-	31: "createdBy",
-	32: "createdOn",
-	33: "modifiedBy",
-	34: "modifiedOn",
-	35: "importTask",
-}
-
-// Decode decodes AnalysisRecordDto from json.
-func (s *AnalysisRecordDto) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDStatusGetInternalServerError from json.
+func (s *APIImporttasksIDStatusGetInternalServerError) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode AnalysisRecordDto to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDStatusGetInternalServerError to nil")
 	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "analysisRecordId":
-			if err := func() error {
-				s.AnalysisRecordId.Reset()
-				if err := s.AnalysisRecordId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"analysisRecordId\"")
-			}
-		case "rowVersion":
-			if err := func() error {
-				v, err := d.Base64()
-				s.RowVersion = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"rowVersion\"")
-			}
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "comparisonDate":
-			if err := func() error {
-				s.ComparisonDate.Reset()
-				if err := s.ComparisonDate.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"comparisonDate\"")
-			}
-		case "targetPrimaryKey":
-			if err := func() error {
-				s.TargetPrimaryKey.Reset()
-				if err := s.TargetPrimaryKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"targetPrimaryKey\"")
-			}
-		case "docKey":
-			if err := func() error {
-				s.DocKey.Reset()
-				if err := s.DocKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"docKey\"")
-			}
-		case "referenceCode":
-			if err := func() error {
-				s.ReferenceCode.Reset()
-				if err := s.ReferenceCode.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"referenceCode\"")
-			}
-		case "level":
-			if err := func() error {
-				s.Level.Reset()
-				if err := s.Level.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"level\"")
-			}
-		case "sourcePrimaryKey":
-			if err := func() error {
-				s.SourcePrimaryKey.Reset()
-				if err := s.SourcePrimaryKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourcePrimaryKey\"")
-			}
-		case "positionNumber":
-			if err := func() error {
-				s.PositionNumber.Reset()
-				if err := s.PositionNumber.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"positionNumber\"")
-			}
-		case "sourceTitle":
-			if err := func() error {
-				s.SourceTitle.Reset()
-				if err := s.SourceTitle.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceTitle\"")
-			}
-		case "destinationTitle":
-			if err := func() error {
-				s.DestinationTitle.Reset()
-				if err := s.DestinationTitle.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationTitle\"")
-			}
-		case "sourceField1":
-			if err := func() error {
-				s.SourceField1.Reset()
-				if err := s.SourceField1.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceField1\"")
-			}
-		case "destinationField1":
-			if err := func() error {
-				s.DestinationField1.Reset()
-				if err := s.DestinationField1.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationField1\"")
-			}
-		case "sourceField2":
-			if err := func() error {
-				s.SourceField2.Reset()
-				if err := s.SourceField2.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceField2\"")
-			}
-		case "destinationField2":
-			if err := func() error {
-				s.DestinationField2.Reset()
-				if err := s.DestinationField2.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationField2\"")
-			}
-		case "sourceField3":
-			if err := func() error {
-				s.SourceField3.Reset()
-				if err := s.SourceField3.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceField3\"")
-			}
-		case "destinationField3":
-			if err := func() error {
-				s.DestinationField3.Reset()
-				if err := s.DestinationField3.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationField3\"")
-			}
-		case "sourceField4":
-			if err := func() error {
-				s.SourceField4.Reset()
-				if err := s.SourceField4.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceField4\"")
-			}
-		case "destinationField4":
-			if err := func() error {
-				s.DestinationField4.Reset()
-				if err := s.DestinationField4.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationField4\"")
-			}
-		case "sourceField5":
-			if err := func() error {
-				s.SourceField5.Reset()
-				if err := s.SourceField5.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceField5\"")
-			}
-		case "destinationField5":
-			if err := func() error {
-				s.DestinationField5.Reset()
-				if err := s.DestinationField5.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationField5\"")
-			}
-		case "titleIsDifferent":
-			if err := func() error {
-				s.TitleIsDifferent.Reset()
-				if err := s.TitleIsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"titleIsDifferent\"")
-			}
-		case "field1IsDifferent":
-			if err := func() error {
-				s.Field1IsDifferent.Reset()
-				if err := s.Field1IsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"field1IsDifferent\"")
-			}
-		case "field2IsDifferent":
-			if err := func() error {
-				s.Field2IsDifferent.Reset()
-				if err := s.Field2IsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"field2IsDifferent\"")
-			}
-		case "field3IsDifferent":
-			if err := func() error {
-				s.Field3IsDifferent.Reset()
-				if err := s.Field3IsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"field3IsDifferent\"")
-			}
-		case "field4IsDifferent":
-			if err := func() error {
-				s.Field4IsDifferent.Reset()
-				if err := s.Field4IsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"field4IsDifferent\"")
-			}
-		case "field5IsDifferent":
-			if err := func() error {
-				s.Field5IsDifferent.Reset()
-				if err := s.Field5IsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"field5IsDifferent\"")
-			}
-		case "status":
-			if err := func() error {
-				s.Status.Reset()
-				if err := s.Status.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "errorMessage":
-			if err := func() error {
-				s.ErrorMessage.Reset()
-				if err := s.ErrorMessage.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"errorMessage\"")
-			}
-		case "containerDocKey":
-			if err := func() error {
-				s.ContainerDocKey.Reset()
-				if err := s.ContainerDocKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"containerDocKey\"")
-			}
-		case "createdBy":
-			if err := func() error {
-				s.CreatedBy.Reset()
-				if err := s.CreatedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdBy\"")
-			}
-		case "createdOn":
-			if err := func() error {
-				s.CreatedOn.Reset()
-				if err := s.CreatedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdOn\"")
-			}
-		case "modifiedBy":
-			if err := func() error {
-				s.ModifiedBy.Reset()
-				if err := s.ModifiedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedBy\"")
-			}
-		case "modifiedOn":
-			if err := func() error {
-				s.ModifiedOn.Reset()
-				if err := s.ModifiedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedOn\"")
-			}
-		case "importTask":
-			if err := func() error {
-				s.ImportTask.Reset()
-				if err := s.ImportTask.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTask\"")
-			}
-		default:
-			return errors.Errorf("unexpected field %q", k)
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
 		}
 		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AnalysisRecordDto")
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
 	}
-
+	*s = APIImporttasksIDStatusGetInternalServerError(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *AnalysisRecordDto) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDStatusGetInternalServerError) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AnalysisRecordDto) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDStatusGetInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksIDStatusGetNotFound as json.
+func (s *APIImporttasksIDStatusGetNotFound) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksIDStatusGetNotFound from json.
+func (s *APIImporttasksIDStatusGetNotFound) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksIDStatusGetNotFound to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksIDStatusGetNotFound(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksIDStatusGetNotFound) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksIDStatusGetNotFound) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksIDStatusGetUnauthorized as json.
+func (s *APIImporttasksIDStatusGetUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksIDStatusGetUnauthorized from json.
+func (s *APIImporttasksIDStatusGetUnauthorized) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksIDStatusGetUnauthorized to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksIDStatusGetUnauthorized(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksIDStatusGetUnauthorized) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksIDStatusGetUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksPostBadRequest as json.
+func (s *APIImporttasksPostBadRequest) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksPostBadRequest from json.
+func (s *APIImporttasksPostBadRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksPostBadRequest to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksPostBadRequest(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksPostBadRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksPostBadRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksPostInternalServerError as json.
+func (s *APIImporttasksPostInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksPostInternalServerError from json.
+func (s *APIImporttasksPostInternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksPostInternalServerError to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksPostInternalServerError(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksPostInternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksPostInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksPostUnauthorized as json.
+func (s *APIImporttasksPostUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksPostUnauthorized from json.
+func (s *APIImporttasksPostUnauthorized) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksPostUnauthorized to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksPostUnauthorized(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksPostUnauthorized) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksPostUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksPostUnsupportedMediaType as json.
+func (s *APIImporttasksPostUnsupportedMediaType) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksPostUnsupportedMediaType from json.
+func (s *APIImporttasksPostUnsupportedMediaType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksPostUnsupportedMediaType to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksPostUnsupportedMediaType(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksPostUnsupportedMediaType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksPostUnsupportedMediaType) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -1218,13 +825,22 @@ func (s *CancelImportTaskRequest) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *CancelImportTaskRequest) encodeFields(e *jx.Encoder) {
 	{
-		e.FieldStart("status")
-		s.Status.Encode(e)
+		if s.Reason.Set {
+			e.FieldStart("reason")
+			s.Reason.Encode(e)
+		}
+	}
+	{
+		if s.CancelledBy.Set {
+			e.FieldStart("cancelledBy")
+			s.CancelledBy.Encode(e)
+		}
 	}
 }
 
-var jsonFieldsNameOfCancelImportTaskRequest = [1]string{
-	0: "status",
+var jsonFieldsNameOfCancelImportTaskRequest = [2]string{
+	0: "reason",
+	1: "cancelledBy",
 }
 
 // Decode decodes CancelImportTaskRequest from json.
@@ -1232,19 +848,28 @@ func (s *CancelImportTaskRequest) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode CancelImportTaskRequest to nil")
 	}
-	var requiredBitSet [1]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "status":
-			requiredBitSet[0] |= 1 << 0
+		case "reason":
 			if err := func() error {
-				if err := s.Status.Decode(d); err != nil {
+				s.Reason.Reset()
+				if err := s.Reason.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
+				return errors.Wrap(err, "decode field \"reason\"")
+			}
+		case "cancelledBy":
+			if err := func() error {
+				s.CancelledBy.Reset()
+				if err := s.CancelledBy.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"cancelledBy\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -1252,38 +877,6 @@ func (s *CancelImportTaskRequest) Decode(d *jx.Decoder) error {
 		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CancelImportTaskRequest")
-	}
-	// Validate required fields.
-	var failures []validate.FieldError
-	for i, mask := range [1]uint8{
-		0b00000001,
-	} {
-		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
-			// Mask only required fields and check equality to mask using XOR.
-			//
-			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
-			// Bits of fields which would be set are actually bits of missed fields.
-			missed := bits.OnesCount8(result)
-			for bitN := 0; bitN < missed; bitN++ {
-				bitIdx := bits.TrailingZeros8(result)
-				fieldIdx := i*8 + bitIdx
-				var name string
-				if fieldIdx < len(jsonFieldsNameOfCancelImportTaskRequest) {
-					name = jsonFieldsNameOfCancelImportTaskRequest[fieldIdx]
-				} else {
-					name = strconv.Itoa(fieldIdx)
-				}
-				failures = append(failures, validate.FieldError{
-					Name:  name,
-					Error: validate.ErrFieldRequired,
-				})
-				// Reset bit.
-				result &^= 1 << bitIdx
-			}
-		}
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
 	}
 
 	return nil
@@ -1312,36 +905,13 @@ func (s *CreateImportRunResponse) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *CreateImportRunResponse) encodeFields(e *jx.Encoder) {
 	{
-		if s.Success.Set {
-			e.FieldStart("success")
-			s.Success.Encode(e)
-		}
-	}
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.ImportRunId.Set {
-			e.FieldStart("importRunId")
-			s.ImportRunId.Encode(e)
-		}
-	}
-	{
-		if s.Error.Set {
-			e.FieldStart("error")
-			s.Error.Encode(e)
-		}
+		e.FieldStart("importRunId")
+		e.Str(s.ImportRunId)
 	}
 }
 
-var jsonFieldsNameOfCreateImportRunResponse = [4]string{
-	0: "success",
-	1: "importTaskId",
-	2: "importRunId",
-	3: "error",
+var jsonFieldsNameOfCreateImportRunResponse = [1]string{
+	0: "importRunId",
 }
 
 // Decode decodes CreateImportRunResponse from json.
@@ -1349,48 +919,21 @@ func (s *CreateImportRunResponse) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode CreateImportRunResponse to nil")
 	}
+	var requiredBitSet [1]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "success":
-			if err := func() error {
-				s.Success.Reset()
-				if err := s.Success.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"success\"")
-			}
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
 		case "importRunId":
+			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				s.ImportRunId.Reset()
-				if err := s.ImportRunId.Decode(d); err != nil {
+				v, err := d.Str()
+				s.ImportRunId = string(v)
+				if err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"importRunId\"")
-			}
-		case "error":
-			if err := func() error {
-				s.Error.Reset()
-				if err := s.Error.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"error\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -1398,6 +941,38 @@ func (s *CreateImportRunResponse) Decode(d *jx.Decoder) error {
 		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CreateImportRunResponse")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfCreateImportRunResponse) {
+					name = jsonFieldsNameOfCreateImportRunResponse[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
 	}
 
 	return nil
@@ -1426,29 +1001,13 @@ func (s *CreateImportTaskResponse) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *CreateImportTaskResponse) encodeFields(e *jx.Encoder) {
 	{
-		if s.Success.Set {
-			e.FieldStart("success")
-			s.Success.Encode(e)
-		}
-	}
-	{
-		if s.Error.Set {
-			e.FieldStart("error")
-			s.Error.Encode(e)
-		}
-	}
-	{
-		if s.ID.Set {
-			e.FieldStart("id")
-			s.ID.Encode(e)
-		}
+		e.FieldStart("importTaskId")
+		e.Str(s.ImportTaskId)
 	}
 }
 
-var jsonFieldsNameOfCreateImportTaskResponse = [3]string{
-	0: "success",
-	1: "error",
-	2: "id",
+var jsonFieldsNameOfCreateImportTaskResponse = [1]string{
+	0: "importTaskId",
 }
 
 // Decode decodes CreateImportTaskResponse from json.
@@ -1456,38 +1015,21 @@ func (s *CreateImportTaskResponse) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode CreateImportTaskResponse to nil")
 	}
+	var requiredBitSet [1]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "success":
+		case "importTaskId":
+			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				s.Success.Reset()
-				if err := s.Success.Decode(d); err != nil {
+				v, err := d.Str()
+				s.ImportTaskId = string(v)
+				if err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"success\"")
-			}
-		case "error":
-			if err := func() error {
-				s.Error.Reset()
-				if err := s.Error.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"error\"")
-			}
-		case "id":
-			if err := func() error {
-				s.ID.Reset()
-				if err := s.ID.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"id\"")
+				return errors.Wrap(err, "decode field \"importTaskId\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -1495,6 +1037,38 @@ func (s *CreateImportTaskResponse) Decode(d *jx.Decoder) error {
 		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CreateImportTaskResponse")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfCreateImportTaskResponse) {
+					name = jsonFieldsNameOfCreateImportTaskResponse[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
 	}
 
 	return nil
@@ -1514,656 +1088,6 @@ func (s *CreateImportTaskResponse) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s *DefaultValueDto) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *DefaultValueDto) encodeFields(e *jx.Encoder) {
-	{
-		if s.DefaultValueId.Set {
-			e.FieldStart("defaultValueId")
-			s.DefaultValueId.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("rowVersion")
-		e.Base64(s.RowVersion)
-	}
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.AccessionDocKey.Set {
-			e.FieldStart("accessionDocKey")
-			s.AccessionDocKey.Encode(e)
-		}
-	}
-	{
-		if s.AccessionIdName.Set {
-			e.FieldStart("accessionIdName")
-			s.AccessionIdName.Encode(e)
-		}
-	}
-	{
-		if s.InsertNodeDocKey.Set {
-			e.FieldStart("insertNodeDocKey")
-			s.InsertNodeDocKey.Encode(e)
-		}
-	}
-	{
-		if s.InsertNodeIdName.Set {
-			e.FieldStart("insertNodeIdName")
-			s.InsertNodeIdName.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
-	}
-	{
-		if s.ProtectionBaseDate.Set {
-			e.FieldStart("protectionBaseDate")
-			s.ProtectionBaseDate.Encode(e)
-		}
-	}
-	{
-		if s.ProtectionCategory.Set {
-			e.FieldStart("protectionCategory")
-			s.ProtectionCategory.Encode(e)
-		}
-	}
-	{
-		if s.ProtectionDuration.Set {
-			e.FieldStart("protectionDuration")
-			s.ProtectionDuration.Encode(e)
-		}
-	}
-	{
-		if s.MetadataCanBePublished.Set {
-			e.FieldStart("metadataCanBePublished")
-			s.MetadataCanBePublished.Encode(e)
-		}
-	}
-	{
-		if s.Accessibility.Set {
-			e.FieldStart("accessibility")
-			s.Accessibility.Encode(e)
-		}
-	}
-	{
-		if s.Usability.Set {
-			e.FieldStart("usability")
-			s.Usability.Encode(e)
-		}
-	}
-	{
-		if s.PermissionType.Set {
-			e.FieldStart("permissionType")
-			s.PermissionType.Encode(e)
-		}
-	}
-	{
-		if s.CreatedBy.Set {
-			e.FieldStart("createdBy")
-			s.CreatedBy.Encode(e)
-		}
-	}
-	{
-		if s.CreatedOn.Set {
-			e.FieldStart("createdOn")
-			s.CreatedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ModifiedBy.Set {
-			e.FieldStart("modifiedBy")
-			s.ModifiedBy.Encode(e)
-		}
-	}
-	{
-		if s.ModifiedOn.Set {
-			e.FieldStart("modifiedOn")
-			s.ModifiedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ImportTask.Set {
-			e.FieldStart("importTask")
-			s.ImportTask.Encode(e)
-		}
-	}
-}
-
-var jsonFieldsNameOfDefaultValueDto = [20]string{
-	0:  "defaultValueId",
-	1:  "rowVersion",
-	2:  "importTaskId",
-	3:  "accessionDocKey",
-	4:  "accessionIdName",
-	5:  "insertNodeDocKey",
-	6:  "insertNodeIdName",
-	7:  "status",
-	8:  "protectionBaseDate",
-	9:  "protectionCategory",
-	10: "protectionDuration",
-	11: "metadataCanBePublished",
-	12: "accessibility",
-	13: "usability",
-	14: "permissionType",
-	15: "createdBy",
-	16: "createdOn",
-	17: "modifiedBy",
-	18: "modifiedOn",
-	19: "importTask",
-}
-
-// Decode decodes DefaultValueDto from json.
-func (s *DefaultValueDto) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode DefaultValueDto to nil")
-	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "defaultValueId":
-			if err := func() error {
-				s.DefaultValueId.Reset()
-				if err := s.DefaultValueId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"defaultValueId\"")
-			}
-		case "rowVersion":
-			if err := func() error {
-				v, err := d.Base64()
-				s.RowVersion = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"rowVersion\"")
-			}
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "accessionDocKey":
-			if err := func() error {
-				s.AccessionDocKey.Reset()
-				if err := s.AccessionDocKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"accessionDocKey\"")
-			}
-		case "accessionIdName":
-			if err := func() error {
-				s.AccessionIdName.Reset()
-				if err := s.AccessionIdName.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"accessionIdName\"")
-			}
-		case "insertNodeDocKey":
-			if err := func() error {
-				s.InsertNodeDocKey.Reset()
-				if err := s.InsertNodeDocKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"insertNodeDocKey\"")
-			}
-		case "insertNodeIdName":
-			if err := func() error {
-				s.InsertNodeIdName.Reset()
-				if err := s.InsertNodeIdName.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"insertNodeIdName\"")
-			}
-		case "status":
-			if err := func() error {
-				s.Status.Reset()
-				if err := s.Status.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "protectionBaseDate":
-			if err := func() error {
-				s.ProtectionBaseDate.Reset()
-				if err := s.ProtectionBaseDate.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"protectionBaseDate\"")
-			}
-		case "protectionCategory":
-			if err := func() error {
-				s.ProtectionCategory.Reset()
-				if err := s.ProtectionCategory.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"protectionCategory\"")
-			}
-		case "protectionDuration":
-			if err := func() error {
-				s.ProtectionDuration.Reset()
-				if err := s.ProtectionDuration.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"protectionDuration\"")
-			}
-		case "metadataCanBePublished":
-			if err := func() error {
-				s.MetadataCanBePublished.Reset()
-				if err := s.MetadataCanBePublished.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"metadataCanBePublished\"")
-			}
-		case "accessibility":
-			if err := func() error {
-				s.Accessibility.Reset()
-				if err := s.Accessibility.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"accessibility\"")
-			}
-		case "usability":
-			if err := func() error {
-				s.Usability.Reset()
-				if err := s.Usability.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"usability\"")
-			}
-		case "permissionType":
-			if err := func() error {
-				s.PermissionType.Reset()
-				if err := s.PermissionType.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"permissionType\"")
-			}
-		case "createdBy":
-			if err := func() error {
-				s.CreatedBy.Reset()
-				if err := s.CreatedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdBy\"")
-			}
-		case "createdOn":
-			if err := func() error {
-				s.CreatedOn.Reset()
-				if err := s.CreatedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdOn\"")
-			}
-		case "modifiedBy":
-			if err := func() error {
-				s.ModifiedBy.Reset()
-				if err := s.ModifiedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedBy\"")
-			}
-		case "modifiedOn":
-			if err := func() error {
-				s.ModifiedOn.Reset()
-				if err := s.ModifiedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedOn\"")
-			}
-		case "importTask":
-			if err := func() error {
-				s.ImportTask.Reset()
-				if err := s.ImportTask.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTask\"")
-			}
-		default:
-			return errors.Errorf("unexpected field %q", k)
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode DefaultValueDto")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s *DefaultValueDto) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *DefaultValueDto) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s *DocumentDto) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *DocumentDto) encodeFields(e *jx.Encoder) {
-	{
-		if s.DocumentId.Set {
-			e.FieldStart("documentId")
-			s.DocumentId.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("rowVersion")
-		e.Base64(s.RowVersion)
-	}
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.FileName.Set {
-			e.FieldStart("fileName")
-			s.FileName.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("dataBlob")
-		e.Base64(s.DataBlob)
-	}
-	{
-		if s.UploadDate.Set {
-			e.FieldStart("uploadDate")
-			s.UploadDate.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.XmlSourceType.Set {
-			e.FieldStart("xmlSourceType")
-			s.XmlSourceType.Encode(e)
-		}
-	}
-	{
-		if s.FileSize.Set {
-			e.FieldStart("fileSize")
-			s.FileSize.Encode(e)
-		}
-	}
-	{
-		if s.CreatedBy.Set {
-			e.FieldStart("createdBy")
-			s.CreatedBy.Encode(e)
-		}
-	}
-	{
-		if s.CreatedOn.Set {
-			e.FieldStart("createdOn")
-			s.CreatedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ModifiedBy.Set {
-			e.FieldStart("modifiedBy")
-			s.ModifiedBy.Encode(e)
-		}
-	}
-	{
-		if s.ModifiedOn.Set {
-			e.FieldStart("modifiedOn")
-			s.ModifiedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ImportTask.Set {
-			e.FieldStart("importTask")
-			s.ImportTask.Encode(e)
-		}
-	}
-}
-
-var jsonFieldsNameOfDocumentDto = [13]string{
-	0:  "documentId",
-	1:  "rowVersion",
-	2:  "importTaskId",
-	3:  "fileName",
-	4:  "dataBlob",
-	5:  "uploadDate",
-	6:  "xmlSourceType",
-	7:  "fileSize",
-	8:  "createdBy",
-	9:  "createdOn",
-	10: "modifiedBy",
-	11: "modifiedOn",
-	12: "importTask",
-}
-
-// Decode decodes DocumentDto from json.
-func (s *DocumentDto) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode DocumentDto to nil")
-	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "documentId":
-			if err := func() error {
-				s.DocumentId.Reset()
-				if err := s.DocumentId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"documentId\"")
-			}
-		case "rowVersion":
-			if err := func() error {
-				v, err := d.Base64()
-				s.RowVersion = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"rowVersion\"")
-			}
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "fileName":
-			if err := func() error {
-				s.FileName.Reset()
-				if err := s.FileName.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"fileName\"")
-			}
-		case "dataBlob":
-			if err := func() error {
-				v, err := d.Base64()
-				s.DataBlob = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"dataBlob\"")
-			}
-		case "uploadDate":
-			if err := func() error {
-				s.UploadDate.Reset()
-				if err := s.UploadDate.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"uploadDate\"")
-			}
-		case "xmlSourceType":
-			if err := func() error {
-				s.XmlSourceType.Reset()
-				if err := s.XmlSourceType.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"xmlSourceType\"")
-			}
-		case "fileSize":
-			if err := func() error {
-				s.FileSize.Reset()
-				if err := s.FileSize.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"fileSize\"")
-			}
-		case "createdBy":
-			if err := func() error {
-				s.CreatedBy.Reset()
-				if err := s.CreatedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdBy\"")
-			}
-		case "createdOn":
-			if err := func() error {
-				s.CreatedOn.Reset()
-				if err := s.CreatedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdOn\"")
-			}
-		case "modifiedBy":
-			if err := func() error {
-				s.ModifiedBy.Reset()
-				if err := s.ModifiedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedBy\"")
-			}
-		case "modifiedOn":
-			if err := func() error {
-				s.ModifiedOn.Reset()
-				if err := s.ModifiedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedOn\"")
-			}
-		case "importTask":
-			if err := func() error {
-				s.ImportTask.Reset()
-				if err := s.ImportTask.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTask\"")
-			}
-		default:
-			return errors.Errorf("unexpected field %q", k)
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode DocumentDto")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s *DocumentDto) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *DocumentDto) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *HealthCheckResult) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -2173,6 +1097,12 @@ func (s *HealthCheckResult) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *HealthCheckResult) encodeFields(e *jx.Encoder) {
 	{
+		if s.DurationMs.Set {
+			e.FieldStart("durationMs")
+			s.DurationMs.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("name")
 		e.Str(s.Name)
 	}
@@ -2180,18 +1110,12 @@ func (s *HealthCheckResult) encodeFields(e *jx.Encoder) {
 		e.FieldStart("status")
 		e.Str(s.Status)
 	}
-	{
-		if s.DurationMs.Set {
-			e.FieldStart("durationMs")
-			s.DurationMs.Encode(e)
-		}
-	}
 }
 
 var jsonFieldsNameOfHealthCheckResult = [3]string{
-	0: "name",
-	1: "status",
-	2: "durationMs",
+	0: "durationMs",
+	1: "name",
+	2: "status",
 }
 
 // Decode decodes HealthCheckResult from json.
@@ -2203,8 +1127,18 @@ func (s *HealthCheckResult) Decode(d *jx.Decoder) error {
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
+		case "durationMs":
+			if err := func() error {
+				s.DurationMs.Reset()
+				if err := s.DurationMs.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"durationMs\"")
+			}
 		case "name":
-			requiredBitSet[0] |= 1 << 0
+			requiredBitSet[0] |= 1 << 1
 			if err := func() error {
 				v, err := d.Str()
 				s.Name = string(v)
@@ -2216,7 +1150,7 @@ func (s *HealthCheckResult) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"name\"")
 			}
 		case "status":
-			requiredBitSet[0] |= 1 << 1
+			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
 				v, err := d.Str()
 				s.Status = string(v)
@@ -2226,16 +1160,6 @@ func (s *HealthCheckResult) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "durationMs":
-			if err := func() error {
-				s.DurationMs.Reset()
-				if err := s.DurationMs.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"durationMs\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -2247,7 +1171,7 @@ func (s *HealthCheckResult) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000110,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -2303,20 +1227,20 @@ func (s *HealthStatusResult) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *HealthStatusResult) encodeFields(e *jx.Encoder) {
 	{
-		e.FieldStart("status")
-		e.Str(s.Status)
-	}
-	{
 		if s.Checks.Set {
 			e.FieldStart("checks")
 			s.Checks.Encode(e)
 		}
 	}
+	{
+		e.FieldStart("status")
+		e.Str(s.Status)
+	}
 }
 
 var jsonFieldsNameOfHealthStatusResult = [2]string{
-	0: "status",
-	1: "checks",
+	0: "checks",
+	1: "status",
 }
 
 // Decode decodes HealthStatusResult from json.
@@ -2328,18 +1252,6 @@ func (s *HealthStatusResult) Decode(d *jx.Decoder) error {
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "status":
-			requiredBitSet[0] |= 1 << 0
-			if err := func() error {
-				v, err := d.Str()
-				s.Status = string(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
 		case "checks":
 			if err := func() error {
 				s.Checks.Reset()
@@ -2349,6 +1261,18 @@ func (s *HealthStatusResult) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"checks\"")
+			}
+		case "status":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.Status = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"status\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -2360,7 +1284,7 @@ func (s *HealthStatusResult) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000001,
+		0b00000010,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -2402,323 +1326,6 @@ func (s *HealthStatusResult) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *HealthStatusResult) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s *ImportDto) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *ImportDto) encodeFields(e *jx.Encoder) {
-	{
-		if s.ImportId.Set {
-			e.FieldStart("importId")
-			s.ImportId.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("rowVersion")
-		e.Base64(s.RowVersion)
-	}
-	{
-		if s.TaskId.Set {
-			e.FieldStart("taskId")
-			s.TaskId.Encode(e)
-		}
-	}
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
-	}
-	{
-		if s.Description.Set {
-			e.FieldStart("description")
-			s.Description.Encode(e)
-		}
-	}
-	{
-		if s.ProcessedDocumentCount.Set {
-			e.FieldStart("processedDocumentCount")
-			s.ProcessedDocumentCount.Encode(e)
-		}
-	}
-	{
-		if s.TotalDocumentCount.Set {
-			e.FieldStart("totalDocumentCount")
-			s.TotalDocumentCount.Encode(e)
-		}
-	}
-	{
-		if s.ImportDate.Set {
-			e.FieldStart("importDate")
-			s.ImportDate.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ImportFileBlob.Set {
-			e.FieldStart("importFileBlob")
-			s.ImportFileBlob.Encode(e)
-		}
-	}
-	{
-		if s.IsSuccessful.Set {
-			e.FieldStart("isSuccessful")
-			s.IsSuccessful.Encode(e)
-		}
-	}
-	{
-		if s.CreatedBy.Set {
-			e.FieldStart("createdBy")
-			s.CreatedBy.Encode(e)
-		}
-	}
-	{
-		if s.CreatedOn.Set {
-			e.FieldStart("createdOn")
-			s.CreatedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ModifiedBy.Set {
-			e.FieldStart("modifiedBy")
-			s.ModifiedBy.Encode(e)
-		}
-	}
-	{
-		if s.ModifiedOn.Set {
-			e.FieldStart("modifiedOn")
-			s.ModifiedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ImportTask.Set {
-			e.FieldStart("importTask")
-			s.ImportTask.Encode(e)
-		}
-	}
-}
-
-var jsonFieldsNameOfImportDto = [16]string{
-	0:  "importId",
-	1:  "rowVersion",
-	2:  "taskId",
-	3:  "importTaskId",
-	4:  "status",
-	5:  "description",
-	6:  "processedDocumentCount",
-	7:  "totalDocumentCount",
-	8:  "importDate",
-	9:  "importFileBlob",
-	10: "isSuccessful",
-	11: "createdBy",
-	12: "createdOn",
-	13: "modifiedBy",
-	14: "modifiedOn",
-	15: "importTask",
-}
-
-// Decode decodes ImportDto from json.
-func (s *ImportDto) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ImportDto to nil")
-	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "importId":
-			if err := func() error {
-				s.ImportId.Reset()
-				if err := s.ImportId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importId\"")
-			}
-		case "rowVersion":
-			if err := func() error {
-				v, err := d.Base64()
-				s.RowVersion = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"rowVersion\"")
-			}
-		case "taskId":
-			if err := func() error {
-				s.TaskId.Reset()
-				if err := s.TaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"taskId\"")
-			}
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "status":
-			if err := func() error {
-				s.Status.Reset()
-				if err := s.Status.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "description":
-			if err := func() error {
-				s.Description.Reset()
-				if err := s.Description.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"description\"")
-			}
-		case "processedDocumentCount":
-			if err := func() error {
-				s.ProcessedDocumentCount.Reset()
-				if err := s.ProcessedDocumentCount.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"processedDocumentCount\"")
-			}
-		case "totalDocumentCount":
-			if err := func() error {
-				s.TotalDocumentCount.Reset()
-				if err := s.TotalDocumentCount.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"totalDocumentCount\"")
-			}
-		case "importDate":
-			if err := func() error {
-				s.ImportDate.Reset()
-				if err := s.ImportDate.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importDate\"")
-			}
-		case "importFileBlob":
-			if err := func() error {
-				s.ImportFileBlob.Reset()
-				if err := s.ImportFileBlob.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importFileBlob\"")
-			}
-		case "isSuccessful":
-			if err := func() error {
-				s.IsSuccessful.Reset()
-				if err := s.IsSuccessful.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"isSuccessful\"")
-			}
-		case "createdBy":
-			if err := func() error {
-				s.CreatedBy.Reset()
-				if err := s.CreatedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdBy\"")
-			}
-		case "createdOn":
-			if err := func() error {
-				s.CreatedOn.Reset()
-				if err := s.CreatedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdOn\"")
-			}
-		case "modifiedBy":
-			if err := func() error {
-				s.ModifiedBy.Reset()
-				if err := s.ModifiedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedBy\"")
-			}
-		case "modifiedOn":
-			if err := func() error {
-				s.ModifiedOn.Reset()
-				if err := s.ModifiedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedOn\"")
-			}
-		case "importTask":
-			if err := func() error {
-				s.ImportTask.Reset()
-				if err := s.ImportTask.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTask\"")
-			}
-		default:
-			return errors.Errorf("unexpected field %q", k)
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ImportDto")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s *ImportDto) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ImportDto) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -2773,22 +1380,8 @@ func (s *ImportRunStatusResponse) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *ImportRunStatusResponse) encodeFields(e *jx.Encoder) {
 	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.ImportRunId.Set {
-			e.FieldStart("importRunId")
-			s.ImportRunId.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
+		e.FieldStart("status")
+		s.Status.Encode(e)
 	}
 	{
 		if s.ProgressPercent.Set {
@@ -2797,19 +1390,31 @@ func (s *ImportRunStatusResponse) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.Error.Set {
-			e.FieldStart("error")
-			s.Error.Encode(e)
+		if s.ImportResult.Set {
+			e.FieldStart("importResult")
+			s.ImportResult.Encode(e)
+		}
+	}
+	{
+		if s.ProcessedDocumentCount.Set {
+			e.FieldStart("processedDocumentCount")
+			s.ProcessedDocumentCount.Encode(e)
+		}
+	}
+	{
+		if s.TotalDocumentCount.Set {
+			e.FieldStart("totalDocumentCount")
+			s.TotalDocumentCount.Encode(e)
 		}
 	}
 }
 
 var jsonFieldsNameOfImportRunStatusResponse = [5]string{
-	0: "importTaskId",
-	1: "importRunId",
-	2: "status",
-	3: "progressPercent",
-	4: "error",
+	0: "status",
+	1: "progressPercent",
+	2: "importResult",
+	3: "processedDocumentCount",
+	4: "totalDocumentCount",
 }
 
 // Decode decodes ImportRunStatusResponse from json.
@@ -2817,32 +1422,13 @@ func (s *ImportRunStatusResponse) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode ImportRunStatusResponse to nil")
 	}
+	var requiredBitSet [1]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "importRunId":
-			if err := func() error {
-				s.ImportRunId.Reset()
-				if err := s.ImportRunId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importRunId\"")
-			}
 		case "status":
+			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				s.Status.Reset()
 				if err := s.Status.Decode(d); err != nil {
 					return err
 				}
@@ -2860,15 +1446,35 @@ func (s *ImportRunStatusResponse) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"progressPercent\"")
 			}
-		case "error":
+		case "importResult":
 			if err := func() error {
-				s.Error.Reset()
-				if err := s.Error.Decode(d); err != nil {
+				s.ImportResult.Reset()
+				if err := s.ImportResult.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"error\"")
+				return errors.Wrap(err, "decode field \"importResult\"")
+			}
+		case "processedDocumentCount":
+			if err := func() error {
+				s.ProcessedDocumentCount.Reset()
+				if err := s.ProcessedDocumentCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"processedDocumentCount\"")
+			}
+		case "totalDocumentCount":
+			if err := func() error {
+				s.TotalDocumentCount.Reset()
+				if err := s.TotalDocumentCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"totalDocumentCount\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -2876,6 +1482,38 @@ func (s *ImportRunStatusResponse) Decode(d *jx.Decoder) error {
 		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode ImportRunStatusResponse")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfImportRunStatusResponse) {
+					name = jsonFieldsNameOfImportRunStatusResponse[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
 	}
 
 	return nil
@@ -2894,414 +1532,58 @@ func (s *ImportRunStatusResponse) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode implements json.Marshaler.
-func (s *ImportTaskDto) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
+// Encode encodes ImportStatus as json.
+func (s ImportStatus) Encode(e *jx.Encoder) {
+	e.Str(string(s))
 }
 
-// encodeFields encodes fields.
-func (s *ImportTaskDto) encodeFields(e *jx.Encoder) {
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("rowVersion")
-		e.Base64(s.RowVersion)
-	}
-	{
-		if s.TaskType.Set {
-			e.FieldStart("taskType")
-			s.TaskType.Encode(e)
-		}
-	}
-	{
-		if s.Name.Set {
-			e.FieldStart("name")
-			s.Name.Encode(e)
-		}
-	}
-	{
-		if s.NoAutomaticImport.Set {
-			e.FieldStart("noAutomaticImport")
-			s.NoAutomaticImport.Encode(e)
-		}
-	}
-	{
-		if s.RequiresContainers.Set {
-			e.FieldStart("requiresContainers")
-			s.RequiresContainers.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
-	}
-	{
-		if s.AnalysisErrorMessage.Set {
-			e.FieldStart("analysisErrorMessage")
-			s.AnalysisErrorMessage.Encode(e)
-		}
-	}
-	{
-		if s.AnalysisResult.Set {
-			e.FieldStart("analysisResult")
-			s.AnalysisResult.Encode(e)
-		}
-	}
-	{
-		if s.AnalysisProgressInPercent.Set {
-			e.FieldStart("analysisProgressInPercent")
-			s.AnalysisProgressInPercent.Encode(e)
-		}
-	}
-	{
-		if s.ImportResult.Set {
-			e.FieldStart("importResult")
-			s.ImportResult.Encode(e)
-		}
-	}
-	{
-		if s.CreatedBy.Set {
-			e.FieldStart("createdBy")
-			s.CreatedBy.Encode(e)
-		}
-	}
-	{
-		if s.CreatedOn.Set {
-			e.FieldStart("createdOn")
-			s.CreatedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ModifiedBy.Set {
-			e.FieldStart("modifiedBy")
-			s.ModifiedBy.Encode(e)
-		}
-	}
-	{
-		if s.ModifiedOn.Set {
-			e.FieldStart("modifiedOn")
-			s.ModifiedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.AnalysisRecords != nil {
-			e.FieldStart("analysisRecords")
-			e.ArrStart()
-			for _, elem := range s.AnalysisRecords {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
-		}
-	}
-	{
-		if s.DefaultValues != nil {
-			e.FieldStart("defaultValues")
-			e.ArrStart()
-			for _, elem := range s.DefaultValues {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
-		}
-	}
-	{
-		if s.Documents != nil {
-			e.FieldStart("documents")
-			e.ArrStart()
-			for _, elem := range s.Documents {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
-		}
-	}
-	{
-		if s.Imports != nil {
-			e.FieldStart("imports")
-			e.ArrStart()
-			for _, elem := range s.Imports {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
-		}
-	}
-}
-
-var jsonFieldsNameOfImportTaskDto = [19]string{
-	0:  "importTaskId",
-	1:  "rowVersion",
-	2:  "taskType",
-	3:  "name",
-	4:  "noAutomaticImport",
-	5:  "requiresContainers",
-	6:  "status",
-	7:  "analysisErrorMessage",
-	8:  "analysisResult",
-	9:  "analysisProgressInPercent",
-	10: "importResult",
-	11: "createdBy",
-	12: "createdOn",
-	13: "modifiedBy",
-	14: "modifiedOn",
-	15: "analysisRecords",
-	16: "defaultValues",
-	17: "documents",
-	18: "imports",
-}
-
-// Decode decodes ImportTaskDto from json.
-func (s *ImportTaskDto) Decode(d *jx.Decoder) error {
+// Decode decodes ImportStatus from json.
+func (s *ImportStatus) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode ImportTaskDto to nil")
+		return errors.New("invalid: unable to decode ImportStatus to nil")
 	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "rowVersion":
-			if err := func() error {
-				v, err := d.Base64()
-				s.RowVersion = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"rowVersion\"")
-			}
-		case "taskType":
-			if err := func() error {
-				s.TaskType.Reset()
-				if err := s.TaskType.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"taskType\"")
-			}
-		case "name":
-			if err := func() error {
-				s.Name.Reset()
-				if err := s.Name.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"name\"")
-			}
-		case "noAutomaticImport":
-			if err := func() error {
-				s.NoAutomaticImport.Reset()
-				if err := s.NoAutomaticImport.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"noAutomaticImport\"")
-			}
-		case "requiresContainers":
-			if err := func() error {
-				s.RequiresContainers.Reset()
-				if err := s.RequiresContainers.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"requiresContainers\"")
-			}
-		case "status":
-			if err := func() error {
-				s.Status.Reset()
-				if err := s.Status.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "analysisErrorMessage":
-			if err := func() error {
-				s.AnalysisErrorMessage.Reset()
-				if err := s.AnalysisErrorMessage.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"analysisErrorMessage\"")
-			}
-		case "analysisResult":
-			if err := func() error {
-				s.AnalysisResult.Reset()
-				if err := s.AnalysisResult.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"analysisResult\"")
-			}
-		case "analysisProgressInPercent":
-			if err := func() error {
-				s.AnalysisProgressInPercent.Reset()
-				if err := s.AnalysisProgressInPercent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"analysisProgressInPercent\"")
-			}
-		case "importResult":
-			if err := func() error {
-				s.ImportResult.Reset()
-				if err := s.ImportResult.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importResult\"")
-			}
-		case "createdBy":
-			if err := func() error {
-				s.CreatedBy.Reset()
-				if err := s.CreatedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdBy\"")
-			}
-		case "createdOn":
-			if err := func() error {
-				s.CreatedOn.Reset()
-				if err := s.CreatedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdOn\"")
-			}
-		case "modifiedBy":
-			if err := func() error {
-				s.ModifiedBy.Reset()
-				if err := s.ModifiedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedBy\"")
-			}
-		case "modifiedOn":
-			if err := func() error {
-				s.ModifiedOn.Reset()
-				if err := s.ModifiedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedOn\"")
-			}
-		case "analysisRecords":
-			if err := func() error {
-				s.AnalysisRecords = make([]AnalysisRecordDto, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem AnalysisRecordDto
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.AnalysisRecords = append(s.AnalysisRecords, elem)
-					return nil
-				}); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"analysisRecords\"")
-			}
-		case "defaultValues":
-			if err := func() error {
-				s.DefaultValues = make([]DefaultValueDto, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem DefaultValueDto
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.DefaultValues = append(s.DefaultValues, elem)
-					return nil
-				}); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"defaultValues\"")
-			}
-		case "documents":
-			if err := func() error {
-				s.Documents = make([]DocumentDto, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem DocumentDto
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.Documents = append(s.Documents, elem)
-					return nil
-				}); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"documents\"")
-			}
-		case "imports":
-			if err := func() error {
-				s.Imports = make([]ImportDto, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem ImportDto
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.Imports = append(s.Imports, elem)
-					return nil
-				}); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"imports\"")
-			}
-		default:
-			return errors.Errorf("unexpected field %q", k)
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ImportTaskDto")
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ImportStatus(v) {
+	case ImportStatusRequestStart:
+		*s = ImportStatusRequestStart
+	case ImportStatusRequestCancel:
+		*s = ImportStatusRequestCancel
+	case ImportStatusStarted:
+		*s = ImportStatusStarted
+	case ImportStatusFailed:
+		*s = ImportStatusFailed
+	case ImportStatusCanceled:
+		*s = ImportStatusCanceled
+	case ImportStatusCompleted:
+		*s = ImportStatusCompleted
+	case ImportStatusUndoStarted:
+		*s = ImportStatusUndoStarted
+	case ImportStatusUndoCompleted:
+		*s = ImportStatusUndoCompleted
+	case ImportStatusCreated:
+		*s = ImportStatusCreated
+	case ImportStatusPreparing:
+		*s = ImportStatusPreparing
+	default:
+		*s = ImportStatus(v)
 	}
 
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *ImportTaskDto) MarshalJSON() ([]byte, error) {
+func (s ImportStatus) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ImportTaskDto) UnmarshalJSON(data []byte) error {
+func (s *ImportStatus) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -3380,39 +1662,25 @@ func (s *ImportTaskStatusResponse) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.AnalysisErrorMessage.Set {
+			e.FieldStart("analysisErrorMessage")
+			s.AnalysisErrorMessage.Encode(e)
+		}
+	}
+	{
 		if s.ImportResult.Set {
 			e.FieldStart("importResult")
 			s.ImportResult.Encode(e)
 		}
 	}
-	{
-		if s.ImportProgressInPercent.Set {
-			e.FieldStart("importProgressInPercent")
-			s.ImportProgressInPercent.Encode(e)
-		}
-	}
-	{
-		if s.ProcessedDocumentCount.Set {
-			e.FieldStart("processedDocumentCount")
-			s.ProcessedDocumentCount.Encode(e)
-		}
-	}
-	{
-		if s.TotalDocumentCount.Set {
-			e.FieldStart("totalDocumentCount")
-			s.TotalDocumentCount.Encode(e)
-		}
-	}
 }
 
-var jsonFieldsNameOfImportTaskStatusResponse = [7]string{
+var jsonFieldsNameOfImportTaskStatusResponse = [5]string{
 	0: "status",
 	1: "analysisResult",
 	2: "analysisProgressInPercent",
-	3: "importResult",
-	4: "importProgressInPercent",
-	5: "processedDocumentCount",
-	6: "totalDocumentCount",
+	3: "analysisErrorMessage",
+	4: "importResult",
 }
 
 // Decode decodes ImportTaskStatusResponse from json.
@@ -3454,6 +1722,16 @@ func (s *ImportTaskStatusResponse) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"analysisProgressInPercent\"")
 			}
+		case "analysisErrorMessage":
+			if err := func() error {
+				s.AnalysisErrorMessage.Reset()
+				if err := s.AnalysisErrorMessage.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"analysisErrorMessage\"")
+			}
 		case "importResult":
 			if err := func() error {
 				s.ImportResult.Reset()
@@ -3463,36 +1741,6 @@ func (s *ImportTaskStatusResponse) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"importResult\"")
-			}
-		case "importProgressInPercent":
-			if err := func() error {
-				s.ImportProgressInPercent.Reset()
-				if err := s.ImportProgressInPercent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importProgressInPercent\"")
-			}
-		case "processedDocumentCount":
-			if err := func() error {
-				s.ProcessedDocumentCount.Reset()
-				if err := s.ProcessedDocumentCount.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"processedDocumentCount\"")
-			}
-		case "totalDocumentCount":
-			if err := func() error {
-				s.TotalDocumentCount.Reset()
-				if err := s.TotalDocumentCount.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"totalDocumentCount\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -3583,76 +1831,6 @@ func (s *OptAnalysisResult) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes bool as json.
-func (o OptBool) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	e.Bool(bool(o.Value))
-}
-
-// Decode decodes bool from json.
-func (o *OptBool) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptBool to nil")
-	}
-	o.Set = true
-	v, err := d.Bool()
-	if err != nil {
-		return err
-	}
-	o.Value = bool(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptBool) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptBool) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes time.Time as json.
-func (o OptDateTime) Encode(e *jx.Encoder, format func(*jx.Encoder, time.Time)) {
-	if !o.Set {
-		return
-	}
-	format(e, o.Value)
-}
-
-// Decode decodes time.Time from json.
-func (o *OptDateTime) Decode(d *jx.Decoder, format func(*jx.Decoder) (time.Time, error)) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptDateTime to nil")
-	}
-	o.Set = true
-	v, err := format(d)
-	if err != nil {
-		return err
-	}
-	o.Value = v
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptDateTime) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e, json.EncodeDateTime)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptDateTime) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d, json.DecodeDateTime)
-}
-
 // Encode encodes float64 as json.
 func (o OptFloat64) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -3719,262 +1897,6 @@ func (s OptImportResult) MarshalJSON() ([]byte, error) {
 func (s *OptImportResult) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
-}
-
-// Encode encodes ImportTaskDto as json.
-func (o OptImportTaskDto) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes ImportTaskDto from json.
-func (o *OptImportTaskDto) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptImportTaskDto to nil")
-	}
-	o.Set = true
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptImportTaskDto) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptImportTaskDto) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes int32 as json.
-func (o OptInt32) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	e.Int32(int32(o.Value))
-}
-
-// Decode decodes int32 from json.
-func (o *OptInt32) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptInt32 to nil")
-	}
-	o.Set = true
-	v, err := d.Int32()
-	if err != nil {
-		return err
-	}
-	o.Value = int32(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptInt32) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptInt32) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes int64 as json.
-func (o OptInt64) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	e.Int64(int64(o.Value))
-}
-
-// Decode decodes int64 from json.
-func (o *OptInt64) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptInt64 to nil")
-	}
-	o.Set = true
-	v, err := d.Int64()
-	if err != nil {
-		return err
-	}
-	o.Value = int64(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptInt64) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptInt64) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes bool as json.
-func (o OptNilBool) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	if o.Null {
-		e.Null()
-		return
-	}
-	e.Bool(bool(o.Value))
-}
-
-// Decode decodes bool from json.
-func (o *OptNilBool) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptNilBool to nil")
-	}
-	if d.Next() == jx.Null {
-		if err := d.Null(); err != nil {
-			return err
-		}
-
-		var v bool
-		o.Value = v
-		o.Set = true
-		o.Null = true
-		return nil
-	}
-	o.Set = true
-	o.Null = false
-	v, err := d.Bool()
-	if err != nil {
-		return err
-	}
-	o.Value = bool(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptNilBool) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptNilBool) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes []byte as json.
-func (o OptNilByte) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	if o.Null {
-		e.Null()
-		return
-	}
-	e.Base64([]byte(o.Value))
-}
-
-// Decode decodes []byte from json.
-func (o *OptNilByte) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptNilByte to nil")
-	}
-	if d.Next() == jx.Null {
-		if err := d.Null(); err != nil {
-			return err
-		}
-
-		var v []byte
-		o.Value = v
-		o.Set = true
-		o.Null = true
-		return nil
-	}
-	o.Set = true
-	o.Null = false
-	v, err := d.Base64()
-	if err != nil {
-		return err
-	}
-	o.Value = []byte(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptNilByte) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptNilByte) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes time.Time as json.
-func (o OptNilDateTime) Encode(e *jx.Encoder, format func(*jx.Encoder, time.Time)) {
-	if !o.Set {
-		return
-	}
-	if o.Null {
-		e.Null()
-		return
-	}
-	format(e, o.Value)
-}
-
-// Decode decodes time.Time from json.
-func (o *OptNilDateTime) Decode(d *jx.Decoder, format func(*jx.Decoder) (time.Time, error)) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptNilDateTime to nil")
-	}
-	if d.Next() == jx.Null {
-		if err := d.Null(); err != nil {
-			return err
-		}
-
-		var v time.Time
-		o.Value = v
-		o.Set = true
-		o.Null = true
-		return nil
-	}
-	o.Set = true
-	o.Null = false
-	v, err := format(d)
-	if err != nil {
-		return err
-	}
-	o.Value = v
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptNilDateTime) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e, json.EncodeDateTime)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptNilDateTime) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d, json.DecodeDateTime)
 }
 
 // Encode encodes []HealthCheckResult as json.
@@ -4136,110 +2058,6 @@ func (s OptNilString) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptNilString) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes string as json.
-func (o OptString) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	e.Str(string(o.Value))
-}
-
-// Decode decodes string from json.
-func (o *OptString) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptString to nil")
-	}
-	o.Set = true
-	v, err := d.Str()
-	if err != nil {
-		return err
-	}
-	o.Value = string(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptString) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptString) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes uuid.UUID as json.
-func (o OptUUID) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	json.EncodeUUID(e, o.Value)
-}
-
-// Decode decodes uuid.UUID from json.
-func (o *OptUUID) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptUUID to nil")
-	}
-	o.Set = true
-	v, err := json.DecodeUUID(d)
-	if err != nil {
-		return err
-	}
-	o.Value = v
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptUUID) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptUUID) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes ValidationProblemDetailsErrors as json.
-func (o OptValidationProblemDetailsErrors) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes ValidationProblemDetailsErrors from json.
-func (o *OptValidationProblemDetailsErrors) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptValidationProblemDetailsErrors to nil")
-	}
-	o.Set = true
-	o.Value = make(ValidationProblemDetailsErrors)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptValidationProblemDetailsErrors) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptValidationProblemDetailsErrors) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -4448,299 +2266,6 @@ func (s ProblemDetailsAdditional) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *ProblemDetailsAdditional) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s *ValidationProblemDetails) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *ValidationProblemDetails) encodeFields(e *jx.Encoder) {
-	{
-		if s.Type.Set {
-			e.FieldStart("type")
-			s.Type.Encode(e)
-		}
-	}
-	{
-		if s.Title.Set {
-			e.FieldStart("title")
-			s.Title.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
-	}
-	{
-		if s.Detail.Set {
-			e.FieldStart("detail")
-			s.Detail.Encode(e)
-		}
-	}
-	{
-		if s.Instance.Set {
-			e.FieldStart("instance")
-			s.Instance.Encode(e)
-		}
-	}
-	{
-		if s.Errors.Set {
-			e.FieldStart("errors")
-			s.Errors.Encode(e)
-		}
-	}
-	for k, elem := range s.AdditionalProps {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-var jsonFieldsNameOfValidationProblemDetails = [6]string{
-	0: "type",
-	1: "title",
-	2: "status",
-	3: "detail",
-	4: "instance",
-	5: "errors",
-}
-
-// Decode decodes ValidationProblemDetails from json.
-func (s *ValidationProblemDetails) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ValidationProblemDetails to nil")
-	}
-	s.AdditionalProps = map[string]jx.Raw{}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "type":
-			if err := func() error {
-				s.Type.Reset()
-				if err := s.Type.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"type\"")
-			}
-		case "title":
-			if err := func() error {
-				s.Title.Reset()
-				if err := s.Title.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"title\"")
-			}
-		case "status":
-			if err := func() error {
-				s.Status.Reset()
-				if err := s.Status.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "detail":
-			if err := func() error {
-				s.Detail.Reset()
-				if err := s.Detail.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"detail\"")
-			}
-		case "instance":
-			if err := func() error {
-				s.Instance.Reset()
-				if err := s.Instance.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"instance\"")
-			}
-		case "errors":
-			if err := func() error {
-				s.Errors.Reset()
-				if err := s.Errors.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"errors\"")
-			}
-		default:
-			var elem jx.Raw
-			if err := func() error {
-				v, err := d.RawAppend(nil)
-				elem = jx.Raw(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrapf(err, "decode field %q", k)
-			}
-			s.AdditionalProps[string(k)] = elem
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ValidationProblemDetails")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s *ValidationProblemDetails) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ValidationProblemDetails) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s ValidationProblemDetailsAdditional) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s ValidationProblemDetailsAdditional) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes ValidationProblemDetailsAdditional from json.
-func (s *ValidationProblemDetailsAdditional) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ValidationProblemDetailsAdditional to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ValidationProblemDetailsAdditional")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s ValidationProblemDetailsAdditional) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ValidationProblemDetailsAdditional) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s ValidationProblemDetailsErrors) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s ValidationProblemDetailsErrors) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		e.ArrStart()
-		for _, elem := range elem {
-			e.Str(elem)
-		}
-		e.ArrEnd()
-	}
-}
-
-// Decode decodes ValidationProblemDetailsErrors from json.
-func (s *ValidationProblemDetailsErrors) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ValidationProblemDetailsErrors to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem []string
-		if err := func() error {
-			elem = make([]string, 0)
-			if err := d.Arr(func(d *jx.Decoder) error {
-				var elemElem string
-				v, err := d.Str()
-				elemElem = string(v)
-				if err != nil {
-					return err
-				}
-				elem = append(elem, elemElem)
-				return nil
-			}); err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ValidationProblemDetailsErrors")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s ValidationProblemDetailsErrors) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ValidationProblemDetailsErrors) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/hack/apis-mock/internal/gen/oas_operations_gen.go
+++ b/hack/apis-mock/internal/gen/oas_operations_gen.go
@@ -7,9 +7,9 @@ type OperationName = string
 
 const (
 	APIHealthzGetOperation                            OperationName = "APIHealthzGet"
-	APIImportTasksIDImportRunsPostOperation           OperationName = "APIImportTasksIDImportRunsPost"
-	APIImportTasksIDImportRunsRunIdStatusGetOperation OperationName = "APIImportTasksIDImportRunsRunIdStatusGet"
-	APIImportTasksIDPatchOperation                    OperationName = "APIImportTasksIDPatch"
-	APIImportTasksIDStatusGetOperation                OperationName = "APIImportTasksIDStatusGet"
-	APIImportTasksPostOperation                       OperationName = "APIImportTasksPost"
+	APIImporttasksIDCancelPostOperation               OperationName = "APIImporttasksIDCancelPost"
+	APIImporttasksIDImportrunsPostOperation           OperationName = "APIImporttasksIDImportrunsPost"
+	APIImporttasksIDImportrunsRunIdStatusGetOperation OperationName = "APIImporttasksIDImportrunsRunIdStatusGet"
+	APIImporttasksIDStatusGetOperation                OperationName = "APIImporttasksIDStatusGet"
+	APIImporttasksPostOperation                       OperationName = "APIImporttasksPost"
 )

--- a/hack/apis-mock/internal/gen/oas_parameters_gen.go
+++ b/hack/apis-mock/internal/gen/oas_parameters_gen.go
@@ -14,13 +14,13 @@ import (
 	"github.com/ogen-go/ogen/validate"
 )
 
-// APIImportTasksIDImportRunsPostParams is parameters of POST /api/ImportTasks/{id}/importRuns operation.
-type APIImportTasksIDImportRunsPostParams struct {
-	// ImportTask identifier.
+// APIImporttasksIDCancelPostParams is parameters of POST /api/importtasks/{id}/cancel operation.
+type APIImporttasksIDCancelPostParams struct {
+	// The unique identifier of the import task to cancel.
 	ID string
 }
 
-func unpackAPIImportTasksIDImportRunsPostParams(packed middleware.Parameters) (params APIImportTasksIDImportRunsPostParams) {
+func unpackAPIImporttasksIDCancelPostParams(packed middleware.Parameters) (params APIImporttasksIDCancelPostParams) {
 	{
 		key := middleware.ParameterKey{
 			Name: "id",
@@ -31,7 +31,7 @@ func unpackAPIImportTasksIDImportRunsPostParams(packed middleware.Parameters) (p
 	return params
 }
 
-func decodeAPIImportTasksIDImportRunsPostParams(args [1]string, argsEscaped bool, r *http.Request) (params APIImportTasksIDImportRunsPostParams, _ error) {
+func decodeAPIImporttasksIDCancelPostParams(args [1]string, argsEscaped bool, r *http.Request) (params APIImporttasksIDCancelPostParams, _ error) {
 	// Decode path: id.
 	if err := func() error {
 		param := args[0]
@@ -80,13 +80,81 @@ func decodeAPIImportTasksIDImportRunsPostParams(args [1]string, argsEscaped bool
 	return params, nil
 }
 
-// APIImportTasksIDImportRunsRunIdStatusGetParams is parameters of GET /api/ImportTasks/{id}/importRuns/{runId}/status operation.
-type APIImportTasksIDImportRunsRunIdStatusGetParams struct {
-	ID    string
+// APIImporttasksIDImportrunsPostParams is parameters of POST /api/importtasks/{id}/importruns operation.
+type APIImporttasksIDImportrunsPostParams struct {
+	// ImportTask identifier.
+	ID string
+}
+
+func unpackAPIImporttasksIDImportrunsPostParams(packed middleware.Parameters) (params APIImporttasksIDImportrunsPostParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "id",
+			In:   "path",
+		}
+		params.ID = packed[key].(string)
+	}
+	return params
+}
+
+func decodeAPIImporttasksIDImportrunsPostParams(args [1]string, argsEscaped bool, r *http.Request) (params APIImporttasksIDImportrunsPostParams, _ error) {
+	// Decode path: id.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "id",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.ID = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "id",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
+// APIImporttasksIDImportrunsRunIdStatusGetParams is parameters of GET /api/importtasks/{id}/importruns/{runId}/status operation.
+type APIImporttasksIDImportrunsRunIdStatusGetParams struct {
+	// The import task identifier.
+	ID string
+	// The import run identifier.
 	RunId string
 }
 
-func unpackAPIImportTasksIDImportRunsRunIdStatusGetParams(packed middleware.Parameters) (params APIImportTasksIDImportRunsRunIdStatusGetParams) {
+func unpackAPIImporttasksIDImportrunsRunIdStatusGetParams(packed middleware.Parameters) (params APIImporttasksIDImportrunsRunIdStatusGetParams) {
 	{
 		key := middleware.ParameterKey{
 			Name: "id",
@@ -104,7 +172,7 @@ func unpackAPIImportTasksIDImportRunsRunIdStatusGetParams(packed middleware.Para
 	return params
 }
 
-func decodeAPIImportTasksIDImportRunsRunIdStatusGetParams(args [2]string, argsEscaped bool, r *http.Request) (params APIImportTasksIDImportRunsRunIdStatusGetParams, _ error) {
+func decodeAPIImporttasksIDImportrunsRunIdStatusGetParams(args [2]string, argsEscaped bool, r *http.Request) (params APIImporttasksIDImportrunsRunIdStatusGetParams, _ error) {
 	// Decode path: id.
 	if err := func() error {
 		param := args[0]
@@ -198,79 +266,13 @@ func decodeAPIImportTasksIDImportRunsRunIdStatusGetParams(args [2]string, argsEs
 	return params, nil
 }
 
-// APIImportTasksIDPatchParams is parameters of PATCH /api/ImportTasks/{id} operation.
-type APIImportTasksIDPatchParams struct {
-	// The unique identifier of the import task to be updated.
-	ID string
-}
-
-func unpackAPIImportTasksIDPatchParams(packed middleware.Parameters) (params APIImportTasksIDPatchParams) {
-	{
-		key := middleware.ParameterKey{
-			Name: "id",
-			In:   "path",
-		}
-		params.ID = packed[key].(string)
-	}
-	return params
-}
-
-func decodeAPIImportTasksIDPatchParams(args [1]string, argsEscaped bool, r *http.Request) (params APIImportTasksIDPatchParams, _ error) {
-	// Decode path: id.
-	if err := func() error {
-		param := args[0]
-		if argsEscaped {
-			unescaped, err := url.PathUnescape(args[0])
-			if err != nil {
-				return errors.Wrap(err, "unescape path")
-			}
-			param = unescaped
-		}
-		if len(param) > 0 {
-			d := uri.NewPathDecoder(uri.PathDecoderConfig{
-				Param:   "id",
-				Value:   param,
-				Style:   uri.PathStyleSimple,
-				Explode: false,
-			})
-
-			if err := func() error {
-				val, err := d.DecodeValue()
-				if err != nil {
-					return err
-				}
-
-				c, err := conv.ToString(val)
-				if err != nil {
-					return err
-				}
-
-				params.ID = c
-				return nil
-			}(); err != nil {
-				return err
-			}
-		} else {
-			return validate.ErrFieldRequired
-		}
-		return nil
-	}(); err != nil {
-		return params, &ogenerrors.DecodeParamError{
-			Name: "id",
-			In:   "path",
-			Err:  err,
-		}
-	}
-	return params, nil
-}
-
-// APIImportTasksIDStatusGetParams is parameters of GET /api/ImportTasks/{id}/status operation.
-type APIImportTasksIDStatusGetParams struct {
+// APIImporttasksIDStatusGetParams is parameters of GET /api/importtasks/{id}/status operation.
+type APIImporttasksIDStatusGetParams struct {
 	// The id of the import task to query.
 	ID string
 }
 
-func unpackAPIImportTasksIDStatusGetParams(packed middleware.Parameters) (params APIImportTasksIDStatusGetParams) {
+func unpackAPIImporttasksIDStatusGetParams(packed middleware.Parameters) (params APIImporttasksIDStatusGetParams) {
 	{
 		key := middleware.ParameterKey{
 			Name: "id",
@@ -281,7 +283,7 @@ func unpackAPIImportTasksIDStatusGetParams(packed middleware.Parameters) (params
 	return params
 }
 
-func decodeAPIImportTasksIDStatusGetParams(args [1]string, argsEscaped bool, r *http.Request) (params APIImportTasksIDStatusGetParams, _ error) {
+func decodeAPIImporttasksIDStatusGetParams(args [1]string, argsEscaped bool, r *http.Request) (params APIImporttasksIDStatusGetParams, _ error) {
 	// Decode path: id.
 	if err := func() error {
 		param := args[0]

--- a/hack/apis-mock/internal/gen/oas_request_decoders_gen.go
+++ b/hack/apis-mock/internal/gen/oas_request_decoders_gen.go
@@ -18,8 +18,127 @@ import (
 	"github.com/ogen-go/ogen/validate"
 )
 
-func (s *Server) decodeAPIImportTasksIDImportRunsPostRequest(r *http.Request) (
-	req OptAPIImportTasksIDImportRunsPostReq,
+func (s *Server) decodeAPIImporttasksIDCancelPostRequest(r *http.Request) (
+	req APIImporttasksIDCancelPostReq,
+	rawBody []byte,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = errors.Join(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = errors.Join(rerr, close())
+		}
+	}()
+	req = &APIImporttasksIDCancelPostReqEmptyBody{}
+	if _, ok := r.Header["Content-Type"]; !ok && r.ContentLength == 0 {
+		return req, rawBody, close, nil
+	}
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, rawBody, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ht.MatchContentType("application/*+json", ct):
+		if r.ContentLength == 0 {
+			return req, rawBody, close, nil
+		}
+		buf, err := io.ReadAll(r.Body)
+		defer func() {
+			_ = r.Body.Close()
+		}()
+		if err != nil {
+			return req, rawBody, close, err
+		}
+
+		// Reset the body to allow for downstream reading.
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
+
+		if len(buf) == 0 {
+			return req, rawBody, close, nil
+		}
+
+		rawBody = append(rawBody, buf...)
+		d := jx.DecodeBytes(buf)
+
+		var request CancelImportTaskRequest
+		if err := func() error {
+			if err := request.Decode(d); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, rawBody, close, err
+		}
+		wrapped := CancelImportTaskRequestWithContentType{
+			ContentType: ct,
+			Content:     request,
+		}
+		return &wrapped, rawBody, close, nil
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, rawBody, close, nil
+		}
+		buf, err := io.ReadAll(r.Body)
+		defer func() {
+			_ = r.Body.Close()
+		}()
+		if err != nil {
+			return req, rawBody, close, err
+		}
+
+		// Reset the body to allow for downstream reading.
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
+
+		if len(buf) == 0 {
+			return req, rawBody, close, nil
+		}
+
+		rawBody = append(rawBody, buf...)
+		d := jx.DecodeBytes(buf)
+
+		var request CancelImportTaskRequest
+		if err := func() error {
+			if err := request.Decode(d); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, rawBody, close, err
+		}
+		return &request, rawBody, close, nil
+	default:
+		return req, rawBody, close, validate.InvalidContentType(ct)
+	}
+}
+
+func (s *Server) decodeAPIImporttasksIDImportrunsPostRequest(r *http.Request) (
+	req OptAPIImporttasksIDImportrunsPostReq,
 	rawBody []byte,
 	close func() error,
 	rerr error,
@@ -63,9 +182,9 @@ func (s *Server) decodeAPIImportTasksIDImportRunsPostRequest(r *http.Request) (
 		form := url.Values(r.MultipartForm.Value)
 		_ = form
 
-		var request OptAPIImportTasksIDImportRunsPostReq
+		var request OptAPIImporttasksIDImportrunsPostReq
 		{
-			var optForm APIImportTasksIDImportRunsPostReq
+			var optForm APIImporttasksIDImportrunsPostReq
 			q := uri.NewQueryDecoder(form)
 			{
 				cfg := uri.QueryParameterDecodingConfig{
@@ -115,6 +234,33 @@ func (s *Server) decodeAPIImportTasksIDImportRunsPostRequest(r *http.Request) (
 				}
 			}
 			{
+				cfg := uri.QueryParameterDecodingConfig{
+					Name:    "username",
+					Style:   uri.QueryStyleForm,
+					Explode: true,
+				}
+				if err := q.HasParam(cfg); err == nil {
+					if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToString(val)
+						if err != nil {
+							return err
+						}
+
+						optForm.Username = c
+						return nil
+					}); err != nil {
+						return req, rawBody, close, errors.Wrap(err, "decode \"username\"")
+					}
+				} else {
+					return req, rawBody, close, errors.Wrap(err, "query")
+				}
+			}
+			{
 				if err := func() error {
 					files, ok := r.MultipartForm.File["file"]
 					if !ok || len(files) < 1 {
@@ -138,7 +284,7 @@ func (s *Server) decodeAPIImportTasksIDImportRunsPostRequest(r *http.Request) (
 					return req, rawBody, close, errors.Wrap(err, "decode \"file\"")
 				}
 			}
-			request = OptAPIImportTasksIDImportRunsPostReq{
+			request = OptAPIImporttasksIDImportrunsPostReq{
 				Value: optForm,
 				Set:   true,
 			}
@@ -149,143 +295,8 @@ func (s *Server) decodeAPIImportTasksIDImportRunsPostRequest(r *http.Request) (
 	}
 }
 
-func (s *Server) decodeAPIImportTasksIDPatchRequest(r *http.Request) (
-	req APIImportTasksIDPatchReq,
-	rawBody []byte,
-	close func() error,
-	rerr error,
-) {
-	var closers []func() error
-	close = func() error {
-		var merr error
-		// Close in reverse order, to match defer behavior.
-		for i := len(closers) - 1; i >= 0; i-- {
-			c := closers[i]
-			merr = errors.Join(merr, c())
-		}
-		return merr
-	}
-	defer func() {
-		if rerr != nil {
-			rerr = errors.Join(rerr, close())
-		}
-	}()
-	req = &APIImportTasksIDPatchReqEmptyBody{}
-	if _, ok := r.Header["Content-Type"]; !ok && r.ContentLength == 0 {
-		return req, rawBody, close, nil
-	}
-	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-	if err != nil {
-		return req, rawBody, close, errors.Wrap(err, "parse media type")
-	}
-	switch {
-	case ht.MatchContentType("application/*+json", ct):
-		if r.ContentLength == 0 {
-			return req, rawBody, close, nil
-		}
-		buf, err := io.ReadAll(r.Body)
-		defer func() {
-			_ = r.Body.Close()
-		}()
-		if err != nil {
-			return req, rawBody, close, err
-		}
-
-		// Reset the body to allow for downstream reading.
-		r.Body = io.NopCloser(bytes.NewBuffer(buf))
-
-		if len(buf) == 0 {
-			return req, rawBody, close, nil
-		}
-
-		rawBody = append(rawBody, buf...)
-		d := jx.DecodeBytes(buf)
-
-		var request CancelImportTaskRequest
-		if err := func() error {
-			if err := request.Decode(d); err != nil {
-				return err
-			}
-			if err := d.Skip(); err != io.EOF {
-				return errors.New("unexpected trailing data")
-			}
-			return nil
-		}(); err != nil {
-			err = &ogenerrors.DecodeBodyError{
-				ContentType: ct,
-				Body:        buf,
-				Err:         err,
-			}
-			return req, rawBody, close, err
-		}
-		if err := func() error {
-			if err := request.Validate(); err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return req, rawBody, close, errors.Wrap(err, "validate")
-		}
-		wrapped := CancelImportTaskRequestWithContentType{
-			ContentType: ct,
-			Content:     request,
-		}
-		return &wrapped, rawBody, close, nil
-	case ct == "application/json":
-		if r.ContentLength == 0 {
-			return req, rawBody, close, nil
-		}
-		buf, err := io.ReadAll(r.Body)
-		defer func() {
-			_ = r.Body.Close()
-		}()
-		if err != nil {
-			return req, rawBody, close, err
-		}
-
-		// Reset the body to allow for downstream reading.
-		r.Body = io.NopCloser(bytes.NewBuffer(buf))
-
-		if len(buf) == 0 {
-			return req, rawBody, close, nil
-		}
-
-		rawBody = append(rawBody, buf...)
-		d := jx.DecodeBytes(buf)
-
-		var request CancelImportTaskRequest
-		if err := func() error {
-			if err := request.Decode(d); err != nil {
-				return err
-			}
-			if err := d.Skip(); err != io.EOF {
-				return errors.New("unexpected trailing data")
-			}
-			return nil
-		}(); err != nil {
-			err = &ogenerrors.DecodeBodyError{
-				ContentType: ct,
-				Body:        buf,
-				Err:         err,
-			}
-			return req, rawBody, close, err
-		}
-		if err := func() error {
-			if err := request.Validate(); err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return req, rawBody, close, errors.Wrap(err, "validate")
-		}
-		return &request, rawBody, close, nil
-	default:
-		return req, rawBody, close, validate.InvalidContentType(ct)
-	}
-}
-
-func (s *Server) decodeAPIImportTasksPostRequest(r *http.Request) (
-	req OptAPIImportTasksPostReq,
+func (s *Server) decodeAPIImporttasksPostRequest(r *http.Request) (
+	req OptAPIImporttasksPostReq,
 	rawBody []byte,
 	close func() error,
 	rerr error,
@@ -329,9 +340,9 @@ func (s *Server) decodeAPIImportTasksPostRequest(r *http.Request) (
 		form := url.Values(r.MultipartForm.Value)
 		_ = form
 
-		var request OptAPIImportTasksPostReq
+		var request OptAPIImporttasksPostReq
 		{
-			var optForm APIImportTasksPostReq
+			var optForm APIImporttasksPostReq
 			q := uri.NewQueryDecoder(form)
 			{
 				cfg := uri.QueryParameterDecodingConfig{
@@ -419,7 +430,7 @@ func (s *Server) decodeAPIImportTasksPostRequest(r *http.Request) (
 					return req, rawBody, close, errors.Wrap(err, "decode \"file\"")
 				}
 			}
-			request = OptAPIImportTasksPostReq{
+			request = OptAPIImporttasksPostReq{
 				Value: optForm,
 				Set:   true,
 			}

--- a/hack/apis-mock/internal/gen/oas_response_encoders_gen.go
+++ b/hack/apis-mock/internal/gen/oas_response_encoders_gen.go
@@ -44,7 +44,72 @@ func encodeAPIHealthzGetResponse(response APIHealthzGetRes, w http.ResponseWrite
 	}
 }
 
-func encodeAPIImportTasksIDImportRunsPostResponse(response APIImportTasksIDImportRunsPostRes, w http.ResponseWriter, span trace.Span) error {
+func encodeAPIImporttasksIDCancelPostResponse(response APIImporttasksIDCancelPostRes, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *APIImporttasksIDCancelPostNoContent:
+		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
+
+		return nil
+
+	case *APIImporttasksIDCancelPostUnauthorized:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *APIImporttasksIDCancelPostNotFound:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *APIImporttasksIDCancelPostConflict:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *APIImporttasksIDCancelPostInternalServerError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
+func encodeAPIImporttasksIDImportrunsPostResponse(response APIImporttasksIDImportrunsPostRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
 	case *CreateImportRunResponse:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -59,7 +124,7 @@ func encodeAPIImportTasksIDImportRunsPostResponse(response APIImportTasksIDImpor
 
 		return nil
 
-	case *ValidationProblemDetails:
+	case *APIImporttasksIDImportrunsPostBadRequest:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(400)
 		span.SetStatus(codes.Error, http.StatusText(400))
@@ -72,7 +137,7 @@ func encodeAPIImportTasksIDImportRunsPostResponse(response APIImportTasksIDImpor
 
 		return nil
 
-	case *APIImportTasksIDImportRunsPostUnauthorized:
+	case *APIImporttasksIDImportrunsPostUnauthorized:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(401)
 		span.SetStatus(codes.Error, http.StatusText(401))
@@ -85,7 +150,7 @@ func encodeAPIImportTasksIDImportRunsPostResponse(response APIImportTasksIDImpor
 
 		return nil
 
-	case *APIImportTasksIDImportRunsPostNotFound:
+	case *APIImporttasksIDImportrunsPostNotFound:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(404)
 		span.SetStatus(codes.Error, http.StatusText(404))
@@ -98,7 +163,7 @@ func encodeAPIImportTasksIDImportRunsPostResponse(response APIImportTasksIDImpor
 
 		return nil
 
-	case *APIImportTasksIDImportRunsPostUnsupportedMediaType:
+	case *APIImporttasksIDImportrunsPostUnsupportedMediaType:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(415)
 		span.SetStatus(codes.Error, http.StatusText(415))
@@ -116,7 +181,7 @@ func encodeAPIImportTasksIDImportRunsPostResponse(response APIImportTasksIDImpor
 	}
 }
 
-func encodeAPIImportTasksIDImportRunsRunIdStatusGetResponse(response APIImportTasksIDImportRunsRunIdStatusGetRes, w http.ResponseWriter, span trace.Span) error {
+func encodeAPIImporttasksIDImportrunsRunIdStatusGetResponse(response APIImporttasksIDImportrunsRunIdStatusGetRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
 	case *ImportRunStatusResponse:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -131,7 +196,7 @@ func encodeAPIImportTasksIDImportRunsRunIdStatusGetResponse(response APIImportTa
 
 		return nil
 
-	case *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized:
+	case *APIImporttasksIDImportrunsRunIdStatusGetUnauthorized:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(401)
 		span.SetStatus(codes.Error, http.StatusText(401))
@@ -144,10 +209,23 @@ func encodeAPIImportTasksIDImportRunsRunIdStatusGetResponse(response APIImportTa
 
 		return nil
 
-	case *APIImportTasksIDImportRunsRunIdStatusGetNotFound:
+	case *APIImporttasksIDImportrunsRunIdStatusGetNotFound:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(404)
 		span.SetStatus(codes.Error, http.StatusText(404))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *APIImporttasksIDImportrunsRunIdStatusGetInternalServerError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 
 		e := new(jx.Encoder)
 		response.Encode(e)
@@ -162,9 +240,9 @@ func encodeAPIImportTasksIDImportRunsRunIdStatusGetResponse(response APIImportTa
 	}
 }
 
-func encodeAPIImportTasksIDPatchResponse(response APIImportTasksIDPatchRes, w http.ResponseWriter, span trace.Span) error {
+func encodeAPIImporttasksIDStatusGetResponse(response APIImporttasksIDStatusGetRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
-	case *ImportTaskDto:
+	case *ImportTaskStatusResponse:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(200)
 		span.SetStatus(codes.Ok, http.StatusText(200))
@@ -177,7 +255,20 @@ func encodeAPIImportTasksIDPatchResponse(response APIImportTasksIDPatchRes, w ht
 
 		return nil
 
-	case *APIImportTasksIDPatchNotFound:
+	case *APIImporttasksIDStatusGetUnauthorized:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *APIImporttasksIDStatusGetNotFound:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(404)
 		span.SetStatus(codes.Error, http.StatusText(404))
@@ -190,10 +281,10 @@ func encodeAPIImportTasksIDPatchResponse(response APIImportTasksIDPatchRes, w ht
 
 		return nil
 
-	case *APIImportTasksIDPatchConflict:
+	case *APIImporttasksIDStatusGetInternalServerError:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(409)
-		span.SetStatus(codes.Error, http.StatusText(409))
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 
 		e := new(jx.Encoder)
 		response.Encode(e)
@@ -208,23 +299,9 @@ func encodeAPIImportTasksIDPatchResponse(response APIImportTasksIDPatchRes, w ht
 	}
 }
 
-func encodeAPIImportTasksIDStatusGetResponse(response *ImportTaskStatusResponse, w http.ResponseWriter, span trace.Span) error {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(200)
-	span.SetStatus(codes.Ok, http.StatusText(200))
-
-	e := new(jx.Encoder)
-	response.Encode(e)
-	if _, err := e.WriteTo(w); err != nil {
-		return errors.Wrap(err, "write")
-	}
-
-	return nil
-}
-
-func encodeAPIImportTasksPostResponse(response APIImportTasksPostRes, w http.ResponseWriter, span trace.Span) error {
+func encodeAPIImporttasksPostResponse(response APIImporttasksPostRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
-	case *APIImportTasksPostCreated:
+	case *CreateImportTaskResponse:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(201)
 		span.SetStatus(codes.Ok, http.StatusText(201))
@@ -237,7 +314,7 @@ func encodeAPIImportTasksPostResponse(response APIImportTasksPostRes, w http.Res
 
 		return nil
 
-	case *APIImportTasksPostBadRequest:
+	case *APIImporttasksPostBadRequest:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(400)
 		span.SetStatus(codes.Error, http.StatusText(400))
@@ -250,7 +327,7 @@ func encodeAPIImportTasksPostResponse(response APIImportTasksPostRes, w http.Res
 
 		return nil
 
-	case *ProblemDetails:
+	case *APIImporttasksPostUnauthorized:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(401)
 		span.SetStatus(codes.Error, http.StatusText(401))
@@ -263,7 +340,7 @@ func encodeAPIImportTasksPostResponse(response APIImportTasksPostRes, w http.Res
 
 		return nil
 
-	case *APIImportTasksPostUnsupportedMediaType:
+	case *APIImporttasksPostUnsupportedMediaType:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(415)
 		span.SetStatus(codes.Error, http.StatusText(415))
@@ -276,7 +353,7 @@ func encodeAPIImportTasksPostResponse(response APIImportTasksPostRes, w http.Res
 
 		return nil
 
-	case *APIImportTasksPostInternalServerError:
+	case *APIImporttasksPostInternalServerError:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(500)
 		span.SetStatus(codes.Error, http.StatusText(500))

--- a/hack/apis-mock/internal/gen/oas_router_gen.go
+++ b/hack/apis-mock/internal/gen/oas_router_gen.go
@@ -14,19 +14,19 @@ var (
 	rn1AllowedHeaders = map[string]string{
 		"GET": "Authorization",
 	}
-	rn11AllowedHeaders = map[string]string{
+	rn12AllowedHeaders = map[string]string{
 		"POST": "Authorization,Content-Type",
-	}
-	rn4AllowedHeaders = map[string]string{
-		"PATCH": "Authorization,Content-Type",
 	}
 	rn5AllowedHeaders = map[string]string{
 		"POST": "Authorization,Content-Type",
 	}
-	rn8AllowedHeaders = map[string]string{
-		"GET": "Authorization",
+	rn7AllowedHeaders = map[string]string{
+		"POST": "Authorization,Content-Type",
 	}
 	rn10AllowedHeaders = map[string]string{
+		"GET": "Authorization",
+	}
+	rn11AllowedHeaders = map[string]string{
 		"GET": "Authorization",
 	}
 )
@@ -82,9 +82,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 			switch elem[0] {
-			case 'H': // Prefix: "Healthz"
+			case 'h': // Prefix: "healthz"
 
-				if l := len("Healthz"); len(elem) >= l && elem[0:l] == "Healthz" {
+				if l := len("healthz"); len(elem) >= l && elem[0:l] == "healthz" {
 					elem = elem[l:]
 				} else {
 					break
@@ -107,9 +107,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
-			case 'I': // Prefix: "ImportTasks"
+			case 'i': // Prefix: "importtasks"
 
-				if l := len("ImportTasks"); len(elem) >= l && elem[0:l] == "ImportTasks" {
+				if l := len("importtasks"); len(elem) >= l && elem[0:l] == "importtasks" {
 					elem = elem[l:]
 				} else {
 					break
@@ -118,11 +118,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				if len(elem) == 0 {
 					switch r.Method {
 					case "POST":
-						s.handleAPIImportTasksPostRequest([0]string{}, elemIsEscaped, w, r)
+						s.handleAPIImporttasksPostRequest([0]string{}, elemIsEscaped, w, r)
 					default:
 						s.notAllowed(w, r, notAllowedParams{
 							allowedMethods: "POST",
-							allowedHeaders: rn11AllowedHeaders,
+							allowedHeaders: rn12AllowedHeaders,
 							acceptPost:     "multipart/form-data",
 							acceptPatch:    "",
 						})
@@ -149,21 +149,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					elem = elem[idx:]
 
 					if len(elem) == 0 {
-						switch r.Method {
-						case "PATCH":
-							s.handleAPIImportTasksIDPatchRequest([1]string{
-								args[0],
-							}, elemIsEscaped, w, r)
-						default:
-							s.notAllowed(w, r, notAllowedParams{
-								allowedMethods: "PATCH",
-								allowedHeaders: rn4AllowedHeaders,
-								acceptPost:     "",
-								acceptPatch:    "application/*+json,application/json",
-							})
-						}
-
-						return
+						break
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
@@ -178,9 +164,36 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							break
 						}
 						switch elem[0] {
-						case 'i': // Prefix: "importRuns"
+						case 'c': // Prefix: "cancel"
 
-							if l := len("importRuns"); len(elem) >= l && elem[0:l] == "importRuns" {
+							if l := len("cancel"); len(elem) >= l && elem[0:l] == "cancel" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch r.Method {
+								case "POST":
+									s.handleAPIImporttasksIDCancelPostRequest([1]string{
+										args[0],
+									}, elemIsEscaped, w, r)
+								default:
+									s.notAllowed(w, r, notAllowedParams{
+										allowedMethods: "POST",
+										allowedHeaders: rn5AllowedHeaders,
+										acceptPost:     "application/*+json,application/json",
+										acceptPatch:    "",
+									})
+								}
+
+								return
+							}
+
+						case 'i': // Prefix: "importruns"
+
+							if l := len("importruns"); len(elem) >= l && elem[0:l] == "importruns" {
 								elem = elem[l:]
 							} else {
 								break
@@ -189,13 +202,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							if len(elem) == 0 {
 								switch r.Method {
 								case "POST":
-									s.handleAPIImportTasksIDImportRunsPostRequest([1]string{
+									s.handleAPIImporttasksIDImportrunsPostRequest([1]string{
 										args[0],
 									}, elemIsEscaped, w, r)
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn5AllowedHeaders,
+										allowedHeaders: rn7AllowedHeaders,
 										acceptPost:     "multipart/form-data",
 										acceptPatch:    "",
 									})
@@ -237,14 +250,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										// Leaf node.
 										switch r.Method {
 										case "GET":
-											s.handleAPIImportTasksIDImportRunsRunIdStatusGetRequest([2]string{
+											s.handleAPIImporttasksIDImportrunsRunIdStatusGetRequest([2]string{
 												args[0],
 												args[1],
 											}, elemIsEscaped, w, r)
 										default:
 											s.notAllowed(w, r, notAllowedParams{
 												allowedMethods: "GET",
-												allowedHeaders: rn8AllowedHeaders,
+												allowedHeaders: rn10AllowedHeaders,
 												acceptPost:     "",
 												acceptPatch:    "",
 											})
@@ -269,13 +282,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								// Leaf node.
 								switch r.Method {
 								case "GET":
-									s.handleAPIImportTasksIDStatusGetRequest([1]string{
+									s.handleAPIImporttasksIDStatusGetRequest([1]string{
 										args[0],
 									}, elemIsEscaped, w, r)
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "GET",
-										allowedHeaders: rn10AllowedHeaders,
+										allowedHeaders: rn11AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -390,9 +403,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				break
 			}
 			switch elem[0] {
-			case 'H': // Prefix: "Healthz"
+			case 'h': // Prefix: "healthz"
 
-				if l := len("Healthz"); len(elem) >= l && elem[0:l] == "Healthz" {
+				if l := len("healthz"); len(elem) >= l && elem[0:l] == "healthz" {
 					elem = elem[l:]
 				} else {
 					break
@@ -406,7 +419,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						r.summary = "Get health status information"
 						r.operationID = ""
 						r.operationGroup = ""
-						r.pathPattern = "/api/Healthz"
+						r.pathPattern = "/api/healthz"
 						r.args = args
 						r.count = 0
 						return r, true
@@ -415,9 +428,9 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					}
 				}
 
-			case 'I': // Prefix: "ImportTasks"
+			case 'i': // Prefix: "importtasks"
 
-				if l := len("ImportTasks"); len(elem) >= l && elem[0:l] == "ImportTasks" {
+				if l := len("importtasks"); len(elem) >= l && elem[0:l] == "importtasks" {
 					elem = elem[l:]
 				} else {
 					break
@@ -426,11 +439,11 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				if len(elem) == 0 {
 					switch method {
 					case "POST":
-						r.name = APIImportTasksPostOperation
+						r.name = APIImporttasksPostOperation
 						r.summary = "Creates a new import task."
 						r.operationID = ""
 						r.operationGroup = ""
-						r.pathPattern = "/api/ImportTasks"
+						r.pathPattern = "/api/importtasks"
 						r.args = args
 						r.count = 0
 						return r, true
@@ -457,19 +470,7 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					elem = elem[idx:]
 
 					if len(elem) == 0 {
-						switch method {
-						case "PATCH":
-							r.name = APIImportTasksIDPatchOperation
-							r.summary = "Updates the status of an existing import task."
-							r.operationID = ""
-							r.operationGroup = ""
-							r.pathPattern = "/api/ImportTasks/{id}"
-							r.args = args
-							r.count = 1
-							return r, true
-						default:
-							return
-						}
+						break
 					}
 					switch elem[0] {
 					case '/': // Prefix: "/"
@@ -484,9 +485,34 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							break
 						}
 						switch elem[0] {
-						case 'i': // Prefix: "importRuns"
+						case 'c': // Prefix: "cancel"
 
-							if l := len("importRuns"); len(elem) >= l && elem[0:l] == "importRuns" {
+							if l := len("cancel"); len(elem) >= l && elem[0:l] == "cancel" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch method {
+								case "POST":
+									r.name = APIImporttasksIDCancelPostOperation
+									r.summary = "Cancels an existing import task."
+									r.operationID = ""
+									r.operationGroup = ""
+									r.pathPattern = "/api/importtasks/{id}/cancel"
+									r.args = args
+									r.count = 1
+									return r, true
+								default:
+									return
+								}
+							}
+
+						case 'i': // Prefix: "importruns"
+
+							if l := len("importruns"); len(elem) >= l && elem[0:l] == "importruns" {
 								elem = elem[l:]
 							} else {
 								break
@@ -495,11 +521,11 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							if len(elem) == 0 {
 								switch method {
 								case "POST":
-									r.name = APIImportTasksIDImportRunsPostOperation
+									r.name = APIImporttasksIDImportrunsPostOperation
 									r.summary = "Starts a new import run for the given import task.\r\nCreates a new import execution (\"run\") resource."
 									r.operationID = ""
 									r.operationGroup = ""
-									r.pathPattern = "/api/ImportTasks/{id}/importRuns"
+									r.pathPattern = "/api/importtasks/{id}/importruns"
 									r.args = args
 									r.count = 1
 									return r, true
@@ -541,11 +567,11 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 										// Leaf node.
 										switch method {
 										case "GET":
-											r.name = APIImportTasksIDImportRunsRunIdStatusGetOperation
+											r.name = APIImporttasksIDImportrunsRunIdStatusGetOperation
 											r.summary = "Gets the status of a specific import run."
 											r.operationID = ""
 											r.operationGroup = ""
-											r.pathPattern = "/api/ImportTasks/{id}/importRuns/{runId}/status"
+											r.pathPattern = "/api/importtasks/{id}/importruns/{runId}/status"
 											r.args = args
 											r.count = 2
 											return r, true
@@ -570,11 +596,11 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								// Leaf node.
 								switch method {
 								case "GET":
-									r.name = APIImportTasksIDStatusGetOperation
-									r.summary = "Query the status of an ongoing analysis or import"
+									r.name = APIImporttasksIDStatusGetOperation
+									r.summary = "Query the status of an ongoing analysis (import task)."
 									r.operationID = ""
 									r.operationGroup = ""
-									r.pathPattern = "/api/ImportTasks/{id}/status"
+									r.pathPattern = "/api/importtasks/{id}/status"
 									r.args = args
 									r.count = 1
 									return r, true

--- a/hack/apis-mock/internal/gen/oas_schemas_gen.go
+++ b/hack/apis-mock/internal/gen/oas_schemas_gen.go
@@ -3,11 +3,8 @@
 package gen
 
 import (
-	"time"
-
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
-	"github.com/google/uuid"
 	ht "github.com/ogen-go/ogen/http"
 )
 
@@ -19,80 +16,121 @@ type APIHealthzGetServiceUnavailable HealthStatusResult
 
 func (*APIHealthzGetServiceUnavailable) aPIHealthzGetRes() {}
 
-type APIImportTasksIDImportRunsPostNotFound ProblemDetails
+type APIImporttasksIDCancelPostConflict ProblemDetails
 
-func (*APIImportTasksIDImportRunsPostNotFound) aPIImportTasksIDImportRunsPostRes() {}
+func (*APIImporttasksIDCancelPostConflict) aPIImporttasksIDCancelPostRes() {}
 
-type APIImportTasksIDImportRunsPostReq struct {
+type APIImporttasksIDCancelPostInternalServerError ProblemDetails
+
+func (*APIImporttasksIDCancelPostInternalServerError) aPIImporttasksIDCancelPostRes() {}
+
+// APIImporttasksIDCancelPostNoContent is response for APIImporttasksIDCancelPost operation.
+type APIImporttasksIDCancelPostNoContent struct{}
+
+func (*APIImporttasksIDCancelPostNoContent) aPIImporttasksIDCancelPostRes() {}
+
+type APIImporttasksIDCancelPostNotFound ProblemDetails
+
+func (*APIImporttasksIDCancelPostNotFound) aPIImporttasksIDCancelPostRes() {}
+
+type APIImporttasksIDCancelPostReqEmptyBody struct{}
+
+func (*APIImporttasksIDCancelPostReqEmptyBody) aPIImporttasksIDCancelPostReq() {}
+
+type APIImporttasksIDCancelPostUnauthorized ProblemDetails
+
+func (*APIImporttasksIDCancelPostUnauthorized) aPIImporttasksIDCancelPostRes() {}
+
+type APIImporttasksIDImportrunsPostBadRequest ProblemDetails
+
+func (*APIImporttasksIDImportrunsPostBadRequest) aPIImporttasksIDImportrunsPostRes() {}
+
+type APIImporttasksIDImportrunsPostNotFound ProblemDetails
+
+func (*APIImporttasksIDImportrunsPostNotFound) aPIImporttasksIDImportrunsPostRes() {}
+
+type APIImporttasksIDImportrunsPostReq struct {
 	// The METS file required for the import.
-	// (To be decided: Or a zip file containing the METS and the metadata.xml file?)).
 	File            ht.MultipartFile       `json:"file"`
 	ImportBehaviour OptImportBehaviourType `json:"importBehaviour"`
+	// The username that is logged as the creator of the import task. Can be the email for example.
+	Username string `json:"username"`
 }
 
 // GetFile returns the value of File.
-func (s *APIImportTasksIDImportRunsPostReq) GetFile() ht.MultipartFile {
+func (s *APIImporttasksIDImportrunsPostReq) GetFile() ht.MultipartFile {
 	return s.File
 }
 
 // GetImportBehaviour returns the value of ImportBehaviour.
-func (s *APIImportTasksIDImportRunsPostReq) GetImportBehaviour() OptImportBehaviourType {
+func (s *APIImporttasksIDImportrunsPostReq) GetImportBehaviour() OptImportBehaviourType {
 	return s.ImportBehaviour
 }
 
+// GetUsername returns the value of Username.
+func (s *APIImporttasksIDImportrunsPostReq) GetUsername() string {
+	return s.Username
+}
+
 // SetFile sets the value of File.
-func (s *APIImportTasksIDImportRunsPostReq) SetFile(val ht.MultipartFile) {
+func (s *APIImporttasksIDImportrunsPostReq) SetFile(val ht.MultipartFile) {
 	s.File = val
 }
 
 // SetImportBehaviour sets the value of ImportBehaviour.
-func (s *APIImportTasksIDImportRunsPostReq) SetImportBehaviour(val OptImportBehaviourType) {
+func (s *APIImporttasksIDImportrunsPostReq) SetImportBehaviour(val OptImportBehaviourType) {
 	s.ImportBehaviour = val
 }
 
-type APIImportTasksIDImportRunsPostUnauthorized ProblemDetails
-
-func (*APIImportTasksIDImportRunsPostUnauthorized) aPIImportTasksIDImportRunsPostRes() {}
-
-type APIImportTasksIDImportRunsPostUnsupportedMediaType ProblemDetails
-
-func (*APIImportTasksIDImportRunsPostUnsupportedMediaType) aPIImportTasksIDImportRunsPostRes() {}
-
-type APIImportTasksIDImportRunsRunIdStatusGetNotFound ProblemDetails
-
-func (*APIImportTasksIDImportRunsRunIdStatusGetNotFound) aPIImportTasksIDImportRunsRunIdStatusGetRes() {
+// SetUsername sets the value of Username.
+func (s *APIImporttasksIDImportrunsPostReq) SetUsername(val string) {
+	s.Username = val
 }
 
-type APIImportTasksIDImportRunsRunIdStatusGetUnauthorized ProblemDetails
+type APIImporttasksIDImportrunsPostUnauthorized ProblemDetails
 
-func (*APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) aPIImportTasksIDImportRunsRunIdStatusGetRes() {
+func (*APIImporttasksIDImportrunsPostUnauthorized) aPIImporttasksIDImportrunsPostRes() {}
+
+type APIImporttasksIDImportrunsPostUnsupportedMediaType ProblemDetails
+
+func (*APIImporttasksIDImportrunsPostUnsupportedMediaType) aPIImporttasksIDImportrunsPostRes() {}
+
+type APIImporttasksIDImportrunsRunIdStatusGetInternalServerError ProblemDetails
+
+func (*APIImporttasksIDImportrunsRunIdStatusGetInternalServerError) aPIImporttasksIDImportrunsRunIdStatusGetRes() {
 }
 
-type APIImportTasksIDPatchConflict ProblemDetails
+type APIImporttasksIDImportrunsRunIdStatusGetNotFound ProblemDetails
 
-func (*APIImportTasksIDPatchConflict) aPIImportTasksIDPatchRes() {}
+func (*APIImporttasksIDImportrunsRunIdStatusGetNotFound) aPIImporttasksIDImportrunsRunIdStatusGetRes() {
+}
 
-type APIImportTasksIDPatchNotFound ProblemDetails
+type APIImporttasksIDImportrunsRunIdStatusGetUnauthorized ProblemDetails
 
-func (*APIImportTasksIDPatchNotFound) aPIImportTasksIDPatchRes() {}
+func (*APIImporttasksIDImportrunsRunIdStatusGetUnauthorized) aPIImporttasksIDImportrunsRunIdStatusGetRes() {
+}
 
-type APIImportTasksIDPatchReqEmptyBody struct{}
+type APIImporttasksIDStatusGetInternalServerError ProblemDetails
 
-func (*APIImportTasksIDPatchReqEmptyBody) aPIImportTasksIDPatchReq() {}
+func (*APIImporttasksIDStatusGetInternalServerError) aPIImporttasksIDStatusGetRes() {}
 
-type APIImportTasksPostBadRequest CreateImportTaskResponse
+type APIImporttasksIDStatusGetNotFound ProblemDetails
 
-func (*APIImportTasksPostBadRequest) aPIImportTasksPostRes() {}
+func (*APIImporttasksIDStatusGetNotFound) aPIImporttasksIDStatusGetRes() {}
 
-type APIImportTasksPostCreated CreateImportTaskResponse
+type APIImporttasksIDStatusGetUnauthorized ProblemDetails
 
-func (*APIImportTasksPostCreated) aPIImportTasksPostRes() {}
+func (*APIImporttasksIDStatusGetUnauthorized) aPIImporttasksIDStatusGetRes() {}
 
-type APIImportTasksPostInternalServerError CreateImportTaskResponse
+type APIImporttasksPostBadRequest ProblemDetails
 
-func (*APIImportTasksPostInternalServerError) aPIImportTasksPostRes() {}
+func (*APIImporttasksPostBadRequest) aPIImporttasksPostRes() {}
 
-type APIImportTasksPostReq struct {
+type APIImporttasksPostInternalServerError ProblemDetails
+
+func (*APIImporttasksPostInternalServerError) aPIImporttasksPostRes() {}
+
+type APIImporttasksPostReq struct {
 	// The metadata.xml file according to eCH-0160.
 	File    ht.MultipartFile `json:"file"`
 	SipType SipType          `json:"sipType"`
@@ -101,438 +139,42 @@ type APIImportTasksPostReq struct {
 }
 
 // GetFile returns the value of File.
-func (s *APIImportTasksPostReq) GetFile() ht.MultipartFile {
+func (s *APIImporttasksPostReq) GetFile() ht.MultipartFile {
 	return s.File
 }
 
 // GetSipType returns the value of SipType.
-func (s *APIImportTasksPostReq) GetSipType() SipType {
+func (s *APIImporttasksPostReq) GetSipType() SipType {
 	return s.SipType
 }
 
 // GetUsername returns the value of Username.
-func (s *APIImportTasksPostReq) GetUsername() string {
+func (s *APIImporttasksPostReq) GetUsername() string {
 	return s.Username
 }
 
 // SetFile sets the value of File.
-func (s *APIImportTasksPostReq) SetFile(val ht.MultipartFile) {
+func (s *APIImporttasksPostReq) SetFile(val ht.MultipartFile) {
 	s.File = val
 }
 
 // SetSipType sets the value of SipType.
-func (s *APIImportTasksPostReq) SetSipType(val SipType) {
+func (s *APIImporttasksPostReq) SetSipType(val SipType) {
 	s.SipType = val
 }
 
 // SetUsername sets the value of Username.
-func (s *APIImportTasksPostReq) SetUsername(val string) {
+func (s *APIImporttasksPostReq) SetUsername(val string) {
 	s.Username = val
 }
 
-type APIImportTasksPostUnsupportedMediaType CreateImportTaskResponse
+type APIImporttasksPostUnauthorized ProblemDetails
 
-func (*APIImportTasksPostUnsupportedMediaType) aPIImportTasksPostRes() {}
+func (*APIImporttasksPostUnauthorized) aPIImporttasksPostRes() {}
 
-// Ref: #/components/schemas/AnalysisRecordDto
-type AnalysisRecordDto struct {
-	AnalysisRecordId  OptInt32         `json:"analysisRecordId"`
-	RowVersion        []byte           `json:"rowVersion"`
-	ImportTaskId      OptInt32         `json:"importTaskId"`
-	ComparisonDate    OptDateTime      `json:"comparisonDate"`
-	TargetPrimaryKey  OptUUID          `json:"targetPrimaryKey"`
-	DocKey            OptNilString     `json:"docKey"`
-	ReferenceCode     OptNilString     `json:"referenceCode"`
-	Level             OptNilString     `json:"level"`
-	SourcePrimaryKey  OptNilString     `json:"sourcePrimaryKey"`
-	PositionNumber    OptString        `json:"positionNumber"`
-	SourceTitle       OptString        `json:"sourceTitle"`
-	DestinationTitle  OptNilString     `json:"destinationTitle"`
-	SourceField1      OptNilString     `json:"sourceField1"`
-	DestinationField1 OptNilString     `json:"destinationField1"`
-	SourceField2      OptNilString     `json:"sourceField2"`
-	DestinationField2 OptNilString     `json:"destinationField2"`
-	SourceField3      OptNilString     `json:"sourceField3"`
-	DestinationField3 OptNilString     `json:"destinationField3"`
-	SourceField4      OptNilString     `json:"sourceField4"`
-	DestinationField4 OptNilString     `json:"destinationField4"`
-	SourceField5      OptNilString     `json:"sourceField5"`
-	DestinationField5 OptNilString     `json:"destinationField5"`
-	TitleIsDifferent  OptBool          `json:"titleIsDifferent"`
-	Field1IsDifferent OptBool          `json:"field1IsDifferent"`
-	Field2IsDifferent OptBool          `json:"field2IsDifferent"`
-	Field3IsDifferent OptBool          `json:"field3IsDifferent"`
-	Field4IsDifferent OptBool          `json:"field4IsDifferent"`
-	Field5IsDifferent OptBool          `json:"field5IsDifferent"`
-	Status            OptNilString     `json:"status"`
-	ErrorMessage      OptNilString     `json:"errorMessage"`
-	ContainerDocKey   OptNilString     `json:"containerDocKey"`
-	CreatedBy         OptString        `json:"createdBy"`
-	CreatedOn         OptDateTime      `json:"createdOn"`
-	ModifiedBy        OptNilString     `json:"modifiedBy"`
-	ModifiedOn        OptNilDateTime   `json:"modifiedOn"`
-	ImportTask        OptImportTaskDto `json:"importTask"`
-}
+type APIImporttasksPostUnsupportedMediaType ProblemDetails
 
-// GetAnalysisRecordId returns the value of AnalysisRecordId.
-func (s *AnalysisRecordDto) GetAnalysisRecordId() OptInt32 {
-	return s.AnalysisRecordId
-}
-
-// GetRowVersion returns the value of RowVersion.
-func (s *AnalysisRecordDto) GetRowVersion() []byte {
-	return s.RowVersion
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *AnalysisRecordDto) GetImportTaskId() OptInt32 {
-	return s.ImportTaskId
-}
-
-// GetComparisonDate returns the value of ComparisonDate.
-func (s *AnalysisRecordDto) GetComparisonDate() OptDateTime {
-	return s.ComparisonDate
-}
-
-// GetTargetPrimaryKey returns the value of TargetPrimaryKey.
-func (s *AnalysisRecordDto) GetTargetPrimaryKey() OptUUID {
-	return s.TargetPrimaryKey
-}
-
-// GetDocKey returns the value of DocKey.
-func (s *AnalysisRecordDto) GetDocKey() OptNilString {
-	return s.DocKey
-}
-
-// GetReferenceCode returns the value of ReferenceCode.
-func (s *AnalysisRecordDto) GetReferenceCode() OptNilString {
-	return s.ReferenceCode
-}
-
-// GetLevel returns the value of Level.
-func (s *AnalysisRecordDto) GetLevel() OptNilString {
-	return s.Level
-}
-
-// GetSourcePrimaryKey returns the value of SourcePrimaryKey.
-func (s *AnalysisRecordDto) GetSourcePrimaryKey() OptNilString {
-	return s.SourcePrimaryKey
-}
-
-// GetPositionNumber returns the value of PositionNumber.
-func (s *AnalysisRecordDto) GetPositionNumber() OptString {
-	return s.PositionNumber
-}
-
-// GetSourceTitle returns the value of SourceTitle.
-func (s *AnalysisRecordDto) GetSourceTitle() OptString {
-	return s.SourceTitle
-}
-
-// GetDestinationTitle returns the value of DestinationTitle.
-func (s *AnalysisRecordDto) GetDestinationTitle() OptNilString {
-	return s.DestinationTitle
-}
-
-// GetSourceField1 returns the value of SourceField1.
-func (s *AnalysisRecordDto) GetSourceField1() OptNilString {
-	return s.SourceField1
-}
-
-// GetDestinationField1 returns the value of DestinationField1.
-func (s *AnalysisRecordDto) GetDestinationField1() OptNilString {
-	return s.DestinationField1
-}
-
-// GetSourceField2 returns the value of SourceField2.
-func (s *AnalysisRecordDto) GetSourceField2() OptNilString {
-	return s.SourceField2
-}
-
-// GetDestinationField2 returns the value of DestinationField2.
-func (s *AnalysisRecordDto) GetDestinationField2() OptNilString {
-	return s.DestinationField2
-}
-
-// GetSourceField3 returns the value of SourceField3.
-func (s *AnalysisRecordDto) GetSourceField3() OptNilString {
-	return s.SourceField3
-}
-
-// GetDestinationField3 returns the value of DestinationField3.
-func (s *AnalysisRecordDto) GetDestinationField3() OptNilString {
-	return s.DestinationField3
-}
-
-// GetSourceField4 returns the value of SourceField4.
-func (s *AnalysisRecordDto) GetSourceField4() OptNilString {
-	return s.SourceField4
-}
-
-// GetDestinationField4 returns the value of DestinationField4.
-func (s *AnalysisRecordDto) GetDestinationField4() OptNilString {
-	return s.DestinationField4
-}
-
-// GetSourceField5 returns the value of SourceField5.
-func (s *AnalysisRecordDto) GetSourceField5() OptNilString {
-	return s.SourceField5
-}
-
-// GetDestinationField5 returns the value of DestinationField5.
-func (s *AnalysisRecordDto) GetDestinationField5() OptNilString {
-	return s.DestinationField5
-}
-
-// GetTitleIsDifferent returns the value of TitleIsDifferent.
-func (s *AnalysisRecordDto) GetTitleIsDifferent() OptBool {
-	return s.TitleIsDifferent
-}
-
-// GetField1IsDifferent returns the value of Field1IsDifferent.
-func (s *AnalysisRecordDto) GetField1IsDifferent() OptBool {
-	return s.Field1IsDifferent
-}
-
-// GetField2IsDifferent returns the value of Field2IsDifferent.
-func (s *AnalysisRecordDto) GetField2IsDifferent() OptBool {
-	return s.Field2IsDifferent
-}
-
-// GetField3IsDifferent returns the value of Field3IsDifferent.
-func (s *AnalysisRecordDto) GetField3IsDifferent() OptBool {
-	return s.Field3IsDifferent
-}
-
-// GetField4IsDifferent returns the value of Field4IsDifferent.
-func (s *AnalysisRecordDto) GetField4IsDifferent() OptBool {
-	return s.Field4IsDifferent
-}
-
-// GetField5IsDifferent returns the value of Field5IsDifferent.
-func (s *AnalysisRecordDto) GetField5IsDifferent() OptBool {
-	return s.Field5IsDifferent
-}
-
-// GetStatus returns the value of Status.
-func (s *AnalysisRecordDto) GetStatus() OptNilString {
-	return s.Status
-}
-
-// GetErrorMessage returns the value of ErrorMessage.
-func (s *AnalysisRecordDto) GetErrorMessage() OptNilString {
-	return s.ErrorMessage
-}
-
-// GetContainerDocKey returns the value of ContainerDocKey.
-func (s *AnalysisRecordDto) GetContainerDocKey() OptNilString {
-	return s.ContainerDocKey
-}
-
-// GetCreatedBy returns the value of CreatedBy.
-func (s *AnalysisRecordDto) GetCreatedBy() OptString {
-	return s.CreatedBy
-}
-
-// GetCreatedOn returns the value of CreatedOn.
-func (s *AnalysisRecordDto) GetCreatedOn() OptDateTime {
-	return s.CreatedOn
-}
-
-// GetModifiedBy returns the value of ModifiedBy.
-func (s *AnalysisRecordDto) GetModifiedBy() OptNilString {
-	return s.ModifiedBy
-}
-
-// GetModifiedOn returns the value of ModifiedOn.
-func (s *AnalysisRecordDto) GetModifiedOn() OptNilDateTime {
-	return s.ModifiedOn
-}
-
-// GetImportTask returns the value of ImportTask.
-func (s *AnalysisRecordDto) GetImportTask() OptImportTaskDto {
-	return s.ImportTask
-}
-
-// SetAnalysisRecordId sets the value of AnalysisRecordId.
-func (s *AnalysisRecordDto) SetAnalysisRecordId(val OptInt32) {
-	s.AnalysisRecordId = val
-}
-
-// SetRowVersion sets the value of RowVersion.
-func (s *AnalysisRecordDto) SetRowVersion(val []byte) {
-	s.RowVersion = val
-}
-
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *AnalysisRecordDto) SetImportTaskId(val OptInt32) {
-	s.ImportTaskId = val
-}
-
-// SetComparisonDate sets the value of ComparisonDate.
-func (s *AnalysisRecordDto) SetComparisonDate(val OptDateTime) {
-	s.ComparisonDate = val
-}
-
-// SetTargetPrimaryKey sets the value of TargetPrimaryKey.
-func (s *AnalysisRecordDto) SetTargetPrimaryKey(val OptUUID) {
-	s.TargetPrimaryKey = val
-}
-
-// SetDocKey sets the value of DocKey.
-func (s *AnalysisRecordDto) SetDocKey(val OptNilString) {
-	s.DocKey = val
-}
-
-// SetReferenceCode sets the value of ReferenceCode.
-func (s *AnalysisRecordDto) SetReferenceCode(val OptNilString) {
-	s.ReferenceCode = val
-}
-
-// SetLevel sets the value of Level.
-func (s *AnalysisRecordDto) SetLevel(val OptNilString) {
-	s.Level = val
-}
-
-// SetSourcePrimaryKey sets the value of SourcePrimaryKey.
-func (s *AnalysisRecordDto) SetSourcePrimaryKey(val OptNilString) {
-	s.SourcePrimaryKey = val
-}
-
-// SetPositionNumber sets the value of PositionNumber.
-func (s *AnalysisRecordDto) SetPositionNumber(val OptString) {
-	s.PositionNumber = val
-}
-
-// SetSourceTitle sets the value of SourceTitle.
-func (s *AnalysisRecordDto) SetSourceTitle(val OptString) {
-	s.SourceTitle = val
-}
-
-// SetDestinationTitle sets the value of DestinationTitle.
-func (s *AnalysisRecordDto) SetDestinationTitle(val OptNilString) {
-	s.DestinationTitle = val
-}
-
-// SetSourceField1 sets the value of SourceField1.
-func (s *AnalysisRecordDto) SetSourceField1(val OptNilString) {
-	s.SourceField1 = val
-}
-
-// SetDestinationField1 sets the value of DestinationField1.
-func (s *AnalysisRecordDto) SetDestinationField1(val OptNilString) {
-	s.DestinationField1 = val
-}
-
-// SetSourceField2 sets the value of SourceField2.
-func (s *AnalysisRecordDto) SetSourceField2(val OptNilString) {
-	s.SourceField2 = val
-}
-
-// SetDestinationField2 sets the value of DestinationField2.
-func (s *AnalysisRecordDto) SetDestinationField2(val OptNilString) {
-	s.DestinationField2 = val
-}
-
-// SetSourceField3 sets the value of SourceField3.
-func (s *AnalysisRecordDto) SetSourceField3(val OptNilString) {
-	s.SourceField3 = val
-}
-
-// SetDestinationField3 sets the value of DestinationField3.
-func (s *AnalysisRecordDto) SetDestinationField3(val OptNilString) {
-	s.DestinationField3 = val
-}
-
-// SetSourceField4 sets the value of SourceField4.
-func (s *AnalysisRecordDto) SetSourceField4(val OptNilString) {
-	s.SourceField4 = val
-}
-
-// SetDestinationField4 sets the value of DestinationField4.
-func (s *AnalysisRecordDto) SetDestinationField4(val OptNilString) {
-	s.DestinationField4 = val
-}
-
-// SetSourceField5 sets the value of SourceField5.
-func (s *AnalysisRecordDto) SetSourceField5(val OptNilString) {
-	s.SourceField5 = val
-}
-
-// SetDestinationField5 sets the value of DestinationField5.
-func (s *AnalysisRecordDto) SetDestinationField5(val OptNilString) {
-	s.DestinationField5 = val
-}
-
-// SetTitleIsDifferent sets the value of TitleIsDifferent.
-func (s *AnalysisRecordDto) SetTitleIsDifferent(val OptBool) {
-	s.TitleIsDifferent = val
-}
-
-// SetField1IsDifferent sets the value of Field1IsDifferent.
-func (s *AnalysisRecordDto) SetField1IsDifferent(val OptBool) {
-	s.Field1IsDifferent = val
-}
-
-// SetField2IsDifferent sets the value of Field2IsDifferent.
-func (s *AnalysisRecordDto) SetField2IsDifferent(val OptBool) {
-	s.Field2IsDifferent = val
-}
-
-// SetField3IsDifferent sets the value of Field3IsDifferent.
-func (s *AnalysisRecordDto) SetField3IsDifferent(val OptBool) {
-	s.Field3IsDifferent = val
-}
-
-// SetField4IsDifferent sets the value of Field4IsDifferent.
-func (s *AnalysisRecordDto) SetField4IsDifferent(val OptBool) {
-	s.Field4IsDifferent = val
-}
-
-// SetField5IsDifferent sets the value of Field5IsDifferent.
-func (s *AnalysisRecordDto) SetField5IsDifferent(val OptBool) {
-	s.Field5IsDifferent = val
-}
-
-// SetStatus sets the value of Status.
-func (s *AnalysisRecordDto) SetStatus(val OptNilString) {
-	s.Status = val
-}
-
-// SetErrorMessage sets the value of ErrorMessage.
-func (s *AnalysisRecordDto) SetErrorMessage(val OptNilString) {
-	s.ErrorMessage = val
-}
-
-// SetContainerDocKey sets the value of ContainerDocKey.
-func (s *AnalysisRecordDto) SetContainerDocKey(val OptNilString) {
-	s.ContainerDocKey = val
-}
-
-// SetCreatedBy sets the value of CreatedBy.
-func (s *AnalysisRecordDto) SetCreatedBy(val OptString) {
-	s.CreatedBy = val
-}
-
-// SetCreatedOn sets the value of CreatedOn.
-func (s *AnalysisRecordDto) SetCreatedOn(val OptDateTime) {
-	s.CreatedOn = val
-}
-
-// SetModifiedBy sets the value of ModifiedBy.
-func (s *AnalysisRecordDto) SetModifiedBy(val OptNilString) {
-	s.ModifiedBy = val
-}
-
-// SetModifiedOn sets the value of ModifiedOn.
-func (s *AnalysisRecordDto) SetModifiedOn(val OptNilDateTime) {
-	s.ModifiedOn = val
-}
-
-// SetImportTask sets the value of ImportTask.
-func (s *AnalysisRecordDto) SetImportTask(val OptImportTaskDto) {
-	s.ImportTask = val
-}
+func (*APIImporttasksPostUnsupportedMediaType) aPIImporttasksPostRes() {}
 
 // Enum values:
 // - `AlleGleich`: The title of all series are the same
@@ -595,22 +237,36 @@ func (s *AnalysisResult) UnmarshalText(data []byte) error {
 	}
 }
 
+// Request to cancel an import task.
 // Ref: #/components/schemas/CancelImportTaskRequest
 type CancelImportTaskRequest struct {
-	Status ImportTaskStatus `json:"status"`
+	// Optional reason for canceling the import task.
+	Reason OptNilString `json:"reason"`
+	// The user who initiated the cancellation.
+	CancelledBy OptNilString `json:"cancelledBy"`
 }
 
-// GetStatus returns the value of Status.
-func (s *CancelImportTaskRequest) GetStatus() ImportTaskStatus {
-	return s.Status
+// GetReason returns the value of Reason.
+func (s *CancelImportTaskRequest) GetReason() OptNilString {
+	return s.Reason
 }
 
-// SetStatus sets the value of Status.
-func (s *CancelImportTaskRequest) SetStatus(val ImportTaskStatus) {
-	s.Status = val
+// GetCancelledBy returns the value of CancelledBy.
+func (s *CancelImportTaskRequest) GetCancelledBy() OptNilString {
+	return s.CancelledBy
 }
 
-func (*CancelImportTaskRequest) aPIImportTasksIDPatchReq() {}
+// SetReason sets the value of Reason.
+func (s *CancelImportTaskRequest) SetReason(val OptNilString) {
+	s.Reason = val
+}
+
+// SetCancelledBy sets the value of CancelledBy.
+func (s *CancelImportTaskRequest) SetCancelledBy(val OptNilString) {
+	s.CancelledBy = val
+}
+
+func (*CancelImportTaskRequest) aPIImporttasksIDCancelPostReq() {}
 
 // CancelImportTaskRequestWithContentType wraps CancelImportTaskRequest with Content-Type.
 type CancelImportTaskRequestWithContentType struct {
@@ -638,482 +294,60 @@ func (s *CancelImportTaskRequestWithContentType) SetContent(val CancelImportTask
 	s.Content = val
 }
 
-func (*CancelImportTaskRequestWithContentType) aPIImportTasksIDPatchReq() {}
+func (*CancelImportTaskRequestWithContentType) aPIImporttasksIDCancelPostReq() {}
 
+// Response returned when an import run is successfully created.
 // Ref: #/components/schemas/CreateImportRunResponse
 type CreateImportRunResponse struct {
-	// Gets a value indicating whether the creation of the import run was successful.
-	Success OptBool `json:"success"`
-	// Gets the identifier of the import task associated with the response.
-	ImportTaskId OptString `json:"importTaskId"`
 	// Gets the unique identifier for the created import run.
-	ImportRunId OptNilString `json:"importRunId"`
-	// Gets or initializes the error message associated with the result of the import run creation.
-	Error OptNilString `json:"error"`
-}
-
-// GetSuccess returns the value of Success.
-func (s *CreateImportRunResponse) GetSuccess() OptBool {
-	return s.Success
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *CreateImportRunResponse) GetImportTaskId() OptString {
-	return s.ImportTaskId
+	ImportRunId string `json:"importRunId"`
 }
 
 // GetImportRunId returns the value of ImportRunId.
-func (s *CreateImportRunResponse) GetImportRunId() OptNilString {
+func (s *CreateImportRunResponse) GetImportRunId() string {
 	return s.ImportRunId
 }
 
-// GetError returns the value of Error.
-func (s *CreateImportRunResponse) GetError() OptNilString {
-	return s.Error
-}
-
-// SetSuccess sets the value of Success.
-func (s *CreateImportRunResponse) SetSuccess(val OptBool) {
-	s.Success = val
-}
-
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *CreateImportRunResponse) SetImportTaskId(val OptString) {
-	s.ImportTaskId = val
-}
-
 // SetImportRunId sets the value of ImportRunId.
-func (s *CreateImportRunResponse) SetImportRunId(val OptNilString) {
+func (s *CreateImportRunResponse) SetImportRunId(val string) {
 	s.ImportRunId = val
 }
 
-// SetError sets the value of Error.
-func (s *CreateImportRunResponse) SetError(val OptNilString) {
-	s.Error = val
-}
+func (*CreateImportRunResponse) aPIImporttasksIDImportrunsPostRes() {}
 
-func (*CreateImportRunResponse) aPIImportTasksIDImportRunsPostRes() {}
-
+// Response returned when an import task is successfully created.
 // Ref: #/components/schemas/CreateImportTaskResponse
 type CreateImportTaskResponse struct {
-	// Gets a value indicating whether the creation of the import task was successful.
-	Success OptBool `json:"success"`
-	// Gets or initializes the error message associated with the result of the import task creation.
-	Error OptNilString `json:"error"`
 	// Gets the unique identifier for the created import task.
-	ID OptNilString `json:"id"`
-}
-
-// GetSuccess returns the value of Success.
-func (s *CreateImportTaskResponse) GetSuccess() OptBool {
-	return s.Success
-}
-
-// GetError returns the value of Error.
-func (s *CreateImportTaskResponse) GetError() OptNilString {
-	return s.Error
-}
-
-// GetID returns the value of ID.
-func (s *CreateImportTaskResponse) GetID() OptNilString {
-	return s.ID
-}
-
-// SetSuccess sets the value of Success.
-func (s *CreateImportTaskResponse) SetSuccess(val OptBool) {
-	s.Success = val
-}
-
-// SetError sets the value of Error.
-func (s *CreateImportTaskResponse) SetError(val OptNilString) {
-	s.Error = val
-}
-
-// SetID sets the value of ID.
-func (s *CreateImportTaskResponse) SetID(val OptNilString) {
-	s.ID = val
-}
-
-// Ref: #/components/schemas/DefaultValueDto
-type DefaultValueDto struct {
-	DefaultValueId         OptInt32         `json:"defaultValueId"`
-	RowVersion             []byte           `json:"rowVersion"`
-	ImportTaskId           OptInt32         `json:"importTaskId"`
-	AccessionDocKey        OptString        `json:"accessionDocKey"`
-	AccessionIdName        OptString        `json:"accessionIdName"`
-	InsertNodeDocKey       OptString        `json:"insertNodeDocKey"`
-	InsertNodeIdName       OptString        `json:"insertNodeIdName"`
-	Status                 OptNilString     `json:"status"`
-	ProtectionBaseDate     OptNilString     `json:"protectionBaseDate"`
-	ProtectionCategory     OptNilString     `json:"protectionCategory"`
-	ProtectionDuration     OptNilInt32      `json:"protectionDuration"`
-	MetadataCanBePublished OptNilBool       `json:"metadataCanBePublished"`
-	Accessibility          OptNilString     `json:"accessibility"`
-	Usability              OptNilString     `json:"usability"`
-	PermissionType         OptNilString     `json:"permissionType"`
-	CreatedBy              OptString        `json:"createdBy"`
-	CreatedOn              OptDateTime      `json:"createdOn"`
-	ModifiedBy             OptNilString     `json:"modifiedBy"`
-	ModifiedOn             OptNilDateTime   `json:"modifiedOn"`
-	ImportTask             OptImportTaskDto `json:"importTask"`
-}
-
-// GetDefaultValueId returns the value of DefaultValueId.
-func (s *DefaultValueDto) GetDefaultValueId() OptInt32 {
-	return s.DefaultValueId
-}
-
-// GetRowVersion returns the value of RowVersion.
-func (s *DefaultValueDto) GetRowVersion() []byte {
-	return s.RowVersion
+	ImportTaskId string `json:"importTaskId"`
 }
 
 // GetImportTaskId returns the value of ImportTaskId.
-func (s *DefaultValueDto) GetImportTaskId() OptInt32 {
+func (s *CreateImportTaskResponse) GetImportTaskId() string {
 	return s.ImportTaskId
 }
 
-// GetAccessionDocKey returns the value of AccessionDocKey.
-func (s *DefaultValueDto) GetAccessionDocKey() OptString {
-	return s.AccessionDocKey
-}
-
-// GetAccessionIdName returns the value of AccessionIdName.
-func (s *DefaultValueDto) GetAccessionIdName() OptString {
-	return s.AccessionIdName
-}
-
-// GetInsertNodeDocKey returns the value of InsertNodeDocKey.
-func (s *DefaultValueDto) GetInsertNodeDocKey() OptString {
-	return s.InsertNodeDocKey
-}
-
-// GetInsertNodeIdName returns the value of InsertNodeIdName.
-func (s *DefaultValueDto) GetInsertNodeIdName() OptString {
-	return s.InsertNodeIdName
-}
-
-// GetStatus returns the value of Status.
-func (s *DefaultValueDto) GetStatus() OptNilString {
-	return s.Status
-}
-
-// GetProtectionBaseDate returns the value of ProtectionBaseDate.
-func (s *DefaultValueDto) GetProtectionBaseDate() OptNilString {
-	return s.ProtectionBaseDate
-}
-
-// GetProtectionCategory returns the value of ProtectionCategory.
-func (s *DefaultValueDto) GetProtectionCategory() OptNilString {
-	return s.ProtectionCategory
-}
-
-// GetProtectionDuration returns the value of ProtectionDuration.
-func (s *DefaultValueDto) GetProtectionDuration() OptNilInt32 {
-	return s.ProtectionDuration
-}
-
-// GetMetadataCanBePublished returns the value of MetadataCanBePublished.
-func (s *DefaultValueDto) GetMetadataCanBePublished() OptNilBool {
-	return s.MetadataCanBePublished
-}
-
-// GetAccessibility returns the value of Accessibility.
-func (s *DefaultValueDto) GetAccessibility() OptNilString {
-	return s.Accessibility
-}
-
-// GetUsability returns the value of Usability.
-func (s *DefaultValueDto) GetUsability() OptNilString {
-	return s.Usability
-}
-
-// GetPermissionType returns the value of PermissionType.
-func (s *DefaultValueDto) GetPermissionType() OptNilString {
-	return s.PermissionType
-}
-
-// GetCreatedBy returns the value of CreatedBy.
-func (s *DefaultValueDto) GetCreatedBy() OptString {
-	return s.CreatedBy
-}
-
-// GetCreatedOn returns the value of CreatedOn.
-func (s *DefaultValueDto) GetCreatedOn() OptDateTime {
-	return s.CreatedOn
-}
-
-// GetModifiedBy returns the value of ModifiedBy.
-func (s *DefaultValueDto) GetModifiedBy() OptNilString {
-	return s.ModifiedBy
-}
-
-// GetModifiedOn returns the value of ModifiedOn.
-func (s *DefaultValueDto) GetModifiedOn() OptNilDateTime {
-	return s.ModifiedOn
-}
-
-// GetImportTask returns the value of ImportTask.
-func (s *DefaultValueDto) GetImportTask() OptImportTaskDto {
-	return s.ImportTask
-}
-
-// SetDefaultValueId sets the value of DefaultValueId.
-func (s *DefaultValueDto) SetDefaultValueId(val OptInt32) {
-	s.DefaultValueId = val
-}
-
-// SetRowVersion sets the value of RowVersion.
-func (s *DefaultValueDto) SetRowVersion(val []byte) {
-	s.RowVersion = val
-}
-
 // SetImportTaskId sets the value of ImportTaskId.
-func (s *DefaultValueDto) SetImportTaskId(val OptInt32) {
+func (s *CreateImportTaskResponse) SetImportTaskId(val string) {
 	s.ImportTaskId = val
 }
 
-// SetAccessionDocKey sets the value of AccessionDocKey.
-func (s *DefaultValueDto) SetAccessionDocKey(val OptString) {
-	s.AccessionDocKey = val
-}
-
-// SetAccessionIdName sets the value of AccessionIdName.
-func (s *DefaultValueDto) SetAccessionIdName(val OptString) {
-	s.AccessionIdName = val
-}
-
-// SetInsertNodeDocKey sets the value of InsertNodeDocKey.
-func (s *DefaultValueDto) SetInsertNodeDocKey(val OptString) {
-	s.InsertNodeDocKey = val
-}
-
-// SetInsertNodeIdName sets the value of InsertNodeIdName.
-func (s *DefaultValueDto) SetInsertNodeIdName(val OptString) {
-	s.InsertNodeIdName = val
-}
-
-// SetStatus sets the value of Status.
-func (s *DefaultValueDto) SetStatus(val OptNilString) {
-	s.Status = val
-}
-
-// SetProtectionBaseDate sets the value of ProtectionBaseDate.
-func (s *DefaultValueDto) SetProtectionBaseDate(val OptNilString) {
-	s.ProtectionBaseDate = val
-}
-
-// SetProtectionCategory sets the value of ProtectionCategory.
-func (s *DefaultValueDto) SetProtectionCategory(val OptNilString) {
-	s.ProtectionCategory = val
-}
-
-// SetProtectionDuration sets the value of ProtectionDuration.
-func (s *DefaultValueDto) SetProtectionDuration(val OptNilInt32) {
-	s.ProtectionDuration = val
-}
-
-// SetMetadataCanBePublished sets the value of MetadataCanBePublished.
-func (s *DefaultValueDto) SetMetadataCanBePublished(val OptNilBool) {
-	s.MetadataCanBePublished = val
-}
-
-// SetAccessibility sets the value of Accessibility.
-func (s *DefaultValueDto) SetAccessibility(val OptNilString) {
-	s.Accessibility = val
-}
-
-// SetUsability sets the value of Usability.
-func (s *DefaultValueDto) SetUsability(val OptNilString) {
-	s.Usability = val
-}
-
-// SetPermissionType sets the value of PermissionType.
-func (s *DefaultValueDto) SetPermissionType(val OptNilString) {
-	s.PermissionType = val
-}
-
-// SetCreatedBy sets the value of CreatedBy.
-func (s *DefaultValueDto) SetCreatedBy(val OptString) {
-	s.CreatedBy = val
-}
-
-// SetCreatedOn sets the value of CreatedOn.
-func (s *DefaultValueDto) SetCreatedOn(val OptDateTime) {
-	s.CreatedOn = val
-}
-
-// SetModifiedBy sets the value of ModifiedBy.
-func (s *DefaultValueDto) SetModifiedBy(val OptNilString) {
-	s.ModifiedBy = val
-}
-
-// SetModifiedOn sets the value of ModifiedOn.
-func (s *DefaultValueDto) SetModifiedOn(val OptNilDateTime) {
-	s.ModifiedOn = val
-}
-
-// SetImportTask sets the value of ImportTask.
-func (s *DefaultValueDto) SetImportTask(val OptImportTaskDto) {
-	s.ImportTask = val
-}
-
-// Ref: #/components/schemas/DocumentDto
-type DocumentDto struct {
-	DocumentId    OptInt32         `json:"documentId"`
-	RowVersion    []byte           `json:"rowVersion"`
-	ImportTaskId  OptInt32         `json:"importTaskId"`
-	FileName      OptString        `json:"fileName"`
-	DataBlob      []byte           `json:"dataBlob"`
-	UploadDate    OptDateTime      `json:"uploadDate"`
-	XmlSourceType OptNilString     `json:"xmlSourceType"`
-	FileSize      OptInt64         `json:"fileSize"`
-	CreatedBy     OptString        `json:"createdBy"`
-	CreatedOn     OptDateTime      `json:"createdOn"`
-	ModifiedBy    OptNilString     `json:"modifiedBy"`
-	ModifiedOn    OptNilDateTime   `json:"modifiedOn"`
-	ImportTask    OptImportTaskDto `json:"importTask"`
-}
-
-// GetDocumentId returns the value of DocumentId.
-func (s *DocumentDto) GetDocumentId() OptInt32 {
-	return s.DocumentId
-}
-
-// GetRowVersion returns the value of RowVersion.
-func (s *DocumentDto) GetRowVersion() []byte {
-	return s.RowVersion
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *DocumentDto) GetImportTaskId() OptInt32 {
-	return s.ImportTaskId
-}
-
-// GetFileName returns the value of FileName.
-func (s *DocumentDto) GetFileName() OptString {
-	return s.FileName
-}
-
-// GetDataBlob returns the value of DataBlob.
-func (s *DocumentDto) GetDataBlob() []byte {
-	return s.DataBlob
-}
-
-// GetUploadDate returns the value of UploadDate.
-func (s *DocumentDto) GetUploadDate() OptDateTime {
-	return s.UploadDate
-}
-
-// GetXmlSourceType returns the value of XmlSourceType.
-func (s *DocumentDto) GetXmlSourceType() OptNilString {
-	return s.XmlSourceType
-}
-
-// GetFileSize returns the value of FileSize.
-func (s *DocumentDto) GetFileSize() OptInt64 {
-	return s.FileSize
-}
-
-// GetCreatedBy returns the value of CreatedBy.
-func (s *DocumentDto) GetCreatedBy() OptString {
-	return s.CreatedBy
-}
-
-// GetCreatedOn returns the value of CreatedOn.
-func (s *DocumentDto) GetCreatedOn() OptDateTime {
-	return s.CreatedOn
-}
-
-// GetModifiedBy returns the value of ModifiedBy.
-func (s *DocumentDto) GetModifiedBy() OptNilString {
-	return s.ModifiedBy
-}
-
-// GetModifiedOn returns the value of ModifiedOn.
-func (s *DocumentDto) GetModifiedOn() OptNilDateTime {
-	return s.ModifiedOn
-}
-
-// GetImportTask returns the value of ImportTask.
-func (s *DocumentDto) GetImportTask() OptImportTaskDto {
-	return s.ImportTask
-}
-
-// SetDocumentId sets the value of DocumentId.
-func (s *DocumentDto) SetDocumentId(val OptInt32) {
-	s.DocumentId = val
-}
-
-// SetRowVersion sets the value of RowVersion.
-func (s *DocumentDto) SetRowVersion(val []byte) {
-	s.RowVersion = val
-}
-
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *DocumentDto) SetImportTaskId(val OptInt32) {
-	s.ImportTaskId = val
-}
-
-// SetFileName sets the value of FileName.
-func (s *DocumentDto) SetFileName(val OptString) {
-	s.FileName = val
-}
-
-// SetDataBlob sets the value of DataBlob.
-func (s *DocumentDto) SetDataBlob(val []byte) {
-	s.DataBlob = val
-}
-
-// SetUploadDate sets the value of UploadDate.
-func (s *DocumentDto) SetUploadDate(val OptDateTime) {
-	s.UploadDate = val
-}
-
-// SetXmlSourceType sets the value of XmlSourceType.
-func (s *DocumentDto) SetXmlSourceType(val OptNilString) {
-	s.XmlSourceType = val
-}
-
-// SetFileSize sets the value of FileSize.
-func (s *DocumentDto) SetFileSize(val OptInt64) {
-	s.FileSize = val
-}
-
-// SetCreatedBy sets the value of CreatedBy.
-func (s *DocumentDto) SetCreatedBy(val OptString) {
-	s.CreatedBy = val
-}
-
-// SetCreatedOn sets the value of CreatedOn.
-func (s *DocumentDto) SetCreatedOn(val OptDateTime) {
-	s.CreatedOn = val
-}
-
-// SetModifiedBy sets the value of ModifiedBy.
-func (s *DocumentDto) SetModifiedBy(val OptNilString) {
-	s.ModifiedBy = val
-}
-
-// SetModifiedOn sets the value of ModifiedOn.
-func (s *DocumentDto) SetModifiedOn(val OptNilDateTime) {
-	s.ModifiedOn = val
-}
-
-// SetImportTask sets the value of ImportTask.
-func (s *DocumentDto) SetImportTask(val OptImportTaskDto) {
-	s.ImportTask = val
-}
+func (*CreateImportTaskResponse) aPIImporttasksPostRes() {}
 
 // The detailed status of an internal service used by the API.
 // Ref: #/components/schemas/HealthCheckResult
 type HealthCheckResult struct {
+	// How much time passed in querying the service status.
+	DurationMs OptFloat64 `json:"durationMs"`
 	// The name of the service.
 	Name string `json:"name"`
 	// The current status of the service.
 	Status string `json:"status"`
-	// How much time passed in querying the service status.
-	DurationMs OptFloat64 `json:"durationMs"`
+}
+
+// GetDurationMs returns the value of DurationMs.
+func (s *HealthCheckResult) GetDurationMs() OptFloat64 {
+	return s.DurationMs
 }
 
 // GetName returns the value of Name.
@@ -1126,9 +360,9 @@ func (s *HealthCheckResult) GetStatus() string {
 	return s.Status
 }
 
-// GetDurationMs returns the value of DurationMs.
-func (s *HealthCheckResult) GetDurationMs() OptFloat64 {
-	return s.DurationMs
+// SetDurationMs sets the value of DurationMs.
+func (s *HealthCheckResult) SetDurationMs(val OptFloat64) {
+	s.DurationMs = val
 }
 
 // SetName sets the value of Name.
@@ -1141,23 +375,13 @@ func (s *HealthCheckResult) SetStatus(val string) {
 	s.Status = val
 }
 
-// SetDurationMs sets the value of DurationMs.
-func (s *HealthCheckResult) SetDurationMs(val OptFloat64) {
-	s.DurationMs = val
-}
-
 // The resulting status with health details on different services.
 // Ref: #/components/schemas/HealthStatusResult
 type HealthStatusResult struct {
-	// The overall status.
-	Status string `json:"status"`
 	// A list with services and it's health statuses.
 	Checks OptNilHealthCheckResultArray `json:"checks"`
-}
-
-// GetStatus returns the value of Status.
-func (s *HealthStatusResult) GetStatus() string {
-	return s.Status
+	// The overall status.
+	Status string `json:"status"`
 }
 
 // GetChecks returns the value of Checks.
@@ -1165,14 +389,19 @@ func (s *HealthStatusResult) GetChecks() OptNilHealthCheckResultArray {
 	return s.Checks
 }
 
-// SetStatus sets the value of Status.
-func (s *HealthStatusResult) SetStatus(val string) {
-	s.Status = val
+// GetStatus returns the value of Status.
+func (s *HealthStatusResult) GetStatus() string {
+	return s.Status
 }
 
 // SetChecks sets the value of Checks.
 func (s *HealthStatusResult) SetChecks(val OptNilHealthCheckResultArray) {
 	s.Checks = val
+}
+
+// SetStatus sets the value of Status.
+func (s *HealthStatusResult) SetStatus(val string) {
+	s.Status = val
 }
 
 // Enum values:
@@ -1220,186 +449,6 @@ func (s *ImportBehaviourType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Ref: #/components/schemas/ImportDto
-type ImportDto struct {
-	ImportId               OptInt32         `json:"importId"`
-	RowVersion             []byte           `json:"rowVersion"`
-	TaskId                 OptString        `json:"taskId"`
-	ImportTaskId           OptInt32         `json:"importTaskId"`
-	Status                 OptString        `json:"status"`
-	Description            OptNilString     `json:"description"`
-	ProcessedDocumentCount OptNilInt32      `json:"processedDocumentCount"`
-	TotalDocumentCount     OptNilInt32      `json:"totalDocumentCount"`
-	ImportDate             OptNilDateTime   `json:"importDate"`
-	ImportFileBlob         OptNilByte       `json:"importFileBlob"`
-	IsSuccessful           OptBool          `json:"isSuccessful"`
-	CreatedBy              OptString        `json:"createdBy"`
-	CreatedOn              OptDateTime      `json:"createdOn"`
-	ModifiedBy             OptNilString     `json:"modifiedBy"`
-	ModifiedOn             OptNilDateTime   `json:"modifiedOn"`
-	ImportTask             OptImportTaskDto `json:"importTask"`
-}
-
-// GetImportId returns the value of ImportId.
-func (s *ImportDto) GetImportId() OptInt32 {
-	return s.ImportId
-}
-
-// GetRowVersion returns the value of RowVersion.
-func (s *ImportDto) GetRowVersion() []byte {
-	return s.RowVersion
-}
-
-// GetTaskId returns the value of TaskId.
-func (s *ImportDto) GetTaskId() OptString {
-	return s.TaskId
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *ImportDto) GetImportTaskId() OptInt32 {
-	return s.ImportTaskId
-}
-
-// GetStatus returns the value of Status.
-func (s *ImportDto) GetStatus() OptString {
-	return s.Status
-}
-
-// GetDescription returns the value of Description.
-func (s *ImportDto) GetDescription() OptNilString {
-	return s.Description
-}
-
-// GetProcessedDocumentCount returns the value of ProcessedDocumentCount.
-func (s *ImportDto) GetProcessedDocumentCount() OptNilInt32 {
-	return s.ProcessedDocumentCount
-}
-
-// GetTotalDocumentCount returns the value of TotalDocumentCount.
-func (s *ImportDto) GetTotalDocumentCount() OptNilInt32 {
-	return s.TotalDocumentCount
-}
-
-// GetImportDate returns the value of ImportDate.
-func (s *ImportDto) GetImportDate() OptNilDateTime {
-	return s.ImportDate
-}
-
-// GetImportFileBlob returns the value of ImportFileBlob.
-func (s *ImportDto) GetImportFileBlob() OptNilByte {
-	return s.ImportFileBlob
-}
-
-// GetIsSuccessful returns the value of IsSuccessful.
-func (s *ImportDto) GetIsSuccessful() OptBool {
-	return s.IsSuccessful
-}
-
-// GetCreatedBy returns the value of CreatedBy.
-func (s *ImportDto) GetCreatedBy() OptString {
-	return s.CreatedBy
-}
-
-// GetCreatedOn returns the value of CreatedOn.
-func (s *ImportDto) GetCreatedOn() OptDateTime {
-	return s.CreatedOn
-}
-
-// GetModifiedBy returns the value of ModifiedBy.
-func (s *ImportDto) GetModifiedBy() OptNilString {
-	return s.ModifiedBy
-}
-
-// GetModifiedOn returns the value of ModifiedOn.
-func (s *ImportDto) GetModifiedOn() OptNilDateTime {
-	return s.ModifiedOn
-}
-
-// GetImportTask returns the value of ImportTask.
-func (s *ImportDto) GetImportTask() OptImportTaskDto {
-	return s.ImportTask
-}
-
-// SetImportId sets the value of ImportId.
-func (s *ImportDto) SetImportId(val OptInt32) {
-	s.ImportId = val
-}
-
-// SetRowVersion sets the value of RowVersion.
-func (s *ImportDto) SetRowVersion(val []byte) {
-	s.RowVersion = val
-}
-
-// SetTaskId sets the value of TaskId.
-func (s *ImportDto) SetTaskId(val OptString) {
-	s.TaskId = val
-}
-
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *ImportDto) SetImportTaskId(val OptInt32) {
-	s.ImportTaskId = val
-}
-
-// SetStatus sets the value of Status.
-func (s *ImportDto) SetStatus(val OptString) {
-	s.Status = val
-}
-
-// SetDescription sets the value of Description.
-func (s *ImportDto) SetDescription(val OptNilString) {
-	s.Description = val
-}
-
-// SetProcessedDocumentCount sets the value of ProcessedDocumentCount.
-func (s *ImportDto) SetProcessedDocumentCount(val OptNilInt32) {
-	s.ProcessedDocumentCount = val
-}
-
-// SetTotalDocumentCount sets the value of TotalDocumentCount.
-func (s *ImportDto) SetTotalDocumentCount(val OptNilInt32) {
-	s.TotalDocumentCount = val
-}
-
-// SetImportDate sets the value of ImportDate.
-func (s *ImportDto) SetImportDate(val OptNilDateTime) {
-	s.ImportDate = val
-}
-
-// SetImportFileBlob sets the value of ImportFileBlob.
-func (s *ImportDto) SetImportFileBlob(val OptNilByte) {
-	s.ImportFileBlob = val
-}
-
-// SetIsSuccessful sets the value of IsSuccessful.
-func (s *ImportDto) SetIsSuccessful(val OptBool) {
-	s.IsSuccessful = val
-}
-
-// SetCreatedBy sets the value of CreatedBy.
-func (s *ImportDto) SetCreatedBy(val OptString) {
-	s.CreatedBy = val
-}
-
-// SetCreatedOn sets the value of CreatedOn.
-func (s *ImportDto) SetCreatedOn(val OptDateTime) {
-	s.CreatedOn = val
-}
-
-// SetModifiedBy sets the value of ModifiedBy.
-func (s *ImportDto) SetModifiedBy(val OptNilString) {
-	s.ModifiedBy = val
-}
-
-// SetModifiedOn sets the value of ModifiedOn.
-func (s *ImportDto) SetModifiedOn(val OptNilDateTime) {
-	s.ModifiedOn = val
-}
-
-// SetImportTask sets the value of ImportTask.
-func (s *ImportDto) SetImportTask(val OptImportTaskDto) {
-	s.ImportTask = val
-}
-
 // Enum values:
 // - `Erfolgreich`: The import was successfull
 // - `Fehler`: The import failed and has errors.
@@ -1445,27 +494,21 @@ func (s *ImportResult) UnmarshalText(data []byte) error {
 	}
 }
 
+// Response containing the status of an import run.
 // Ref: #/components/schemas/ImportRunStatusResponse
 type ImportRunStatusResponse struct {
-	ImportTaskId    OptInt32     `json:"importTaskId"`
-	ImportRunId     OptString    `json:"importRunId"`
-	Status          OptString    `json:"status"`
-	ProgressPercent OptNilInt32  `json:"progressPercent"`
-	Error           OptNilString `json:"error"`
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *ImportRunStatusResponse) GetImportTaskId() OptInt32 {
-	return s.ImportTaskId
-}
-
-// GetImportRunId returns the value of ImportRunId.
-func (s *ImportRunStatusResponse) GetImportRunId() OptString {
-	return s.ImportRunId
+	Status ImportStatus `json:"status"`
+	// The progress of the import run in percent (0-100), if available.
+	ProgressPercent OptNilInt32     `json:"progressPercent"`
+	ImportResult    OptImportResult `json:"importResult"`
+	// How many records were processed during the import.
+	ProcessedDocumentCount OptNilInt32 `json:"processedDocumentCount"`
+	// The total number of records to be processed during the import.
+	TotalDocumentCount OptNilInt32 `json:"totalDocumentCount"`
 }
 
 // GetStatus returns the value of Status.
-func (s *ImportRunStatusResponse) GetStatus() OptString {
+func (s *ImportRunStatusResponse) GetStatus() ImportStatus {
 	return s.Status
 }
 
@@ -1474,23 +517,23 @@ func (s *ImportRunStatusResponse) GetProgressPercent() OptNilInt32 {
 	return s.ProgressPercent
 }
 
-// GetError returns the value of Error.
-func (s *ImportRunStatusResponse) GetError() OptNilString {
-	return s.Error
+// GetImportResult returns the value of ImportResult.
+func (s *ImportRunStatusResponse) GetImportResult() OptImportResult {
+	return s.ImportResult
 }
 
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *ImportRunStatusResponse) SetImportTaskId(val OptInt32) {
-	s.ImportTaskId = val
+// GetProcessedDocumentCount returns the value of ProcessedDocumentCount.
+func (s *ImportRunStatusResponse) GetProcessedDocumentCount() OptNilInt32 {
+	return s.ProcessedDocumentCount
 }
 
-// SetImportRunId sets the value of ImportRunId.
-func (s *ImportRunStatusResponse) SetImportRunId(val OptString) {
-	s.ImportRunId = val
+// GetTotalDocumentCount returns the value of TotalDocumentCount.
+func (s *ImportRunStatusResponse) GetTotalDocumentCount() OptNilInt32 {
+	return s.TotalDocumentCount
 }
 
 // SetStatus sets the value of Status.
-func (s *ImportRunStatusResponse) SetStatus(val OptString) {
+func (s *ImportRunStatusResponse) SetStatus(val ImportStatus) {
 	s.Status = val
 }
 
@@ -1499,227 +542,131 @@ func (s *ImportRunStatusResponse) SetProgressPercent(val OptNilInt32) {
 	s.ProgressPercent = val
 }
 
-// SetError sets the value of Error.
-func (s *ImportRunStatusResponse) SetError(val OptNilString) {
-	s.Error = val
-}
-
-func (*ImportRunStatusResponse) aPIImportTasksIDImportRunsRunIdStatusGetRes() {}
-
-// Ref: #/components/schemas/ImportTaskDto
-type ImportTaskDto struct {
-	ImportTaskId              OptInt32            `json:"importTaskId"`
-	RowVersion                []byte              `json:"rowVersion"`
-	TaskType                  OptString           `json:"taskType"`
-	Name                      OptNilString        `json:"name"`
-	NoAutomaticImport         OptBool             `json:"noAutomaticImport"`
-	RequiresContainers        OptBool             `json:"requiresContainers"`
-	Status                    OptString           `json:"status"`
-	AnalysisErrorMessage      OptNilString        `json:"analysisErrorMessage"`
-	AnalysisResult            OptNilString        `json:"analysisResult"`
-	AnalysisProgressInPercent OptNilInt32         `json:"analysisProgressInPercent"`
-	ImportResult              OptNilString        `json:"importResult"`
-	CreatedBy                 OptString           `json:"createdBy"`
-	CreatedOn                 OptDateTime         `json:"createdOn"`
-	ModifiedBy                OptNilString        `json:"modifiedBy"`
-	ModifiedOn                OptNilDateTime      `json:"modifiedOn"`
-	AnalysisRecords           []AnalysisRecordDto `json:"analysisRecords"`
-	DefaultValues             []DefaultValueDto   `json:"defaultValues"`
-	Documents                 []DocumentDto       `json:"documents"`
-	Imports                   []ImportDto         `json:"imports"`
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *ImportTaskDto) GetImportTaskId() OptInt32 {
-	return s.ImportTaskId
-}
-
-// GetRowVersion returns the value of RowVersion.
-func (s *ImportTaskDto) GetRowVersion() []byte {
-	return s.RowVersion
-}
-
-// GetTaskType returns the value of TaskType.
-func (s *ImportTaskDto) GetTaskType() OptString {
-	return s.TaskType
-}
-
-// GetName returns the value of Name.
-func (s *ImportTaskDto) GetName() OptNilString {
-	return s.Name
-}
-
-// GetNoAutomaticImport returns the value of NoAutomaticImport.
-func (s *ImportTaskDto) GetNoAutomaticImport() OptBool {
-	return s.NoAutomaticImport
-}
-
-// GetRequiresContainers returns the value of RequiresContainers.
-func (s *ImportTaskDto) GetRequiresContainers() OptBool {
-	return s.RequiresContainers
-}
-
-// GetStatus returns the value of Status.
-func (s *ImportTaskDto) GetStatus() OptString {
-	return s.Status
-}
-
-// GetAnalysisErrorMessage returns the value of AnalysisErrorMessage.
-func (s *ImportTaskDto) GetAnalysisErrorMessage() OptNilString {
-	return s.AnalysisErrorMessage
-}
-
-// GetAnalysisResult returns the value of AnalysisResult.
-func (s *ImportTaskDto) GetAnalysisResult() OptNilString {
-	return s.AnalysisResult
-}
-
-// GetAnalysisProgressInPercent returns the value of AnalysisProgressInPercent.
-func (s *ImportTaskDto) GetAnalysisProgressInPercent() OptNilInt32 {
-	return s.AnalysisProgressInPercent
-}
-
-// GetImportResult returns the value of ImportResult.
-func (s *ImportTaskDto) GetImportResult() OptNilString {
-	return s.ImportResult
-}
-
-// GetCreatedBy returns the value of CreatedBy.
-func (s *ImportTaskDto) GetCreatedBy() OptString {
-	return s.CreatedBy
-}
-
-// GetCreatedOn returns the value of CreatedOn.
-func (s *ImportTaskDto) GetCreatedOn() OptDateTime {
-	return s.CreatedOn
-}
-
-// GetModifiedBy returns the value of ModifiedBy.
-func (s *ImportTaskDto) GetModifiedBy() OptNilString {
-	return s.ModifiedBy
-}
-
-// GetModifiedOn returns the value of ModifiedOn.
-func (s *ImportTaskDto) GetModifiedOn() OptNilDateTime {
-	return s.ModifiedOn
-}
-
-// GetAnalysisRecords returns the value of AnalysisRecords.
-func (s *ImportTaskDto) GetAnalysisRecords() []AnalysisRecordDto {
-	return s.AnalysisRecords
-}
-
-// GetDefaultValues returns the value of DefaultValues.
-func (s *ImportTaskDto) GetDefaultValues() []DefaultValueDto {
-	return s.DefaultValues
-}
-
-// GetDocuments returns the value of Documents.
-func (s *ImportTaskDto) GetDocuments() []DocumentDto {
-	return s.Documents
-}
-
-// GetImports returns the value of Imports.
-func (s *ImportTaskDto) GetImports() []ImportDto {
-	return s.Imports
-}
-
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *ImportTaskDto) SetImportTaskId(val OptInt32) {
-	s.ImportTaskId = val
-}
-
-// SetRowVersion sets the value of RowVersion.
-func (s *ImportTaskDto) SetRowVersion(val []byte) {
-	s.RowVersion = val
-}
-
-// SetTaskType sets the value of TaskType.
-func (s *ImportTaskDto) SetTaskType(val OptString) {
-	s.TaskType = val
-}
-
-// SetName sets the value of Name.
-func (s *ImportTaskDto) SetName(val OptNilString) {
-	s.Name = val
-}
-
-// SetNoAutomaticImport sets the value of NoAutomaticImport.
-func (s *ImportTaskDto) SetNoAutomaticImport(val OptBool) {
-	s.NoAutomaticImport = val
-}
-
-// SetRequiresContainers sets the value of RequiresContainers.
-func (s *ImportTaskDto) SetRequiresContainers(val OptBool) {
-	s.RequiresContainers = val
-}
-
-// SetStatus sets the value of Status.
-func (s *ImportTaskDto) SetStatus(val OptString) {
-	s.Status = val
-}
-
-// SetAnalysisErrorMessage sets the value of AnalysisErrorMessage.
-func (s *ImportTaskDto) SetAnalysisErrorMessage(val OptNilString) {
-	s.AnalysisErrorMessage = val
-}
-
-// SetAnalysisResult sets the value of AnalysisResult.
-func (s *ImportTaskDto) SetAnalysisResult(val OptNilString) {
-	s.AnalysisResult = val
-}
-
-// SetAnalysisProgressInPercent sets the value of AnalysisProgressInPercent.
-func (s *ImportTaskDto) SetAnalysisProgressInPercent(val OptNilInt32) {
-	s.AnalysisProgressInPercent = val
-}
-
 // SetImportResult sets the value of ImportResult.
-func (s *ImportTaskDto) SetImportResult(val OptNilString) {
+func (s *ImportRunStatusResponse) SetImportResult(val OptImportResult) {
 	s.ImportResult = val
 }
 
-// SetCreatedBy sets the value of CreatedBy.
-func (s *ImportTaskDto) SetCreatedBy(val OptString) {
-	s.CreatedBy = val
+// SetProcessedDocumentCount sets the value of ProcessedDocumentCount.
+func (s *ImportRunStatusResponse) SetProcessedDocumentCount(val OptNilInt32) {
+	s.ProcessedDocumentCount = val
 }
 
-// SetCreatedOn sets the value of CreatedOn.
-func (s *ImportTaskDto) SetCreatedOn(val OptDateTime) {
-	s.CreatedOn = val
+// SetTotalDocumentCount sets the value of TotalDocumentCount.
+func (s *ImportRunStatusResponse) SetTotalDocumentCount(val OptNilInt32) {
+	s.TotalDocumentCount = val
 }
 
-// SetModifiedBy sets the value of ModifiedBy.
-func (s *ImportTaskDto) SetModifiedBy(val OptNilString) {
-	s.ModifiedBy = val
+func (*ImportRunStatusResponse) aPIImporttasksIDImportrunsRunIdStatusGetRes() {}
+
+// Enum values:
+// - `RequestStart`
+// - `RequestCancel`
+// - `Started`
+// - `Failed`
+// - `Canceled`
+// - `Completed`
+// - `UndoStarted`
+// - `UndoCompleted`
+// - `Created`
+// - `Preparing`.
+// Ref: #/components/schemas/ImportStatus
+type ImportStatus string
+
+const (
+	ImportStatusRequestStart  ImportStatus = "RequestStart"
+	ImportStatusRequestCancel ImportStatus = "RequestCancel"
+	ImportStatusStarted       ImportStatus = "Started"
+	ImportStatusFailed        ImportStatus = "Failed"
+	ImportStatusCanceled      ImportStatus = "Canceled"
+	ImportStatusCompleted     ImportStatus = "Completed"
+	ImportStatusUndoStarted   ImportStatus = "UndoStarted"
+	ImportStatusUndoCompleted ImportStatus = "UndoCompleted"
+	ImportStatusCreated       ImportStatus = "Created"
+	ImportStatusPreparing     ImportStatus = "Preparing"
+)
+
+// AllValues returns all ImportStatus values.
+func (ImportStatus) AllValues() []ImportStatus {
+	return []ImportStatus{
+		ImportStatusRequestStart,
+		ImportStatusRequestCancel,
+		ImportStatusStarted,
+		ImportStatusFailed,
+		ImportStatusCanceled,
+		ImportStatusCompleted,
+		ImportStatusUndoStarted,
+		ImportStatusUndoCompleted,
+		ImportStatusCreated,
+		ImportStatusPreparing,
+	}
 }
 
-// SetModifiedOn sets the value of ModifiedOn.
-func (s *ImportTaskDto) SetModifiedOn(val OptNilDateTime) {
-	s.ModifiedOn = val
+// MarshalText implements encoding.TextMarshaler.
+func (s ImportStatus) MarshalText() ([]byte, error) {
+	switch s {
+	case ImportStatusRequestStart:
+		return []byte(s), nil
+	case ImportStatusRequestCancel:
+		return []byte(s), nil
+	case ImportStatusStarted:
+		return []byte(s), nil
+	case ImportStatusFailed:
+		return []byte(s), nil
+	case ImportStatusCanceled:
+		return []byte(s), nil
+	case ImportStatusCompleted:
+		return []byte(s), nil
+	case ImportStatusUndoStarted:
+		return []byte(s), nil
+	case ImportStatusUndoCompleted:
+		return []byte(s), nil
+	case ImportStatusCreated:
+		return []byte(s), nil
+	case ImportStatusPreparing:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
 }
 
-// SetAnalysisRecords sets the value of AnalysisRecords.
-func (s *ImportTaskDto) SetAnalysisRecords(val []AnalysisRecordDto) {
-	s.AnalysisRecords = val
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ImportStatus) UnmarshalText(data []byte) error {
+	switch ImportStatus(data) {
+	case ImportStatusRequestStart:
+		*s = ImportStatusRequestStart
+		return nil
+	case ImportStatusRequestCancel:
+		*s = ImportStatusRequestCancel
+		return nil
+	case ImportStatusStarted:
+		*s = ImportStatusStarted
+		return nil
+	case ImportStatusFailed:
+		*s = ImportStatusFailed
+		return nil
+	case ImportStatusCanceled:
+		*s = ImportStatusCanceled
+		return nil
+	case ImportStatusCompleted:
+		*s = ImportStatusCompleted
+		return nil
+	case ImportStatusUndoStarted:
+		*s = ImportStatusUndoStarted
+		return nil
+	case ImportStatusUndoCompleted:
+		*s = ImportStatusUndoCompleted
+		return nil
+	case ImportStatusCreated:
+		*s = ImportStatusCreated
+		return nil
+	case ImportStatusPreparing:
+		*s = ImportStatusPreparing
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
-
-// SetDefaultValues sets the value of DefaultValues.
-func (s *ImportTaskDto) SetDefaultValues(val []DefaultValueDto) {
-	s.DefaultValues = val
-}
-
-// SetDocuments sets the value of Documents.
-func (s *ImportTaskDto) SetDocuments(val []DocumentDto) {
-	s.Documents = val
-}
-
-// SetImports sets the value of Imports.
-func (s *ImportTaskDto) SetImports(val []ImportDto) {
-	s.Imports = val
-}
-
-func (*ImportTaskDto) aPIImportTasksIDPatchRes() {}
 
 // Enum values:
 // - `Neu`: The initial status of an import task
@@ -1798,19 +745,16 @@ func (s *ImportTaskStatus) UnmarshalText(data []byte) error {
 	}
 }
 
+// Response containing the status of an import task (analysis phase).
 // Ref: #/components/schemas/ImportTaskStatusResponse
 type ImportTaskStatusResponse struct {
 	Status         ImportTaskStatus  `json:"status"`
 	AnalysisResult OptAnalysisResult `json:"analysisResult"`
 	// During the analysis, this indicates the progress in percent.
-	AnalysisProgressInPercent OptNilInt32     `json:"analysisProgressInPercent"`
-	ImportResult              OptImportResult `json:"importResult"`
-	// During the import, this indicates the progress in percent.
-	ImportProgressInPercent OptNilInt32 `json:"importProgressInPercent"`
-	// How many records were processed by the import.
-	ProcessedDocumentCount OptNilInt32 `json:"processedDocumentCount"`
-	// The total number of records that should have been processed by the import.
-	TotalDocumentCount OptNilInt32 `json:"totalDocumentCount"`
+	AnalysisProgressInPercent OptNilInt32 `json:"analysisProgressInPercent"`
+	// If there was an error during the analysis, this contains the error message.
+	AnalysisErrorMessage OptNilString    `json:"analysisErrorMessage"`
+	ImportResult         OptImportResult `json:"importResult"`
 }
 
 // GetStatus returns the value of Status.
@@ -1828,24 +772,14 @@ func (s *ImportTaskStatusResponse) GetAnalysisProgressInPercent() OptNilInt32 {
 	return s.AnalysisProgressInPercent
 }
 
+// GetAnalysisErrorMessage returns the value of AnalysisErrorMessage.
+func (s *ImportTaskStatusResponse) GetAnalysisErrorMessage() OptNilString {
+	return s.AnalysisErrorMessage
+}
+
 // GetImportResult returns the value of ImportResult.
 func (s *ImportTaskStatusResponse) GetImportResult() OptImportResult {
 	return s.ImportResult
-}
-
-// GetImportProgressInPercent returns the value of ImportProgressInPercent.
-func (s *ImportTaskStatusResponse) GetImportProgressInPercent() OptNilInt32 {
-	return s.ImportProgressInPercent
-}
-
-// GetProcessedDocumentCount returns the value of ProcessedDocumentCount.
-func (s *ImportTaskStatusResponse) GetProcessedDocumentCount() OptNilInt32 {
-	return s.ProcessedDocumentCount
-}
-
-// GetTotalDocumentCount returns the value of TotalDocumentCount.
-func (s *ImportTaskStatusResponse) GetTotalDocumentCount() OptNilInt32 {
-	return s.TotalDocumentCount
 }
 
 // SetStatus sets the value of Status.
@@ -1863,58 +797,50 @@ func (s *ImportTaskStatusResponse) SetAnalysisProgressInPercent(val OptNilInt32)
 	s.AnalysisProgressInPercent = val
 }
 
+// SetAnalysisErrorMessage sets the value of AnalysisErrorMessage.
+func (s *ImportTaskStatusResponse) SetAnalysisErrorMessage(val OptNilString) {
+	s.AnalysisErrorMessage = val
+}
+
 // SetImportResult sets the value of ImportResult.
 func (s *ImportTaskStatusResponse) SetImportResult(val OptImportResult) {
 	s.ImportResult = val
 }
 
-// SetImportProgressInPercent sets the value of ImportProgressInPercent.
-func (s *ImportTaskStatusResponse) SetImportProgressInPercent(val OptNilInt32) {
-	s.ImportProgressInPercent = val
-}
+func (*ImportTaskStatusResponse) aPIImporttasksIDStatusGetRes() {}
 
-// SetProcessedDocumentCount sets the value of ProcessedDocumentCount.
-func (s *ImportTaskStatusResponse) SetProcessedDocumentCount(val OptNilInt32) {
-	s.ProcessedDocumentCount = val
-}
-
-// SetTotalDocumentCount sets the value of TotalDocumentCount.
-func (s *ImportTaskStatusResponse) SetTotalDocumentCount(val OptNilInt32) {
-	s.TotalDocumentCount = val
-}
-
-// NewOptAPIImportTasksIDImportRunsPostReq returns new OptAPIImportTasksIDImportRunsPostReq with value set to v.
-func NewOptAPIImportTasksIDImportRunsPostReq(v APIImportTasksIDImportRunsPostReq) OptAPIImportTasksIDImportRunsPostReq {
-	return OptAPIImportTasksIDImportRunsPostReq{
+// NewOptAPIImporttasksIDImportrunsPostReq returns new OptAPIImporttasksIDImportrunsPostReq with value set to v.
+func NewOptAPIImporttasksIDImportrunsPostReq(v APIImporttasksIDImportrunsPostReq) OptAPIImporttasksIDImportrunsPostReq {
+	return OptAPIImporttasksIDImportrunsPostReq{
 		Value: v,
 		Set:   true,
 	}
 }
 
-// OptAPIImportTasksIDImportRunsPostReq is optional APIImportTasksIDImportRunsPostReq.
-type OptAPIImportTasksIDImportRunsPostReq struct {
-	Value APIImportTasksIDImportRunsPostReq
+// OptAPIImporttasksIDImportrunsPostReq is optional APIImporttasksIDImportrunsPostReq.
+type OptAPIImporttasksIDImportrunsPostReq struct {
+	Value APIImporttasksIDImportrunsPostReq
 	Set   bool
 }
 
-// IsSet returns true if OptAPIImportTasksIDImportRunsPostReq was set.
-func (o OptAPIImportTasksIDImportRunsPostReq) IsSet() bool { return o.Set }
+// IsSet returns true if OptAPIImporttasksIDImportrunsPostReq was set.
+func (o OptAPIImporttasksIDImportrunsPostReq) IsSet() bool { return o.Set }
 
 // Reset unsets value.
-func (o *OptAPIImportTasksIDImportRunsPostReq) Reset() {
-	var v APIImportTasksIDImportRunsPostReq
+func (o *OptAPIImporttasksIDImportrunsPostReq) Reset() {
+	var v APIImporttasksIDImportrunsPostReq
 	o.Value = v
 	o.Set = false
 }
 
 // SetTo sets value to v.
-func (o *OptAPIImportTasksIDImportRunsPostReq) SetTo(v APIImportTasksIDImportRunsPostReq) {
+func (o *OptAPIImporttasksIDImportrunsPostReq) SetTo(v APIImporttasksIDImportrunsPostReq) {
 	o.Set = true
 	o.Value = v
 }
 
 // Get returns value and boolean that denotes whether value was set.
-func (o OptAPIImportTasksIDImportRunsPostReq) Get() (v APIImportTasksIDImportRunsPostReq, ok bool) {
+func (o OptAPIImporttasksIDImportrunsPostReq) Get() (v APIImporttasksIDImportrunsPostReq, ok bool) {
 	if !o.Set {
 		return v, false
 	}
@@ -1922,45 +848,45 @@ func (o OptAPIImportTasksIDImportRunsPostReq) Get() (v APIImportTasksIDImportRun
 }
 
 // Or returns value if set, or given parameter if does not.
-func (o OptAPIImportTasksIDImportRunsPostReq) Or(d APIImportTasksIDImportRunsPostReq) APIImportTasksIDImportRunsPostReq {
+func (o OptAPIImporttasksIDImportrunsPostReq) Or(d APIImporttasksIDImportrunsPostReq) APIImporttasksIDImportrunsPostReq {
 	if v, ok := o.Get(); ok {
 		return v
 	}
 	return d
 }
 
-// NewOptAPIImportTasksPostReq returns new OptAPIImportTasksPostReq with value set to v.
-func NewOptAPIImportTasksPostReq(v APIImportTasksPostReq) OptAPIImportTasksPostReq {
-	return OptAPIImportTasksPostReq{
+// NewOptAPIImporttasksPostReq returns new OptAPIImporttasksPostReq with value set to v.
+func NewOptAPIImporttasksPostReq(v APIImporttasksPostReq) OptAPIImporttasksPostReq {
+	return OptAPIImporttasksPostReq{
 		Value: v,
 		Set:   true,
 	}
 }
 
-// OptAPIImportTasksPostReq is optional APIImportTasksPostReq.
-type OptAPIImportTasksPostReq struct {
-	Value APIImportTasksPostReq
+// OptAPIImporttasksPostReq is optional APIImporttasksPostReq.
+type OptAPIImporttasksPostReq struct {
+	Value APIImporttasksPostReq
 	Set   bool
 }
 
-// IsSet returns true if OptAPIImportTasksPostReq was set.
-func (o OptAPIImportTasksPostReq) IsSet() bool { return o.Set }
+// IsSet returns true if OptAPIImporttasksPostReq was set.
+func (o OptAPIImporttasksPostReq) IsSet() bool { return o.Set }
 
 // Reset unsets value.
-func (o *OptAPIImportTasksPostReq) Reset() {
-	var v APIImportTasksPostReq
+func (o *OptAPIImporttasksPostReq) Reset() {
+	var v APIImporttasksPostReq
 	o.Value = v
 	o.Set = false
 }
 
 // SetTo sets value to v.
-func (o *OptAPIImportTasksPostReq) SetTo(v APIImportTasksPostReq) {
+func (o *OptAPIImporttasksPostReq) SetTo(v APIImporttasksPostReq) {
 	o.Set = true
 	o.Value = v
 }
 
 // Get returns value and boolean that denotes whether value was set.
-func (o OptAPIImportTasksPostReq) Get() (v APIImportTasksPostReq, ok bool) {
+func (o OptAPIImporttasksPostReq) Get() (v APIImporttasksPostReq, ok bool) {
 	if !o.Set {
 		return v, false
 	}
@@ -1968,7 +894,7 @@ func (o OptAPIImportTasksPostReq) Get() (v APIImportTasksPostReq, ok bool) {
 }
 
 // Or returns value if set, or given parameter if does not.
-func (o OptAPIImportTasksPostReq) Or(d APIImportTasksPostReq) APIImportTasksPostReq {
+func (o OptAPIImporttasksPostReq) Or(d APIImporttasksPostReq) APIImporttasksPostReq {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -2015,98 +941,6 @@ func (o OptAnalysisResult) Get() (v AnalysisResult, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptAnalysisResult) Or(d AnalysisResult) AnalysisResult {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptBool returns new OptBool with value set to v.
-func NewOptBool(v bool) OptBool {
-	return OptBool{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptBool is optional bool.
-type OptBool struct {
-	Value bool
-	Set   bool
-}
-
-// IsSet returns true if OptBool was set.
-func (o OptBool) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptBool) Reset() {
-	var v bool
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptBool) SetTo(v bool) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptBool) Get() (v bool, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptBool) Or(d bool) bool {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptDateTime returns new OptDateTime with value set to v.
-func NewOptDateTime(v time.Time) OptDateTime {
-	return OptDateTime{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptDateTime is optional time.Time.
-type OptDateTime struct {
-	Value time.Time
-	Set   bool
-}
-
-// IsSet returns true if OptDateTime was set.
-func (o OptDateTime) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptDateTime) Reset() {
-	var v time.Time
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptDateTime) SetTo(v time.Time) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptDateTime) Get() (v time.Time, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptDateTime) Or(d time.Time) time.Time {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -2245,333 +1079,6 @@ func (o OptImportResult) Get() (v ImportResult, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptImportResult) Or(d ImportResult) ImportResult {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptImportTaskDto returns new OptImportTaskDto with value set to v.
-func NewOptImportTaskDto(v ImportTaskDto) OptImportTaskDto {
-	return OptImportTaskDto{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptImportTaskDto is optional ImportTaskDto.
-type OptImportTaskDto struct {
-	Value ImportTaskDto
-	Set   bool
-}
-
-// IsSet returns true if OptImportTaskDto was set.
-func (o OptImportTaskDto) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptImportTaskDto) Reset() {
-	var v ImportTaskDto
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptImportTaskDto) SetTo(v ImportTaskDto) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptImportTaskDto) Get() (v ImportTaskDto, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptImportTaskDto) Or(d ImportTaskDto) ImportTaskDto {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptInt32 returns new OptInt32 with value set to v.
-func NewOptInt32(v int32) OptInt32 {
-	return OptInt32{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptInt32 is optional int32.
-type OptInt32 struct {
-	Value int32
-	Set   bool
-}
-
-// IsSet returns true if OptInt32 was set.
-func (o OptInt32) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptInt32) Reset() {
-	var v int32
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptInt32) SetTo(v int32) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptInt32) Get() (v int32, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptInt32) Or(d int32) int32 {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptInt64 returns new OptInt64 with value set to v.
-func NewOptInt64(v int64) OptInt64 {
-	return OptInt64{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptInt64 is optional int64.
-type OptInt64 struct {
-	Value int64
-	Set   bool
-}
-
-// IsSet returns true if OptInt64 was set.
-func (o OptInt64) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptInt64) Reset() {
-	var v int64
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptInt64) SetTo(v int64) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptInt64) Get() (v int64, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptInt64) Or(d int64) int64 {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptNilBool returns new OptNilBool with value set to v.
-func NewOptNilBool(v bool) OptNilBool {
-	return OptNilBool{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptNilBool is optional nullable bool.
-type OptNilBool struct {
-	Value bool
-	Set   bool
-	Null  bool
-}
-
-// IsSet returns true if OptNilBool was set.
-func (o OptNilBool) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptNilBool) Reset() {
-	var v bool
-	o.Value = v
-	o.Set = false
-	o.Null = false
-}
-
-// SetTo sets value to v.
-func (o *OptNilBool) SetTo(v bool) {
-	o.Set = true
-	o.Null = false
-	o.Value = v
-}
-
-// IsNull returns true if value is Null.
-func (o OptNilBool) IsNull() bool { return o.Null }
-
-// SetToNull sets value to null.
-func (o *OptNilBool) SetToNull() {
-	o.Set = true
-	o.Null = true
-	var v bool
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptNilBool) Get() (v bool, ok bool) {
-	if o.Null {
-		return v, false
-	}
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptNilBool) Or(d bool) bool {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptNilByte returns new OptNilByte with value set to v.
-func NewOptNilByte(v []byte) OptNilByte {
-	return OptNilByte{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptNilByte is optional nullable []byte.
-type OptNilByte struct {
-	Value []byte
-	Set   bool
-	Null  bool
-}
-
-// IsSet returns true if OptNilByte was set.
-func (o OptNilByte) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptNilByte) Reset() {
-	var v []byte
-	o.Value = v
-	o.Set = false
-	o.Null = false
-}
-
-// SetTo sets value to v.
-func (o *OptNilByte) SetTo(v []byte) {
-	o.Set = true
-	o.Null = false
-	o.Value = v
-}
-
-// IsNull returns true if value is Null.
-func (o OptNilByte) IsNull() bool { return o.Null }
-
-// SetToNull sets value to null.
-func (o *OptNilByte) SetToNull() {
-	o.Set = true
-	o.Null = true
-	var v []byte
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptNilByte) Get() (v []byte, ok bool) {
-	if o.Null {
-		return v, false
-	}
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptNilByte) Or(d []byte) []byte {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptNilDateTime returns new OptNilDateTime with value set to v.
-func NewOptNilDateTime(v time.Time) OptNilDateTime {
-	return OptNilDateTime{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptNilDateTime is optional nullable time.Time.
-type OptNilDateTime struct {
-	Value time.Time
-	Set   bool
-	Null  bool
-}
-
-// IsSet returns true if OptNilDateTime was set.
-func (o OptNilDateTime) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptNilDateTime) Reset() {
-	var v time.Time
-	o.Value = v
-	o.Set = false
-	o.Null = false
-}
-
-// SetTo sets value to v.
-func (o *OptNilDateTime) SetTo(v time.Time) {
-	o.Set = true
-	o.Null = false
-	o.Value = v
-}
-
-// IsNull returns true if value is Null.
-func (o OptNilDateTime) IsNull() bool { return o.Null }
-
-// SetToNull sets value to null.
-func (o *OptNilDateTime) SetToNull() {
-	o.Set = true
-	o.Null = true
-	var v time.Time
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptNilDateTime) Get() (v time.Time, ok bool) {
-	if o.Null {
-		return v, false
-	}
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptNilDateTime) Or(d time.Time) time.Time {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -2767,144 +1274,6 @@ func (o OptNilString) Or(d string) string {
 	return d
 }
 
-// NewOptString returns new OptString with value set to v.
-func NewOptString(v string) OptString {
-	return OptString{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptString is optional string.
-type OptString struct {
-	Value string
-	Set   bool
-}
-
-// IsSet returns true if OptString was set.
-func (o OptString) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptString) Reset() {
-	var v string
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptString) SetTo(v string) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptString) Get() (v string, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptString) Or(d string) string {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptUUID returns new OptUUID with value set to v.
-func NewOptUUID(v uuid.UUID) OptUUID {
-	return OptUUID{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptUUID is optional uuid.UUID.
-type OptUUID struct {
-	Value uuid.UUID
-	Set   bool
-}
-
-// IsSet returns true if OptUUID was set.
-func (o OptUUID) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptUUID) Reset() {
-	var v uuid.UUID
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptUUID) SetTo(v uuid.UUID) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptUUID) Get() (v uuid.UUID, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptUUID) Or(d uuid.UUID) uuid.UUID {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptValidationProblemDetailsErrors returns new OptValidationProblemDetailsErrors with value set to v.
-func NewOptValidationProblemDetailsErrors(v ValidationProblemDetailsErrors) OptValidationProblemDetailsErrors {
-	return OptValidationProblemDetailsErrors{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptValidationProblemDetailsErrors is optional ValidationProblemDetailsErrors.
-type OptValidationProblemDetailsErrors struct {
-	Value ValidationProblemDetailsErrors
-	Set   bool
-}
-
-// IsSet returns true if OptValidationProblemDetailsErrors was set.
-func (o OptValidationProblemDetailsErrors) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptValidationProblemDetailsErrors) Reset() {
-	var v ValidationProblemDetailsErrors
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptValidationProblemDetailsErrors) SetTo(v ValidationProblemDetailsErrors) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptValidationProblemDetailsErrors) Get() (v ValidationProblemDetailsErrors, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptValidationProblemDetailsErrors) Or(d ValidationProblemDetailsErrors) ValidationProblemDetailsErrors {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // Ref: #/components/schemas/ProblemDetails
 type ProblemDetails struct {
 	Type            OptNilString `json:"type"`
@@ -2974,8 +1343,6 @@ func (s *ProblemDetails) SetInstance(val OptNilString) {
 func (s *ProblemDetails) SetAdditionalProps(val ProblemDetailsAdditional) {
 	s.AdditionalProps = val
 }
-
-func (*ProblemDetails) aPIImportTasksPostRes() {}
 
 type ProblemDetailsAdditional map[string]jx.Raw
 
@@ -3072,109 +1439,4 @@ func (s *Smart) SetToken(val string) {
 // SetRoles sets the value of Roles.
 func (s *Smart) SetRoles(val []string) {
 	s.Roles = val
-}
-
-// Ref: #/components/schemas/ValidationProblemDetails
-type ValidationProblemDetails struct {
-	Type            OptNilString                      `json:"type"`
-	Title           OptNilString                      `json:"title"`
-	Status          OptNilInt32                       `json:"status"`
-	Detail          OptNilString                      `json:"detail"`
-	Instance        OptNilString                      `json:"instance"`
-	Errors          OptValidationProblemDetailsErrors `json:"errors"`
-	AdditionalProps ValidationProblemDetailsAdditional
-}
-
-// GetType returns the value of Type.
-func (s *ValidationProblemDetails) GetType() OptNilString {
-	return s.Type
-}
-
-// GetTitle returns the value of Title.
-func (s *ValidationProblemDetails) GetTitle() OptNilString {
-	return s.Title
-}
-
-// GetStatus returns the value of Status.
-func (s *ValidationProblemDetails) GetStatus() OptNilInt32 {
-	return s.Status
-}
-
-// GetDetail returns the value of Detail.
-func (s *ValidationProblemDetails) GetDetail() OptNilString {
-	return s.Detail
-}
-
-// GetInstance returns the value of Instance.
-func (s *ValidationProblemDetails) GetInstance() OptNilString {
-	return s.Instance
-}
-
-// GetErrors returns the value of Errors.
-func (s *ValidationProblemDetails) GetErrors() OptValidationProblemDetailsErrors {
-	return s.Errors
-}
-
-// GetAdditionalProps returns the value of AdditionalProps.
-func (s *ValidationProblemDetails) GetAdditionalProps() ValidationProblemDetailsAdditional {
-	return s.AdditionalProps
-}
-
-// SetType sets the value of Type.
-func (s *ValidationProblemDetails) SetType(val OptNilString) {
-	s.Type = val
-}
-
-// SetTitle sets the value of Title.
-func (s *ValidationProblemDetails) SetTitle(val OptNilString) {
-	s.Title = val
-}
-
-// SetStatus sets the value of Status.
-func (s *ValidationProblemDetails) SetStatus(val OptNilInt32) {
-	s.Status = val
-}
-
-// SetDetail sets the value of Detail.
-func (s *ValidationProblemDetails) SetDetail(val OptNilString) {
-	s.Detail = val
-}
-
-// SetInstance sets the value of Instance.
-func (s *ValidationProblemDetails) SetInstance(val OptNilString) {
-	s.Instance = val
-}
-
-// SetErrors sets the value of Errors.
-func (s *ValidationProblemDetails) SetErrors(val OptValidationProblemDetailsErrors) {
-	s.Errors = val
-}
-
-// SetAdditionalProps sets the value of AdditionalProps.
-func (s *ValidationProblemDetails) SetAdditionalProps(val ValidationProblemDetailsAdditional) {
-	s.AdditionalProps = val
-}
-
-func (*ValidationProblemDetails) aPIImportTasksIDImportRunsPostRes() {}
-
-type ValidationProblemDetailsAdditional map[string]jx.Raw
-
-func (s *ValidationProblemDetailsAdditional) init() ValidationProblemDetailsAdditional {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
-type ValidationProblemDetailsErrors map[string][]string
-
-func (s *ValidationProblemDetailsErrors) init() ValidationProblemDetailsErrors {
-	m := *s
-	if m == nil {
-		m = map[string][]string{}
-		*s = m
-	}
-	return m
 }

--- a/hack/apis-mock/internal/gen/oas_security_gen.go
+++ b/hack/apis-mock/internal/gen/oas_security_gen.go
@@ -36,11 +36,11 @@ func findAuthorization(h http.Header, prefix string) (string, bool) {
 // operationRolesSmart is a private map storing roles per operation.
 var operationRolesSmart = map[string][]string{
 	APIHealthzGetOperation:                            []string{},
-	APIImportTasksIDImportRunsPostOperation:           []string{},
-	APIImportTasksIDImportRunsRunIdStatusGetOperation: []string{},
-	APIImportTasksIDPatchOperation:                    []string{},
-	APIImportTasksIDStatusGetOperation:                []string{},
-	APIImportTasksPostOperation:                       []string{},
+	APIImporttasksIDCancelPostOperation:               []string{},
+	APIImporttasksIDImportrunsPostOperation:           []string{},
+	APIImporttasksIDImportrunsRunIdStatusGetOperation: []string{},
+	APIImporttasksIDStatusGetOperation:                []string{},
+	APIImporttasksPostOperation:                       []string{},
 }
 
 // GetRolesForSmart returns the required roles for the given operation.

--- a/hack/apis-mock/internal/gen/oas_server_gen.go
+++ b/hack/apis-mock/internal/gen/oas_server_gen.go
@@ -8,43 +8,45 @@ import (
 
 // Handler handles operations described by OpenAPI v3 specification.
 type Handler interface {
-	// APIHealthzGet implements GET /api/Healthz operation.
+	// APIHealthzGet implements GET /api/healthz operation.
 	//
 	// Get health status information.
 	//
-	// GET /api/Healthz
+	// GET /api/healthz
 	APIHealthzGet(ctx context.Context) (APIHealthzGetRes, error)
-	// APIImportTasksIDImportRunsPost implements POST /api/ImportTasks/{id}/importRuns operation.
+	// APIImporttasksIDCancelPost implements POST /api/importtasks/{id}/cancel operation.
+	//
+	// Cancels an existing import task.
+	//
+	// POST /api/importtasks/{id}/cancel
+	APIImporttasksIDCancelPost(ctx context.Context, req APIImporttasksIDCancelPostReq, params APIImporttasksIDCancelPostParams) (APIImporttasksIDCancelPostRes, error)
+	// APIImporttasksIDImportrunsPost implements POST /api/importtasks/{id}/importruns operation.
 	//
 	// Starts a new import run for the given import task.
 	// Creates a new import execution ("run") resource.
 	//
-	// POST /api/ImportTasks/{id}/importRuns
-	APIImportTasksIDImportRunsPost(ctx context.Context, req OptAPIImportTasksIDImportRunsPostReq, params APIImportTasksIDImportRunsPostParams) (APIImportTasksIDImportRunsPostRes, error)
-	// APIImportTasksIDImportRunsRunIdStatusGet implements GET /api/ImportTasks/{id}/importRuns/{runId}/status operation.
+	// POST /api/importtasks/{id}/importruns
+	APIImporttasksIDImportrunsPost(ctx context.Context, req OptAPIImporttasksIDImportrunsPostReq, params APIImporttasksIDImportrunsPostParams) (APIImporttasksIDImportrunsPostRes, error)
+	// APIImporttasksIDImportrunsRunIdStatusGet implements GET /api/importtasks/{id}/importruns/{runId}/status operation.
 	//
-	// Gets the status of a specific import run.
+	// If the import has started in ACTApro (TaskId is present), the status is fetched from ACTApro.
+	// Otherwise, the local status from the database is returned.
 	//
-	// GET /api/ImportTasks/{id}/importRuns/{runId}/status
-	APIImportTasksIDImportRunsRunIdStatusGet(ctx context.Context, params APIImportTasksIDImportRunsRunIdStatusGetParams) (APIImportTasksIDImportRunsRunIdStatusGetRes, error)
-	// APIImportTasksIDPatch implements PATCH /api/ImportTasks/{id} operation.
+	// GET /api/importtasks/{id}/importruns/{runId}/status
+	APIImporttasksIDImportrunsRunIdStatusGet(ctx context.Context, params APIImporttasksIDImportrunsRunIdStatusGetParams) (APIImporttasksIDImportrunsRunIdStatusGetRes, error)
+	// APIImporttasksIDStatusGet implements GET /api/importtasks/{id}/status operation.
 	//
-	// Updates the status of an existing import task.
+	// This endpoint returns the status of the import task analysis phase only.
+	// For import run progress and results, use the import run status endpoint.
 	//
-	// PATCH /api/ImportTasks/{id}
-	APIImportTasksIDPatch(ctx context.Context, req APIImportTasksIDPatchReq, params APIImportTasksIDPatchParams) (APIImportTasksIDPatchRes, error)
-	// APIImportTasksIDStatusGet implements GET /api/ImportTasks/{id}/status operation.
-	//
-	// Query the status of an ongoing analysis or import.
-	//
-	// GET /api/ImportTasks/{id}/status
-	APIImportTasksIDStatusGet(ctx context.Context, params APIImportTasksIDStatusGetParams) (*ImportTaskStatusResponse, error)
-	// APIImportTasksPost implements POST /api/ImportTasks operation.
+	// GET /api/importtasks/{id}/status
+	APIImporttasksIDStatusGet(ctx context.Context, params APIImporttasksIDStatusGetParams) (APIImporttasksIDStatusGetRes, error)
+	// APIImporttasksPost implements POST /api/importtasks operation.
 	//
 	// Creates a new import task.
 	//
-	// POST /api/ImportTasks
-	APIImportTasksPost(ctx context.Context, req OptAPIImportTasksPostReq) (APIImportTasksPostRes, error)
+	// POST /api/importtasks
+	APIImporttasksPost(ctx context.Context, req OptAPIImporttasksPostReq) (APIImporttasksPostRes, error)
 }
 
 // Server implements http server based on OpenAPI v3 specification and

--- a/hack/apis-mock/internal/gen/oas_unimplemented_gen.go
+++ b/hack/apis-mock/internal/gen/oas_unimplemented_gen.go
@@ -13,57 +13,59 @@ type UnimplementedHandler struct{}
 
 var _ Handler = UnimplementedHandler{}
 
-// APIHealthzGet implements GET /api/Healthz operation.
+// APIHealthzGet implements GET /api/healthz operation.
 //
 // Get health status information.
 //
-// GET /api/Healthz
+// GET /api/healthz
 func (UnimplementedHandler) APIHealthzGet(ctx context.Context) (r APIHealthzGetRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 
-// APIImportTasksIDImportRunsPost implements POST /api/ImportTasks/{id}/importRuns operation.
+// APIImporttasksIDCancelPost implements POST /api/importtasks/{id}/cancel operation.
+//
+// Cancels an existing import task.
+//
+// POST /api/importtasks/{id}/cancel
+func (UnimplementedHandler) APIImporttasksIDCancelPost(ctx context.Context, req APIImporttasksIDCancelPostReq, params APIImporttasksIDCancelPostParams) (r APIImporttasksIDCancelPostRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// APIImporttasksIDImportrunsPost implements POST /api/importtasks/{id}/importruns operation.
 //
 // Starts a new import run for the given import task.
 // Creates a new import execution ("run") resource.
 //
-// POST /api/ImportTasks/{id}/importRuns
-func (UnimplementedHandler) APIImportTasksIDImportRunsPost(ctx context.Context, req OptAPIImportTasksIDImportRunsPostReq, params APIImportTasksIDImportRunsPostParams) (r APIImportTasksIDImportRunsPostRes, _ error) {
+// POST /api/importtasks/{id}/importruns
+func (UnimplementedHandler) APIImporttasksIDImportrunsPost(ctx context.Context, req OptAPIImporttasksIDImportrunsPostReq, params APIImporttasksIDImportrunsPostParams) (r APIImporttasksIDImportrunsPostRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 
-// APIImportTasksIDImportRunsRunIdStatusGet implements GET /api/ImportTasks/{id}/importRuns/{runId}/status operation.
+// APIImporttasksIDImportrunsRunIdStatusGet implements GET /api/importtasks/{id}/importruns/{runId}/status operation.
 //
-// Gets the status of a specific import run.
+// If the import has started in ACTApro (TaskId is present), the status is fetched from ACTApro.
+// Otherwise, the local status from the database is returned.
 //
-// GET /api/ImportTasks/{id}/importRuns/{runId}/status
-func (UnimplementedHandler) APIImportTasksIDImportRunsRunIdStatusGet(ctx context.Context, params APIImportTasksIDImportRunsRunIdStatusGetParams) (r APIImportTasksIDImportRunsRunIdStatusGetRes, _ error) {
+// GET /api/importtasks/{id}/importruns/{runId}/status
+func (UnimplementedHandler) APIImporttasksIDImportrunsRunIdStatusGet(ctx context.Context, params APIImporttasksIDImportrunsRunIdStatusGetParams) (r APIImporttasksIDImportrunsRunIdStatusGetRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 
-// APIImportTasksIDPatch implements PATCH /api/ImportTasks/{id} operation.
+// APIImporttasksIDStatusGet implements GET /api/importtasks/{id}/status operation.
 //
-// Updates the status of an existing import task.
+// This endpoint returns the status of the import task analysis phase only.
+// For import run progress and results, use the import run status endpoint.
 //
-// PATCH /api/ImportTasks/{id}
-func (UnimplementedHandler) APIImportTasksIDPatch(ctx context.Context, req APIImportTasksIDPatchReq, params APIImportTasksIDPatchParams) (r APIImportTasksIDPatchRes, _ error) {
+// GET /api/importtasks/{id}/status
+func (UnimplementedHandler) APIImporttasksIDStatusGet(ctx context.Context, params APIImporttasksIDStatusGetParams) (r APIImporttasksIDStatusGetRes, _ error) {
 	return r, ht.ErrNotImplemented
 }
 
-// APIImportTasksIDStatusGet implements GET /api/ImportTasks/{id}/status operation.
-//
-// Query the status of an ongoing analysis or import.
-//
-// GET /api/ImportTasks/{id}/status
-func (UnimplementedHandler) APIImportTasksIDStatusGet(ctx context.Context, params APIImportTasksIDStatusGetParams) (r *ImportTaskStatusResponse, _ error) {
-	return r, ht.ErrNotImplemented
-}
-
-// APIImportTasksPost implements POST /api/ImportTasks operation.
+// APIImporttasksPost implements POST /api/importtasks operation.
 //
 // Creates a new import task.
 //
-// POST /api/ImportTasks
-func (UnimplementedHandler) APIImportTasksPost(ctx context.Context, req OptAPIImportTasksPostReq) (r APIImportTasksPostRes, _ error) {
+// POST /api/importtasks
+func (UnimplementedHandler) APIImporttasksPost(ctx context.Context, req OptAPIImporttasksPostReq) (r APIImporttasksPostRes, _ error) {
 	return r, ht.ErrNotImplemented
 }

--- a/hack/apis-mock/internal/gen/oas_validators_gen.go
+++ b/hack/apis-mock/internal/gen/oas_validators_gen.go
@@ -25,7 +25,7 @@ func (s *APIHealthzGetServiceUnavailable) Validate() error {
 	return nil
 }
 
-func (s *APIImportTasksIDImportRunsPostReq) Validate() error {
+func (s *APIImporttasksIDImportrunsPostReq) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
 	}
@@ -55,7 +55,7 @@ func (s *APIImportTasksIDImportRunsPostReq) Validate() error {
 	return nil
 }
 
-func (s *APIImportTasksPostReq) Validate() error {
+func (s *APIImporttasksPostReq) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
 	}
@@ -91,52 +91,6 @@ func (s AnalysisResult) Validate() error {
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
-}
-
-func (s *CancelImportTaskRequest) Validate() error {
-	if s == nil {
-		return validate.ErrNilPointer
-	}
-
-	var failures []validate.FieldError
-	if err := func() error {
-		if err := s.Status.Validate(); err != nil {
-			return err
-		}
-		return nil
-	}(); err != nil {
-		failures = append(failures, validate.FieldError{
-			Name:  "status",
-			Error: err,
-		})
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-	return nil
-}
-
-func (s *CancelImportTaskRequestWithContentType) Validate() error {
-	if s == nil {
-		return validate.ErrNilPointer
-	}
-
-	var failures []validate.FieldError
-	if err := func() error {
-		if err := s.Content.Validate(); err != nil {
-			return err
-		}
-		return nil
-	}(); err != nil {
-		failures = append(failures, validate.FieldError{
-			Name:  "Content",
-			Error: err,
-		})
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-	return nil
 }
 
 func (s *HealthCheckResult) Validate() error {
@@ -238,6 +192,74 @@ func (s ImportResult) Validate() error {
 	}
 }
 
+func (s *ImportRunStatusResponse) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Status.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "status",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.ImportResult.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "importResult",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ImportStatus) Validate() error {
+	switch s {
+	case "RequestStart":
+		return nil
+	case "RequestCancel":
+		return nil
+	case "Started":
+		return nil
+	case "Failed":
+		return nil
+	case "Canceled":
+		return nil
+	case "Completed":
+		return nil
+	case "UndoStarted":
+		return nil
+	case "UndoCompleted":
+		return nil
+	case "Created":
+		return nil
+	case "Preparing":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
 func (s ImportTaskStatus) Validate() error {
 	switch s {
 	case "Neu":
@@ -329,56 +351,4 @@ func (s SipType) Validate() error {
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
-}
-
-func (s *ValidationProblemDetails) Validate() error {
-	if s == nil {
-		return validate.ErrNilPointer
-	}
-
-	var failures []validate.FieldError
-	if err := func() error {
-		if value, ok := s.Errors.Get(); ok {
-			if err := func() error {
-				if err := value.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return err
-			}
-		}
-		return nil
-	}(); err != nil {
-		failures = append(failures, validate.FieldError{
-			Name:  "errors",
-			Error: err,
-		})
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-	return nil
-}
-
-func (s ValidationProblemDetailsErrors) Validate() error {
-	var failures []validate.FieldError
-	for key, elem := range s {
-		if err := func() error {
-			if elem == nil {
-				return errors.New("nil is invalid value")
-			}
-			return nil
-		}(); err != nil {
-			failures = append(failures, validate.FieldError{
-				Name:  key,
-				Error: err,
-			})
-		}
-	}
-
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-	return nil
 }

--- a/hack/apis-mock/internal/mock/server.go
+++ b/hack/apis-mock/internal/mock/server.go
@@ -42,7 +42,6 @@ type Handler struct {
 // taskState stores the minimal in-memory state for an APIS import task.
 type taskState struct {
 	id             string
-	seqID          int32
 	name           string
 	createdBy      string
 	createdAt      time.Time
@@ -64,16 +63,16 @@ func NewHandler() *Handler {
 // APIHealthzGet is left unimplemented because the preprocessing
 // integration work only depends on the import-task endpoints.
 func (h *Handler) APIHealthzGet(_ context.Context) (gen.APIHealthzGetRes, error) {
-	return nil, errors.New("not implemented")
+	return &gen.APIHealthzGetOK{Status: "OK"}, nil
 }
 
-// APIImportTasksPost creates one in-memory task with a predetermined analysis
+// APIImporttasksPost creates one in-memory task with a predetermined analysis
 // outcome. Later polling simply walks that task through the expected APIS
 // lifecycle until the terminal result becomes visible.
-func (h *Handler) APIImportTasksPost(
+func (h *Handler) APIImporttasksPost(
 	_ context.Context,
-	req gen.OptAPIImportTasksPostReq,
-) (gen.APIImportTasksPostRes, error) {
+	req gen.OptAPIImporttasksPostReq,
+) (gen.APIImporttasksPostRes, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -81,7 +80,6 @@ func (h *Handler) APIImportTasksPost(
 	taskID := fmt.Sprintf("task-%06d", h.nextTask)
 	task := &taskState{
 		id:             taskID,
-		seqID:          int32(h.nextTask),
 		createdAt:      time.Now().UTC(),
 		status:         gen.ImportTaskStatusNeu,
 		analysisResult: gen.AnalysisResultAlleNeu,
@@ -98,39 +96,31 @@ func (h *Handler) APIImportTasksPost(
 
 	h.tasks[taskID] = task
 
-	return &gen.APIImportTasksPostCreated{
-		Success: gen.NewOptBool(true),
-		ID:      gen.NewOptNilString(taskID),
+	return &gen.CreateImportTaskResponse{
+		ImportTaskId: taskID,
 	}, nil
 }
 
-// APIImportTasksIDPatch only supports the cancellation transition used by the
+// APIImporttasksIDCancelPost only supports the cancellation transition used by the
 // preprocessing conflict flow.
-func (h *Handler) APIImportTasksIDPatch(
+func (h *Handler) APIImporttasksIDCancelPost(
 	_ context.Context,
-	req gen.APIImportTasksIDPatchReq,
-	params gen.APIImportTasksIDPatchParams,
-) (gen.APIImportTasksIDPatchRes, error) {
+	_ gen.APIImporttasksIDCancelPostReq,
+	params gen.APIImporttasksIDCancelPostParams,
+) (gen.APIImporttasksIDCancelPostRes, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	task, ok := h.tasks[params.ID]
 	if !ok {
-		notFound := gen.APIImportTasksIDPatchNotFound(
+		notFound := gen.APIImporttasksIDCancelPostNotFound(
 			problem(404, "Not Found", "import task does not exist"),
 		)
 		return &notFound, nil
 	}
 
-	status, ok := patchStatus(req)
-	if !ok || status != gen.ImportTaskStatusAbgebrochen {
-		conflict := gen.APIImportTasksIDPatchConflict(
-			problem(409, "Conflict", "only status=Abgebrochen can be applied"),
-		)
-		return &conflict, nil
-	}
 	if task.status == gen.ImportTaskStatusImportiert {
-		conflict := gen.APIImportTasksIDPatchConflict(
+		conflict := gen.APIImporttasksIDCancelPostConflict(
 			problem(409, "Conflict", "cannot cancel an already imported task"),
 		)
 		return &conflict, nil
@@ -138,54 +128,38 @@ func (h *Handler) APIImportTasksIDPatch(
 
 	task.status = gen.ImportTaskStatusAbgebrochen
 
-	return taskDTO(task), nil
+	return &gen.APIImporttasksIDCancelPostNoContent{}, nil
 }
 
-// APIImportTasksIDImportRunsPost starts the import phase after a successful
+// APIImporttasksIDImportrunsPost starts the import phase after a successful
 // analysis result. The POST itself only allocates the run; subsequent polling
 // on the task status endpoint exposes the import lifecycle.
-func (h *Handler) APIImportTasksIDImportRunsPost(
+func (h *Handler) APIImporttasksIDImportrunsPost(
 	_ context.Context,
-	req gen.OptAPIImportTasksIDImportRunsPostReq,
-	params gen.APIImportTasksIDImportRunsPostParams,
-) (gen.APIImportTasksIDImportRunsPostRes, error) {
+	req gen.OptAPIImporttasksIDImportrunsPostReq,
+	params gen.APIImporttasksIDImportrunsPostParams,
+) (gen.APIImporttasksIDImportrunsPostRes, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	task, ok := h.tasks[params.ID]
 	if !ok {
-		notFound := gen.APIImportTasksIDImportRunsPostNotFound(
+		notFound := gen.APIImporttasksIDImportrunsPostNotFound(
 			problem(404, "Not Found", "import task does not exist"),
 		)
 		return &notFound, nil
 	}
 	if task.status == gen.ImportTaskStatusAbgebrochen {
-		return validationProblem(
-			"cannot create import run for canceled task",
-			"status",
-			"task is canceled",
-		), nil
+		return badRequest("cannot create import run for canceled task"), nil
 	}
 	if task.status != gen.ImportTaskStatusAnalysiert {
-		return validationProblem(
-			"cannot create import run before analysis has finished",
-			"status",
-			"task analysis is still running",
-		), nil
+		return badRequest("cannot create import run before analysis has finished"), nil
 	}
 	if task.analysisResult != gen.AnalysisResultAlleNeu && task.analysisResult != gen.AnalysisResultAlleGleich {
-		return validationProblem(
-			"cannot create import run for this analysis result",
-			"analysisResult",
-			string(task.analysisResult),
-		), nil
+		return badRequest("cannot create import run for this analysis result"), nil
 	}
 	if task.runID != "" {
-		return validationProblem(
-			"cannot create a second import run for the same task",
-			"status",
-			"task already has an import run",
-		), nil
+		return badRequest("cannot create a second import run for the same task"), nil
 	}
 
 	h.nextRun++
@@ -201,32 +175,30 @@ func (h *Handler) APIImportTasksIDImportRunsPost(
 	}
 
 	return &gen.CreateImportRunResponse{
-		Success:      gen.NewOptBool(true),
-		ImportTaskId: gen.NewOptString(task.id),
-		ImportRunId:  gen.NewOptNilString(runID),
+		ImportRunId: runID,
 	}, nil
 }
 
-// APIImportTasksIDImportRunsRunIdStatusGet mirrors the current import phase in
+// APIImporttasksIDImportrunsRunIdStatusGet mirrors the current import phase in
 // the lighter-weight run-specific vocabulary from the spec. It never advances
 // state on its own; the task status endpoint remains the single lifecycle
 // driver for the mock.
-func (h *Handler) APIImportTasksIDImportRunsRunIdStatusGet(
+func (h *Handler) APIImporttasksIDImportrunsRunIdStatusGet(
 	_ context.Context,
-	params gen.APIImportTasksIDImportRunsRunIdStatusGetParams,
-) (gen.APIImportTasksIDImportRunsRunIdStatusGetRes, error) {
+	params gen.APIImporttasksIDImportrunsRunIdStatusGetParams,
+) (gen.APIImporttasksIDImportrunsRunIdStatusGetRes, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	task, ok := h.tasks[params.ID]
 	if !ok {
-		notFound := gen.APIImportTasksIDImportRunsRunIdStatusGetNotFound(
+		notFound := gen.APIImporttasksIDImportrunsRunIdStatusGetNotFound(
 			problem(404, "Not Found", "import task does not exist"),
 		)
 		return &notFound, nil
 	}
 	if task.runID == "" || task.runID != params.RunId {
-		notFound := gen.APIImportTasksIDImportRunsRunIdStatusGetNotFound(
+		notFound := gen.APIImporttasksIDImportrunsRunIdStatusGetNotFound(
 			problem(404, "Not Found", "import run does not exist"),
 		)
 		return &notFound, nil
@@ -235,41 +207,30 @@ func (h *Handler) APIImportTasksIDImportRunsRunIdStatusGet(
 	return importRunStatusResponse(task), nil
 }
 
-// APIImportTasksIDStatusGet is the canonical lifecycle endpoint for the mock.
+// APIImporttasksIDStatusGet is the canonical lifecycle endpoint for the mock.
 // Each poll advances analysis or import by one deterministic step because the
 // real integration also treats this endpoint as the main source of truth.
 //
-// The shared spec only models a 200 response here. The mock still fails fast
-// for unknown task IDs instead of fabricating a happy-path task because that
-// catches worker bugs earlier during development.
-func (h *Handler) APIImportTasksIDStatusGet(
+// The mock still returns a proper 404 response for unknown task IDs instead of
+// fabricating a happy-path task because that catches worker bugs earlier.
+func (h *Handler) APIImporttasksIDStatusGet(
 	_ context.Context,
-	params gen.APIImportTasksIDStatusGetParams,
-) (*gen.ImportTaskStatusResponse, error) {
+	params gen.APIImporttasksIDStatusGetParams,
+) (gen.APIImporttasksIDStatusGetRes, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	task, ok := h.tasks[params.ID]
 	if !ok {
-		return nil, fmt.Errorf("import task does not exist: %s", params.ID)
+		notFound := gen.APIImporttasksIDStatusGetNotFound(
+			problem(404, "Not Found", "import task does not exist"),
+		)
+		return &notFound, nil
 	}
 
 	advanceTask(task)
 
 	return taskStatusResponse(task), nil
-}
-
-// patchStatus extracts the requested task status from either generated PATCH
-// request wrapper used by ogen.
-func patchStatus(req gen.APIImportTasksIDPatchReq) (gen.ImportTaskStatus, bool) {
-	switch t := req.(type) {
-	case *gen.CancelImportTaskRequest:
-		return t.Status, true
-	case *gen.CancelImportTaskRequestWithContentType:
-		return t.Content.Status, true
-	default:
-		return "", false
-	}
 }
 
 // advanceTask encodes the smallest state machine that still matches the flows
@@ -311,59 +272,23 @@ func taskStatusResponse(task *taskState) *gen.ImportTaskStatusResponse {
 // importRunStatusResponse projects task import state onto the run status
 // endpoint for callers that still want a run-specific view.
 func importRunStatusResponse(task *taskState) *gen.ImportRunStatusResponse {
-	status := "Neu"
+	res := &gen.ImportRunStatusResponse{Status: gen.ImportStatusCreated}
 
 	switch task.status {
 	case gen.ImportTaskStatusAbgebrochen:
-		status = "Abgebrochen"
+		res.Status = gen.ImportStatusCanceled
 	case gen.ImportTaskStatusWirdImportiert:
-		status = "WirdImportiert"
+		res.Status = gen.ImportStatusStarted
 	case gen.ImportTaskStatusImportiert:
 		if task.importResult == gen.ImportResultFehler {
-			status = "Fehler"
+			res.Status = gen.ImportStatusFailed
 		} else {
-			status = "Abgeschlossen"
+			res.Status = gen.ImportStatusCompleted
 		}
-	}
-
-	res := &gen.ImportRunStatusResponse{
-		ImportTaskId: gen.NewOptInt32(task.seqID),
-		ImportRunId:  gen.NewOptString(task.runID),
-		Status:       gen.NewOptString(status),
-	}
-	if status == "Fehler" {
-		res.Error = gen.NewOptNilString("mock import failed")
+		res.ImportResult = gen.NewOptImportResult(task.importResult)
 	}
 
 	return res
-}
-
-// taskDTO builds the narrow PATCH response payload needed by clients after a
-// cancellation request.
-func taskDTO(task *taskState) *gen.ImportTaskDto {
-	dto := &gen.ImportTaskDto{
-		ImportTaskId:       gen.NewOptInt32(task.seqID),
-		RowVersion:         []byte{},
-		TaskType:           gen.NewOptString("MockImportTask"),
-		Name:               gen.NewOptNilString(task.name),
-		NoAutomaticImport:  gen.NewOptBool(false),
-		RequiresContainers: gen.NewOptBool(false),
-		Status:             gen.NewOptString(string(task.status)),
-		CreatedBy:          gen.NewOptString(task.createdBy),
-		CreatedOn:          gen.NewOptDateTime(task.createdAt),
-		AnalysisRecords:    []gen.AnalysisRecordDto{},
-		DefaultValues:      []gen.DefaultValueDto{},
-		Documents:          []gen.DocumentDto{},
-		Imports:            []gen.ImportDto{},
-	}
-	if task.analysisDone {
-		dto.AnalysisResult = gen.NewOptNilString(string(task.analysisResult))
-	}
-	if task.importDone {
-		dto.ImportResult = gen.NewOptNilString(string(task.importResult))
-	}
-
-	return dto
 }
 
 // problem builds the common RFC 7807-style response payloads used by the
@@ -376,16 +301,11 @@ func problem(status int32, title, detail string) gen.ProblemDetails {
 	}
 }
 
-// validationProblem returns the field-oriented 400 response shape generated
-// from the APIS spec for rejected import-run requests.
-func validationProblem(detail, field, message string) *gen.ValidationProblemDetails {
-	return &gen.ValidationProblemDetails{
+func badRequest(detail string) *gen.APIImporttasksIDImportrunsPostBadRequest {
+	return &gen.APIImporttasksIDImportrunsPostBadRequest{
 		Status: gen.NewOptNilInt32(400),
 		Title:  gen.NewOptNilString("Bad Request"),
 		Detail: gen.NewOptNilString(detail),
-		Errors: gen.NewOptValidationProblemDetailsErrors(
-			gen.ValidationProblemDetailsErrors{field: {message}},
-		),
 	}
 }
 

--- a/hack/apis-mock/internal/mock/server_test.go
+++ b/hack/apis-mock/internal/mock/server_test.go
@@ -3,9 +3,7 @@ package mock_test
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
 	ogenhttp "github.com/ogen-go/ogen/http"
 	"gotest.tools/v3/assert"
 
@@ -37,9 +35,7 @@ func TestTaskStatusDrivesAnalysisAndImportLifecycle(t *testing.T) {
 	runID := createRun(t, ctx, h, taskID, "METS.xml", "")
 	runStatus := getImportRunStatus(t, ctx, h, taskID, runID)
 	assert.DeepEqual(t, runStatus, &gen.ImportRunStatusResponse{
-		Status:       gen.NewOptString("WirdImportiert"),
-		ImportTaskId: gen.NewOptInt32(1),
-		ImportRunId:  gen.NewOptString("run-000001"),
+		Status: gen.ImportStatusStarted,
 	})
 
 	status = getTaskStatus(t, ctx, h, taskID)
@@ -50,9 +46,7 @@ func TestTaskStatusDrivesAnalysisAndImportLifecycle(t *testing.T) {
 
 	runStatus = getImportRunStatus(t, ctx, h, taskID, runID)
 	assert.DeepEqual(t, runStatus, &gen.ImportRunStatusResponse{
-		Status:       gen.NewOptString("WirdImportiert"),
-		ImportTaskId: gen.NewOptInt32(1),
-		ImportRunId:  gen.NewOptString("run-000001"),
+		Status: gen.ImportStatusStarted,
 	})
 
 	status = getTaskStatus(t, ctx, h, taskID)
@@ -64,9 +58,8 @@ func TestTaskStatusDrivesAnalysisAndImportLifecycle(t *testing.T) {
 
 	runStatus = getImportRunStatus(t, ctx, h, taskID, runID)
 	assert.DeepEqual(t, runStatus, &gen.ImportRunStatusResponse{
-		Status:       gen.NewOptString("Abgeschlossen"),
-		ImportTaskId: gen.NewOptInt32(1),
-		ImportRunId:  gen.NewOptString("run-000001"),
+		Status:       gen.ImportStatusCompleted,
+		ImportResult: gen.NewOptImportResult(gen.ImportResultErfolgreich),
 	})
 }
 
@@ -83,28 +76,13 @@ func TestConflictTaskCanBeCancelled(t *testing.T) {
 		AnalysisResult: gen.NewOptAnalysisResult(gen.AnalysisResultKonflikte),
 	})
 
-	patchRes, err := h.APIImportTasksIDPatch(
+	cancelRes, err := h.APIImporttasksIDCancelPost(
 		ctx,
-		&gen.CancelImportTaskRequest{Status: gen.ImportTaskStatusAbgebrochen},
-		gen.APIImportTasksIDPatchParams{ID: taskID},
+		&gen.CancelImportTaskRequest{},
+		gen.APIImporttasksIDCancelPostParams{ID: taskID},
 	)
 	assert.NilError(t, err)
-	assert.DeepEqual(t, patchRes, &gen.ImportTaskDto{
-		Status:             gen.NewOptString(string(gen.ImportTaskStatusAbgebrochen)),
-		AnalysisResult:     gen.NewOptNilString(string(gen.AnalysisResultKonflikte)),
-		ImportTaskId:       gen.NewOptInt32(1),
-		RowVersion:         []uint8{},
-		TaskType:           gen.NewOptString("MockImportTask"),
-		Name:               gen.NewOptNilString("metadata-mock-konflikte.xml"),
-		NoAutomaticImport:  gen.NewOptBool(false),
-		RequiresContainers: gen.NewOptBool(false),
-		CreatedBy:          gen.NewOptString("dev@example.com"),
-		CreatedOn:          gen.NewOptDateTime(time.Now()),
-		AnalysisRecords:    []gen.AnalysisRecordDto{},
-		DefaultValues:      []gen.DefaultValueDto{},
-		Documents:          []gen.DocumentDto{},
-		Imports:            []gen.ImportDto{},
-	}, cmpopts.EquateApproxTime(time.Second))
+	assert.DeepEqual(t, cancelRes, &gen.APIImporttasksIDCancelPostNoContent{})
 
 	status = getTaskStatus(t, ctx, h, taskID)
 	assert.DeepEqual(t, status, &gen.ImportTaskStatusResponse{
@@ -112,21 +90,18 @@ func TestConflictTaskCanBeCancelled(t *testing.T) {
 		AnalysisResult: gen.NewOptAnalysisResult(gen.AnalysisResultKonflikte),
 	})
 
-	runRes, err := h.APIImportTasksIDImportRunsPost(
+	runRes, err := h.APIImporttasksIDImportrunsPost(
 		ctx,
-		gen.NewOptAPIImportTasksIDImportRunsPostReq(gen.APIImportTasksIDImportRunsPostReq{
+		gen.NewOptAPIImporttasksIDImportrunsPostReq(gen.APIImporttasksIDImportrunsPostReq{
 			File: ogenhttp.MultipartFile{Name: "METS.xml"},
 		}),
-		gen.APIImportTasksIDImportRunsPostParams{ID: taskID},
+		gen.APIImporttasksIDImportrunsPostParams{ID: taskID},
 	)
 	assert.NilError(t, err)
-	assert.DeepEqual(t, runRes, &gen.ValidationProblemDetails{
+	assert.DeepEqual(t, runRes, &gen.APIImporttasksIDImportrunsPostBadRequest{
 		Title:  gen.NewOptNilString("Bad Request"),
 		Status: gen.NewOptNilInt32(400),
 		Detail: gen.NewOptNilString("cannot create import run for canceled task"),
-		Errors: gen.NewOptValidationProblemDetailsErrors(
-			gen.ValidationProblemDetailsErrors{"status": {"task is canceled"}},
-		),
 	})
 }
 
@@ -150,10 +125,8 @@ func TestImportFailureIsSurfacedThroughTaskStatus(t *testing.T) {
 
 	runStatus := getImportRunStatus(t, ctx, h, taskID, runID)
 	assert.DeepEqual(t, runStatus, &gen.ImportRunStatusResponse{
-		Status:       gen.NewOptString("Fehler"),
-		ImportTaskId: gen.NewOptInt32(1),
-		ImportRunId:  gen.NewOptString("run-000001"),
-		Error:        gen.NewOptNilString("mock import failed"),
+		Status:       gen.ImportStatusFailed,
+		ImportResult: gen.NewOptImportResult(gen.ImportResultFehler),
 	})
 }
 
@@ -161,25 +134,30 @@ func TestPatchUnknownTaskReturnsNotFound(t *testing.T) {
 	ctx := t.Context()
 	h := mock.NewHandler()
 
-	res, err := h.APIImportTasksIDPatch(
+	res, err := h.APIImporttasksIDCancelPost(
 		ctx,
-		&gen.CancelImportTaskRequest{Status: gen.ImportTaskStatusAbgebrochen},
-		gen.APIImportTasksIDPatchParams{ID: "missing"},
+		&gen.CancelImportTaskRequest{},
+		gen.APIImporttasksIDCancelPostParams{ID: "missing"},
 	)
 	assert.NilError(t, err)
-	assert.DeepEqual(t, res, &gen.APIImportTasksIDPatchNotFound{
+	assert.DeepEqual(t, res, &gen.APIImporttasksIDCancelPostNotFound{
 		Title:  gen.NewOptNilString("Not Found"),
 		Status: gen.NewOptNilInt32(404),
 		Detail: gen.NewOptNilString("import task does not exist"),
 	})
 }
 
-func TestStatusUnknownTaskReturnsError(t *testing.T) {
+func TestStatusUnknownTaskReturnsNotFound(t *testing.T) {
 	ctx := t.Context()
 	h := mock.NewHandler()
 
-	_, err := h.APIImportTasksIDStatusGet(ctx, gen.APIImportTasksIDStatusGetParams{ID: "missing"})
-	assert.Error(t, err, "import task does not exist: missing")
+	res, err := h.APIImporttasksIDStatusGet(ctx, gen.APIImporttasksIDStatusGetParams{ID: "missing"})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, res, &gen.APIImporttasksIDStatusGetNotFound{
+		Title:  gen.NewOptNilString("Not Found"),
+		Status: gen.NewOptNilInt32(404),
+		Detail: gen.NewOptNilString("import task does not exist"),
+	})
 }
 
 func TestSecurityHandlerTokenValidation(t *testing.T) {
@@ -196,18 +174,17 @@ func TestSecurityHandlerTokenValidation(t *testing.T) {
 func createTask(t *testing.T, ctx context.Context, h *mock.Handler, filename, username string) string {
 	t.Helper()
 
-	res, err := h.APIImportTasksPost(ctx, gen.NewOptAPIImportTasksPostReq(gen.APIImportTasksPostReq{
+	res, err := h.APIImporttasksPost(ctx, gen.NewOptAPIImporttasksPostReq(gen.APIImporttasksPostReq{
 		File:     ogenhttp.MultipartFile{Name: filename},
 		SipType:  gen.SipTypeBornDigitalSIP,
 		Username: username,
 	}))
 	assert.NilError(t, err)
-	assert.DeepEqual(t, res, &gen.APIImportTasksPostCreated{
-		ID:      gen.NewOptNilString("task-000001"),
-		Success: gen.NewOptBool(true),
+	assert.DeepEqual(t, res, &gen.CreateImportTaskResponse{
+		ImportTaskId: "task-000001",
 	})
 
-	return res.(*gen.APIImportTasksPostCreated).ID.Value
+	return res.(*gen.CreateImportTaskResponse).ImportTaskId
 }
 
 func createRun(
@@ -220,26 +197,24 @@ func createRun(
 ) string {
 	t.Helper()
 
-	req := gen.APIImportTasksIDImportRunsPostReq{
+	req := gen.APIImporttasksIDImportrunsPostReq{
 		File: ogenhttp.MultipartFile{Name: filename},
 	}
 	if behaviour != "" {
 		req.ImportBehaviour = gen.NewOptImportBehaviourType(behaviour)
 	}
 
-	res, err := h.APIImportTasksIDImportRunsPost(
+	res, err := h.APIImporttasksIDImportrunsPost(
 		ctx,
-		gen.NewOptAPIImportTasksIDImportRunsPostReq(req),
-		gen.APIImportTasksIDImportRunsPostParams{ID: taskID},
+		gen.NewOptAPIImporttasksIDImportrunsPostReq(req),
+		gen.APIImporttasksIDImportrunsPostParams{ID: taskID},
 	)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, res, &gen.CreateImportRunResponse{
-		ImportTaskId: gen.NewOptString("task-000001"),
-		ImportRunId:  gen.NewOptNilString("run-000001"),
-		Success:      gen.NewOptBool(true),
+		ImportRunId: "run-000001",
 	})
 
-	return res.(*gen.CreateImportRunResponse).ImportRunId.Value
+	return res.(*gen.CreateImportRunResponse).ImportRunId
 }
 
 func getTaskStatus(
@@ -250,10 +225,13 @@ func getTaskStatus(
 ) *gen.ImportTaskStatusResponse {
 	t.Helper()
 
-	res, err := h.APIImportTasksIDStatusGet(ctx, gen.APIImportTasksIDStatusGetParams{ID: taskID})
+	res, err := h.APIImporttasksIDStatusGet(ctx, gen.APIImporttasksIDStatusGetParams{ID: taskID})
 	assert.NilError(t, err)
 
-	return res
+	status, ok := res.(*gen.ImportTaskStatusResponse)
+	assert.Assert(t, ok, "expected import task status response, got %T", res)
+
+	return status
 }
 
 func getImportRunStatus(
@@ -264,7 +242,7 @@ func getImportRunStatus(
 ) *gen.ImportRunStatusResponse {
 	t.Helper()
 
-	res, err := h.APIImportTasksIDImportRunsRunIdStatusGet(ctx, gen.APIImportTasksIDImportRunsRunIdStatusGetParams{
+	res, err := h.APIImporttasksIDImportrunsRunIdStatusGet(ctx, gen.APIImporttasksIDImportrunsRunIdStatusGetParams{
 		ID:    taskID,
 		RunId: runID,
 	})

--- a/internal/apis/create_import_task_activity.go
+++ b/internal/apis/create_import_task_activity.go
@@ -53,7 +53,7 @@ func (a *CreateImportTaskActivity) Execute(
 		return nil, temporal.NewNonRetryableError(fmt.Errorf("invalid SIP type %q: %v", params.SIP.Type, err))
 	}
 
-	req := gen.APIImportTasksPostReq{
+	req := gen.APIImporttasksPostReq{
 		File: ogenhttp.MultipartFile{
 			Name: filepath.Base(params.SIP.MetadataPath),
 			File: metadata,
@@ -61,45 +61,37 @@ func (a *CreateImportTaskActivity) Execute(
 		SipType:  sipType,
 		Username: params.Username,
 	}
-	res, err := a.client.APIImportTasksPost(ctx, gen.NewOptAPIImportTasksPostReq(req))
+	res, err := a.client.APIImporttasksPost(ctx, gen.NewOptAPIImporttasksPostReq(req))
 	if err != nil {
 		return nil, fmt.Errorf("create APIS import task: %v", err)
 	}
 
 	switch t := res.(type) {
-	case *gen.APIImportTasksPostCreated:
-		taskID, ok := t.ID.Get()
-		if !ok || taskID == "" {
+	case *gen.CreateImportTaskResponse:
+		if t.ImportTaskId == "" {
 			return nil, temporal.NewNonRetryableError(fmt.Errorf(
 				"create APIS import task: missing task ID in created response",
 			))
 		}
-		return &CreateImportTaskResult{TaskID: taskID}, nil
-	case *gen.APIImportTasksPostBadRequest:
+		return &CreateImportTaskResult{TaskID: t.ImportTaskId}, nil
+	case *gen.APIImporttasksPostBadRequest:
 		return nil, temporal.NewNonRetryableError(fmt.Errorf(
 			"create APIS import task: bad request: %s",
-			createImportTaskResponseError((*gen.CreateImportTaskResponse)(t)),
+			problemDetail(t.Detail),
 		))
-	case *gen.APIImportTasksPostUnsupportedMediaType:
+	case *gen.APIImporttasksPostUnsupportedMediaType:
 		return nil, temporal.NewNonRetryableError(fmt.Errorf(
 			"create APIS import task: unsupported media type: %s",
-			createImportTaskResponseError((*gen.CreateImportTaskResponse)(t)),
+			problemDetail(t.Detail),
 		))
-	case *gen.APIImportTasksPostInternalServerError:
+	case *gen.APIImporttasksPostInternalServerError:
 		return nil, fmt.Errorf(
 			"create APIS import task: server error: %s",
-			createImportTaskResponseError((*gen.CreateImportTaskResponse)(t)),
+			problemDetail(t.Detail),
 		)
-	case *gen.ProblemDetails:
+	case *gen.APIImporttasksPostUnauthorized:
 		return nil, temporal.NewNonRetryableError(fmt.Errorf("create APIS import task: unauthorized"))
 	default:
 		return nil, temporal.NewNonRetryableError(fmt.Errorf("create APIS import task: unexpected response"))
 	}
-}
-
-func createImportTaskResponseError(res *gen.CreateImportTaskResponse) string {
-	if errMsg, ok := res.Error.Get(); ok && errMsg != "" {
-		return errMsg
-	}
-	return "no additional details"
 }

--- a/internal/apis/create_import_task_activity_test.go
+++ b/internal/apis/create_import_task_activity_test.go
@@ -50,8 +50,8 @@ func TestCreateImportTaskActivity(t *testing.T) {
 				Username: "archivist@example.com",
 			},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksPost(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ context.Context, req apisgen.OptAPIImportTasksPostReq) (apisgen.APIImportTasksPostRes, error) {
+				m.APIImporttasksPost(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, req apisgen.OptAPIImporttasksPostReq) (apisgen.APIImporttasksPostRes, error) {
 						payload, ok := req.Get()
 						assert.Assert(t, ok)
 						assert.Equal(t, payload.Username, "archivist@example.com")
@@ -62,9 +62,8 @@ func TestCreateImportTaskActivity(t *testing.T) {
 						assert.NilError(t, err)
 						assert.Equal(t, string(body), "metadata-body")
 
-						res := apisgen.APIImportTasksPostCreated{
-							Success: apisgen.NewOptBool(true),
-							ID:      apisgen.NewOptNilString("task-000001"),
+						res := apisgen.CreateImportTaskResponse{
+							ImportTaskId: "task-000001",
 						}
 						return &res, nil
 					},
@@ -78,15 +77,14 @@ func TestCreateImportTaskActivity(t *testing.T) {
 				SIP: sipValue,
 			},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksPost(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ context.Context, req apisgen.OptAPIImportTasksPostReq) (apisgen.APIImportTasksPostRes, error) {
+				m.APIImporttasksPost(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, req apisgen.OptAPIImporttasksPostReq) (apisgen.APIImporttasksPostRes, error) {
 						payload, ok := req.Get()
 						assert.Assert(t, ok)
 						assert.Equal(t, payload.Username, "")
 
-						res := apisgen.APIImportTasksPostCreated{
-							Success: apisgen.NewOptBool(true),
-							ID:      apisgen.NewOptNilString("task-000002"),
+						res := apisgen.CreateImportTaskResponse{
+							ImportTaskId: "task-000002",
 						}
 						return &res, nil
 					},
@@ -100,10 +98,9 @@ func TestCreateImportTaskActivity(t *testing.T) {
 				SIP: sipValue,
 			},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksPost(gomock.Any(), gomock.Any()).Return(
-					&apisgen.APIImportTasksPostBadRequest{
-						Success: apisgen.NewOptBool(false),
-						Error:   apisgen.NewOptNilString("invalid payload"),
+				m.APIImporttasksPost(gomock.Any(), gomock.Any()).Return(
+					&apisgen.APIImporttasksPostBadRequest{
+						Detail: apisgen.NewOptNilString("invalid payload"),
 					},
 					nil,
 				)
@@ -116,8 +113,8 @@ func TestCreateImportTaskActivity(t *testing.T) {
 				SIP: sipValue,
 			},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksPost(gomock.Any(), gomock.Any()).Return(
-					&apisgen.ProblemDetails{Detail: apisgen.NewOptNilString("unauthorized")},
+				m.APIImporttasksPost(gomock.Any(), gomock.Any()).Return(
+					&apisgen.APIImporttasksPostUnauthorized{Detail: apisgen.NewOptNilString("unauthorized")},
 					nil,
 				)
 			},
@@ -129,7 +126,7 @@ func TestCreateImportTaskActivity(t *testing.T) {
 				SIP: sipValue,
 			},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksPost(gomock.Any(), gomock.Any()).Return(nil, errors.New("error from client"))
+				m.APIImporttasksPost(gomock.Any(), gomock.Any()).Return(nil, errors.New("error from client"))
 			},
 			wantErr: "create APIS import task: error from client",
 		},

--- a/internal/apis/fake/mock_client.go
+++ b/internal/apis/fake/mock_client.go
@@ -80,197 +80,197 @@ func (c *MockClientAPIHealthzGetCall) DoAndReturn(f func(context.Context) (gen.A
 	return c
 }
 
-// APIImportTasksIDImportRunsPost mocks base method.
-func (m *MockClient) APIImportTasksIDImportRunsPost(ctx context.Context, request gen.OptAPIImportTasksIDImportRunsPostReq, params gen.APIImportTasksIDImportRunsPostParams) (gen.APIImportTasksIDImportRunsPostRes, error) {
+// APIImporttasksIDCancelPost mocks base method.
+func (m *MockClient) APIImporttasksIDCancelPost(ctx context.Context, request gen.APIImporttasksIDCancelPostReq, params gen.APIImporttasksIDCancelPostParams) (gen.APIImporttasksIDCancelPostRes, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIImportTasksIDImportRunsPost", ctx, request, params)
-	ret0, _ := ret[0].(gen.APIImportTasksIDImportRunsPostRes)
+	ret := m.ctrl.Call(m, "APIImporttasksIDCancelPost", ctx, request, params)
+	ret0, _ := ret[0].(gen.APIImporttasksIDCancelPostRes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// APIImportTasksIDImportRunsPost indicates an expected call of APIImportTasksIDImportRunsPost.
-func (mr *MockClientMockRecorder) APIImportTasksIDImportRunsPost(ctx, request, params any) *MockClientAPIImportTasksIDImportRunsPostCall {
+// APIImporttasksIDCancelPost indicates an expected call of APIImporttasksIDCancelPost.
+func (mr *MockClientMockRecorder) APIImporttasksIDCancelPost(ctx, request, params any) *MockClientAPIImporttasksIDCancelPostCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIImportTasksIDImportRunsPost", reflect.TypeOf((*MockClient)(nil).APIImportTasksIDImportRunsPost), ctx, request, params)
-	return &MockClientAPIImportTasksIDImportRunsPostCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIImporttasksIDCancelPost", reflect.TypeOf((*MockClient)(nil).APIImporttasksIDCancelPost), ctx, request, params)
+	return &MockClientAPIImporttasksIDCancelPostCall{Call: call}
 }
 
-// MockClientAPIImportTasksIDImportRunsPostCall wrap *gomock.Call
-type MockClientAPIImportTasksIDImportRunsPostCall struct {
+// MockClientAPIImporttasksIDCancelPostCall wrap *gomock.Call
+type MockClientAPIImporttasksIDCancelPostCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClientAPIImportTasksIDImportRunsPostCall) Return(arg0 gen.APIImportTasksIDImportRunsPostRes, arg1 error) *MockClientAPIImportTasksIDImportRunsPostCall {
+func (c *MockClientAPIImporttasksIDCancelPostCall) Return(arg0 gen.APIImporttasksIDCancelPostRes, arg1 error) *MockClientAPIImporttasksIDCancelPostCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientAPIImportTasksIDImportRunsPostCall) Do(f func(context.Context, gen.OptAPIImportTasksIDImportRunsPostReq, gen.APIImportTasksIDImportRunsPostParams) (gen.APIImportTasksIDImportRunsPostRes, error)) *MockClientAPIImportTasksIDImportRunsPostCall {
+func (c *MockClientAPIImporttasksIDCancelPostCall) Do(f func(context.Context, gen.APIImporttasksIDCancelPostReq, gen.APIImporttasksIDCancelPostParams) (gen.APIImporttasksIDCancelPostRes, error)) *MockClientAPIImporttasksIDCancelPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientAPIImportTasksIDImportRunsPostCall) DoAndReturn(f func(context.Context, gen.OptAPIImportTasksIDImportRunsPostReq, gen.APIImportTasksIDImportRunsPostParams) (gen.APIImportTasksIDImportRunsPostRes, error)) *MockClientAPIImportTasksIDImportRunsPostCall {
+func (c *MockClientAPIImporttasksIDCancelPostCall) DoAndReturn(f func(context.Context, gen.APIImporttasksIDCancelPostReq, gen.APIImporttasksIDCancelPostParams) (gen.APIImporttasksIDCancelPostRes, error)) *MockClientAPIImporttasksIDCancelPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// APIImportTasksIDImportRunsRunIdStatusGet mocks base method.
-func (m *MockClient) APIImportTasksIDImportRunsRunIdStatusGet(ctx context.Context, params gen.APIImportTasksIDImportRunsRunIdStatusGetParams) (gen.APIImportTasksIDImportRunsRunIdStatusGetRes, error) {
+// APIImporttasksIDImportrunsPost mocks base method.
+func (m *MockClient) APIImporttasksIDImportrunsPost(ctx context.Context, request gen.OptAPIImporttasksIDImportrunsPostReq, params gen.APIImporttasksIDImportrunsPostParams) (gen.APIImporttasksIDImportrunsPostRes, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIImportTasksIDImportRunsRunIdStatusGet", ctx, params)
-	ret0, _ := ret[0].(gen.APIImportTasksIDImportRunsRunIdStatusGetRes)
+	ret := m.ctrl.Call(m, "APIImporttasksIDImportrunsPost", ctx, request, params)
+	ret0, _ := ret[0].(gen.APIImporttasksIDImportrunsPostRes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// APIImportTasksIDImportRunsRunIdStatusGet indicates an expected call of APIImportTasksIDImportRunsRunIdStatusGet.
-func (mr *MockClientMockRecorder) APIImportTasksIDImportRunsRunIdStatusGet(ctx, params any) *MockClientAPIImportTasksIDImportRunsRunIdStatusGetCall {
+// APIImporttasksIDImportrunsPost indicates an expected call of APIImporttasksIDImportrunsPost.
+func (mr *MockClientMockRecorder) APIImporttasksIDImportrunsPost(ctx, request, params any) *MockClientAPIImporttasksIDImportrunsPostCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIImportTasksIDImportRunsRunIdStatusGet", reflect.TypeOf((*MockClient)(nil).APIImportTasksIDImportRunsRunIdStatusGet), ctx, params)
-	return &MockClientAPIImportTasksIDImportRunsRunIdStatusGetCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIImporttasksIDImportrunsPost", reflect.TypeOf((*MockClient)(nil).APIImporttasksIDImportrunsPost), ctx, request, params)
+	return &MockClientAPIImporttasksIDImportrunsPostCall{Call: call}
 }
 
-// MockClientAPIImportTasksIDImportRunsRunIdStatusGetCall wrap *gomock.Call
-type MockClientAPIImportTasksIDImportRunsRunIdStatusGetCall struct {
+// MockClientAPIImporttasksIDImportrunsPostCall wrap *gomock.Call
+type MockClientAPIImporttasksIDImportrunsPostCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClientAPIImportTasksIDImportRunsRunIdStatusGetCall) Return(arg0 gen.APIImportTasksIDImportRunsRunIdStatusGetRes, arg1 error) *MockClientAPIImportTasksIDImportRunsRunIdStatusGetCall {
+func (c *MockClientAPIImporttasksIDImportrunsPostCall) Return(arg0 gen.APIImporttasksIDImportrunsPostRes, arg1 error) *MockClientAPIImporttasksIDImportrunsPostCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientAPIImportTasksIDImportRunsRunIdStatusGetCall) Do(f func(context.Context, gen.APIImportTasksIDImportRunsRunIdStatusGetParams) (gen.APIImportTasksIDImportRunsRunIdStatusGetRes, error)) *MockClientAPIImportTasksIDImportRunsRunIdStatusGetCall {
+func (c *MockClientAPIImporttasksIDImportrunsPostCall) Do(f func(context.Context, gen.OptAPIImporttasksIDImportrunsPostReq, gen.APIImporttasksIDImportrunsPostParams) (gen.APIImporttasksIDImportrunsPostRes, error)) *MockClientAPIImporttasksIDImportrunsPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientAPIImportTasksIDImportRunsRunIdStatusGetCall) DoAndReturn(f func(context.Context, gen.APIImportTasksIDImportRunsRunIdStatusGetParams) (gen.APIImportTasksIDImportRunsRunIdStatusGetRes, error)) *MockClientAPIImportTasksIDImportRunsRunIdStatusGetCall {
+func (c *MockClientAPIImporttasksIDImportrunsPostCall) DoAndReturn(f func(context.Context, gen.OptAPIImporttasksIDImportrunsPostReq, gen.APIImporttasksIDImportrunsPostParams) (gen.APIImporttasksIDImportrunsPostRes, error)) *MockClientAPIImporttasksIDImportrunsPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// APIImportTasksIDPatch mocks base method.
-func (m *MockClient) APIImportTasksIDPatch(ctx context.Context, request gen.APIImportTasksIDPatchReq, params gen.APIImportTasksIDPatchParams) (gen.APIImportTasksIDPatchRes, error) {
+// APIImporttasksIDImportrunsRunIdStatusGet mocks base method.
+func (m *MockClient) APIImporttasksIDImportrunsRunIdStatusGet(ctx context.Context, params gen.APIImporttasksIDImportrunsRunIdStatusGetParams) (gen.APIImporttasksIDImportrunsRunIdStatusGetRes, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIImportTasksIDPatch", ctx, request, params)
-	ret0, _ := ret[0].(gen.APIImportTasksIDPatchRes)
+	ret := m.ctrl.Call(m, "APIImporttasksIDImportrunsRunIdStatusGet", ctx, params)
+	ret0, _ := ret[0].(gen.APIImporttasksIDImportrunsRunIdStatusGetRes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// APIImportTasksIDPatch indicates an expected call of APIImportTasksIDPatch.
-func (mr *MockClientMockRecorder) APIImportTasksIDPatch(ctx, request, params any) *MockClientAPIImportTasksIDPatchCall {
+// APIImporttasksIDImportrunsRunIdStatusGet indicates an expected call of APIImporttasksIDImportrunsRunIdStatusGet.
+func (mr *MockClientMockRecorder) APIImporttasksIDImportrunsRunIdStatusGet(ctx, params any) *MockClientAPIImporttasksIDImportrunsRunIdStatusGetCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIImportTasksIDPatch", reflect.TypeOf((*MockClient)(nil).APIImportTasksIDPatch), ctx, request, params)
-	return &MockClientAPIImportTasksIDPatchCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIImporttasksIDImportrunsRunIdStatusGet", reflect.TypeOf((*MockClient)(nil).APIImporttasksIDImportrunsRunIdStatusGet), ctx, params)
+	return &MockClientAPIImporttasksIDImportrunsRunIdStatusGetCall{Call: call}
 }
 
-// MockClientAPIImportTasksIDPatchCall wrap *gomock.Call
-type MockClientAPIImportTasksIDPatchCall struct {
+// MockClientAPIImporttasksIDImportrunsRunIdStatusGetCall wrap *gomock.Call
+type MockClientAPIImporttasksIDImportrunsRunIdStatusGetCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClientAPIImportTasksIDPatchCall) Return(arg0 gen.APIImportTasksIDPatchRes, arg1 error) *MockClientAPIImportTasksIDPatchCall {
+func (c *MockClientAPIImporttasksIDImportrunsRunIdStatusGetCall) Return(arg0 gen.APIImporttasksIDImportrunsRunIdStatusGetRes, arg1 error) *MockClientAPIImporttasksIDImportrunsRunIdStatusGetCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientAPIImportTasksIDPatchCall) Do(f func(context.Context, gen.APIImportTasksIDPatchReq, gen.APIImportTasksIDPatchParams) (gen.APIImportTasksIDPatchRes, error)) *MockClientAPIImportTasksIDPatchCall {
+func (c *MockClientAPIImporttasksIDImportrunsRunIdStatusGetCall) Do(f func(context.Context, gen.APIImporttasksIDImportrunsRunIdStatusGetParams) (gen.APIImporttasksIDImportrunsRunIdStatusGetRes, error)) *MockClientAPIImporttasksIDImportrunsRunIdStatusGetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientAPIImportTasksIDPatchCall) DoAndReturn(f func(context.Context, gen.APIImportTasksIDPatchReq, gen.APIImportTasksIDPatchParams) (gen.APIImportTasksIDPatchRes, error)) *MockClientAPIImportTasksIDPatchCall {
+func (c *MockClientAPIImporttasksIDImportrunsRunIdStatusGetCall) DoAndReturn(f func(context.Context, gen.APIImporttasksIDImportrunsRunIdStatusGetParams) (gen.APIImporttasksIDImportrunsRunIdStatusGetRes, error)) *MockClientAPIImporttasksIDImportrunsRunIdStatusGetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// APIImportTasksIDStatusGet mocks base method.
-func (m *MockClient) APIImportTasksIDStatusGet(ctx context.Context, params gen.APIImportTasksIDStatusGetParams) (*gen.ImportTaskStatusResponse, error) {
+// APIImporttasksIDStatusGet mocks base method.
+func (m *MockClient) APIImporttasksIDStatusGet(ctx context.Context, params gen.APIImporttasksIDStatusGetParams) (gen.APIImporttasksIDStatusGetRes, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIImportTasksIDStatusGet", ctx, params)
-	ret0, _ := ret[0].(*gen.ImportTaskStatusResponse)
+	ret := m.ctrl.Call(m, "APIImporttasksIDStatusGet", ctx, params)
+	ret0, _ := ret[0].(gen.APIImporttasksIDStatusGetRes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// APIImportTasksIDStatusGet indicates an expected call of APIImportTasksIDStatusGet.
-func (mr *MockClientMockRecorder) APIImportTasksIDStatusGet(ctx, params any) *MockClientAPIImportTasksIDStatusGetCall {
+// APIImporttasksIDStatusGet indicates an expected call of APIImporttasksIDStatusGet.
+func (mr *MockClientMockRecorder) APIImporttasksIDStatusGet(ctx, params any) *MockClientAPIImporttasksIDStatusGetCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIImportTasksIDStatusGet", reflect.TypeOf((*MockClient)(nil).APIImportTasksIDStatusGet), ctx, params)
-	return &MockClientAPIImportTasksIDStatusGetCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIImporttasksIDStatusGet", reflect.TypeOf((*MockClient)(nil).APIImporttasksIDStatusGet), ctx, params)
+	return &MockClientAPIImporttasksIDStatusGetCall{Call: call}
 }
 
-// MockClientAPIImportTasksIDStatusGetCall wrap *gomock.Call
-type MockClientAPIImportTasksIDStatusGetCall struct {
+// MockClientAPIImporttasksIDStatusGetCall wrap *gomock.Call
+type MockClientAPIImporttasksIDStatusGetCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClientAPIImportTasksIDStatusGetCall) Return(arg0 *gen.ImportTaskStatusResponse, arg1 error) *MockClientAPIImportTasksIDStatusGetCall {
+func (c *MockClientAPIImporttasksIDStatusGetCall) Return(arg0 gen.APIImporttasksIDStatusGetRes, arg1 error) *MockClientAPIImporttasksIDStatusGetCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientAPIImportTasksIDStatusGetCall) Do(f func(context.Context, gen.APIImportTasksIDStatusGetParams) (*gen.ImportTaskStatusResponse, error)) *MockClientAPIImportTasksIDStatusGetCall {
+func (c *MockClientAPIImporttasksIDStatusGetCall) Do(f func(context.Context, gen.APIImporttasksIDStatusGetParams) (gen.APIImporttasksIDStatusGetRes, error)) *MockClientAPIImporttasksIDStatusGetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientAPIImportTasksIDStatusGetCall) DoAndReturn(f func(context.Context, gen.APIImportTasksIDStatusGetParams) (*gen.ImportTaskStatusResponse, error)) *MockClientAPIImportTasksIDStatusGetCall {
+func (c *MockClientAPIImporttasksIDStatusGetCall) DoAndReturn(f func(context.Context, gen.APIImporttasksIDStatusGetParams) (gen.APIImporttasksIDStatusGetRes, error)) *MockClientAPIImporttasksIDStatusGetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// APIImportTasksPost mocks base method.
-func (m *MockClient) APIImportTasksPost(ctx context.Context, request gen.OptAPIImportTasksPostReq) (gen.APIImportTasksPostRes, error) {
+// APIImporttasksPost mocks base method.
+func (m *MockClient) APIImporttasksPost(ctx context.Context, request gen.OptAPIImporttasksPostReq) (gen.APIImporttasksPostRes, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIImportTasksPost", ctx, request)
-	ret0, _ := ret[0].(gen.APIImportTasksPostRes)
+	ret := m.ctrl.Call(m, "APIImporttasksPost", ctx, request)
+	ret0, _ := ret[0].(gen.APIImporttasksPostRes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// APIImportTasksPost indicates an expected call of APIImportTasksPost.
-func (mr *MockClientMockRecorder) APIImportTasksPost(ctx, request any) *MockClientAPIImportTasksPostCall {
+// APIImporttasksPost indicates an expected call of APIImporttasksPost.
+func (mr *MockClientMockRecorder) APIImporttasksPost(ctx, request any) *MockClientAPIImporttasksPostCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIImportTasksPost", reflect.TypeOf((*MockClient)(nil).APIImportTasksPost), ctx, request)
-	return &MockClientAPIImportTasksPostCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIImporttasksPost", reflect.TypeOf((*MockClient)(nil).APIImporttasksPost), ctx, request)
+	return &MockClientAPIImporttasksPostCall{Call: call}
 }
 
-// MockClientAPIImportTasksPostCall wrap *gomock.Call
-type MockClientAPIImportTasksPostCall struct {
+// MockClientAPIImporttasksPostCall wrap *gomock.Call
+type MockClientAPIImporttasksPostCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClientAPIImportTasksPostCall) Return(arg0 gen.APIImportTasksPostRes, arg1 error) *MockClientAPIImportTasksPostCall {
+func (c *MockClientAPIImporttasksPostCall) Return(arg0 gen.APIImporttasksPostRes, arg1 error) *MockClientAPIImporttasksPostCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientAPIImportTasksPostCall) Do(f func(context.Context, gen.OptAPIImportTasksPostReq) (gen.APIImportTasksPostRes, error)) *MockClientAPIImportTasksPostCall {
+func (c *MockClientAPIImporttasksPostCall) Do(f func(context.Context, gen.OptAPIImporttasksPostReq) (gen.APIImporttasksPostRes, error)) *MockClientAPIImporttasksPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientAPIImportTasksPostCall) DoAndReturn(f func(context.Context, gen.OptAPIImportTasksPostReq) (gen.APIImportTasksPostRes, error)) *MockClientAPIImportTasksPostCall {
+func (c *MockClientAPIImporttasksPostCall) DoAndReturn(f func(context.Context, gen.OptAPIImporttasksPostReq) (gen.APIImporttasksPostRes, error)) *MockClientAPIImporttasksPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/apis/gen/oas_client_gen.go
+++ b/internal/apis/gen/oas_client_gen.go
@@ -27,43 +27,45 @@ func trimTrailingSlashes(u *url.URL) {
 
 // Invoker invokes operations described by OpenAPI v3 specification.
 type Invoker interface {
-	// APIHealthzGet invokes GET /api/Healthz operation.
+	// APIHealthzGet invokes GET /api/healthz operation.
 	//
 	// Get health status information.
 	//
-	// GET /api/Healthz
+	// GET /api/healthz
 	APIHealthzGet(ctx context.Context) (APIHealthzGetRes, error)
-	// APIImportTasksIDImportRunsPost invokes POST /api/ImportTasks/{id}/importRuns operation.
+	// APIImporttasksIDCancelPost invokes POST /api/importtasks/{id}/cancel operation.
+	//
+	// Cancels an existing import task.
+	//
+	// POST /api/importtasks/{id}/cancel
+	APIImporttasksIDCancelPost(ctx context.Context, request APIImporttasksIDCancelPostReq, params APIImporttasksIDCancelPostParams) (APIImporttasksIDCancelPostRes, error)
+	// APIImporttasksIDImportrunsPost invokes POST /api/importtasks/{id}/importruns operation.
 	//
 	// Starts a new import run for the given import task.
 	// Creates a new import execution ("run") resource.
 	//
-	// POST /api/ImportTasks/{id}/importRuns
-	APIImportTasksIDImportRunsPost(ctx context.Context, request OptAPIImportTasksIDImportRunsPostReq, params APIImportTasksIDImportRunsPostParams) (APIImportTasksIDImportRunsPostRes, error)
-	// APIImportTasksIDImportRunsRunIdStatusGet invokes GET /api/ImportTasks/{id}/importRuns/{runId}/status operation.
+	// POST /api/importtasks/{id}/importruns
+	APIImporttasksIDImportrunsPost(ctx context.Context, request OptAPIImporttasksIDImportrunsPostReq, params APIImporttasksIDImportrunsPostParams) (APIImporttasksIDImportrunsPostRes, error)
+	// APIImporttasksIDImportrunsRunIdStatusGet invokes GET /api/importtasks/{id}/importruns/{runId}/status operation.
 	//
-	// Gets the status of a specific import run.
+	// If the import has started in ACTApro (TaskId is present), the status is fetched from ACTApro.
+	// Otherwise, the local status from the database is returned.
 	//
-	// GET /api/ImportTasks/{id}/importRuns/{runId}/status
-	APIImportTasksIDImportRunsRunIdStatusGet(ctx context.Context, params APIImportTasksIDImportRunsRunIdStatusGetParams) (APIImportTasksIDImportRunsRunIdStatusGetRes, error)
-	// APIImportTasksIDPatch invokes PATCH /api/ImportTasks/{id} operation.
+	// GET /api/importtasks/{id}/importruns/{runId}/status
+	APIImporttasksIDImportrunsRunIdStatusGet(ctx context.Context, params APIImporttasksIDImportrunsRunIdStatusGetParams) (APIImporttasksIDImportrunsRunIdStatusGetRes, error)
+	// APIImporttasksIDStatusGet invokes GET /api/importtasks/{id}/status operation.
 	//
-	// Updates the status of an existing import task.
+	// This endpoint returns the status of the import task analysis phase only.
+	// For import run progress and results, use the import run status endpoint.
 	//
-	// PATCH /api/ImportTasks/{id}
-	APIImportTasksIDPatch(ctx context.Context, request APIImportTasksIDPatchReq, params APIImportTasksIDPatchParams) (APIImportTasksIDPatchRes, error)
-	// APIImportTasksIDStatusGet invokes GET /api/ImportTasks/{id}/status operation.
-	//
-	// Query the status of an ongoing analysis or import.
-	//
-	// GET /api/ImportTasks/{id}/status
-	APIImportTasksIDStatusGet(ctx context.Context, params APIImportTasksIDStatusGetParams) (*ImportTaskStatusResponse, error)
-	// APIImportTasksPost invokes POST /api/ImportTasks operation.
+	// GET /api/importtasks/{id}/status
+	APIImporttasksIDStatusGet(ctx context.Context, params APIImporttasksIDStatusGetParams) (APIImporttasksIDStatusGetRes, error)
+	// APIImporttasksPost invokes POST /api/importtasks operation.
 	//
 	// Creates a new import task.
 	//
-	// POST /api/ImportTasks
-	APIImportTasksPost(ctx context.Context, request OptAPIImportTasksPostReq) (APIImportTasksPostRes, error)
+	// POST /api/importtasks
+	APIImporttasksPost(ctx context.Context, request OptAPIImporttasksPostReq) (APIImporttasksPostRes, error)
 }
 
 // Client implements OAS client.
@@ -107,11 +109,11 @@ func (c *Client) requestURL(ctx context.Context) *url.URL {
 	return u
 }
 
-// APIHealthzGet invokes GET /api/Healthz operation.
+// APIHealthzGet invokes GET /api/healthz operation.
 //
 // Get health status information.
 //
-// GET /api/Healthz
+// GET /api/healthz
 func (c *Client) APIHealthzGet(ctx context.Context) (APIHealthzGetRes, error) {
 	res, err := c.sendAPIHealthzGet(ctx)
 	return res, err
@@ -120,7 +122,7 @@ func (c *Client) APIHealthzGet(ctx context.Context) (APIHealthzGetRes, error) {
 func (c *Client) sendAPIHealthzGet(ctx context.Context) (res APIHealthzGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		semconv.HTTPRequestMethodKey.String("GET"),
-		semconv.URLTemplateKey.String("/api/Healthz"),
+		semconv.URLTemplateKey.String("/api/healthz"),
 	}
 	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
 
@@ -154,7 +156,7 @@ func (c *Client) sendAPIHealthzGet(ctx context.Context) (res APIHealthzGetRes, e
 	stage = "BuildURL"
 	u := uri.Clone(c.requestURL(ctx))
 	var pathParts [1]string
-	pathParts[0] = "/api/Healthz"
+	pathParts[0] = "/api/healthz"
 	uri.AddPathParts(u, pathParts[:]...)
 
 	stage = "EncodeRequest"
@@ -213,21 +215,20 @@ func (c *Client) sendAPIHealthzGet(ctx context.Context) (res APIHealthzGetRes, e
 	return result, nil
 }
 
-// APIImportTasksIDImportRunsPost invokes POST /api/ImportTasks/{id}/importRuns operation.
+// APIImporttasksIDCancelPost invokes POST /api/importtasks/{id}/cancel operation.
 //
-// Starts a new import run for the given import task.
-// Creates a new import execution ("run") resource.
+// Cancels an existing import task.
 //
-// POST /api/ImportTasks/{id}/importRuns
-func (c *Client) APIImportTasksIDImportRunsPost(ctx context.Context, request OptAPIImportTasksIDImportRunsPostReq, params APIImportTasksIDImportRunsPostParams) (APIImportTasksIDImportRunsPostRes, error) {
-	res, err := c.sendAPIImportTasksIDImportRunsPost(ctx, request, params)
+// POST /api/importtasks/{id}/cancel
+func (c *Client) APIImporttasksIDCancelPost(ctx context.Context, request APIImporttasksIDCancelPostReq, params APIImporttasksIDCancelPostParams) (APIImporttasksIDCancelPostRes, error) {
+	res, err := c.sendAPIImporttasksIDCancelPost(ctx, request, params)
 	return res, err
 }
 
-func (c *Client) sendAPIImportTasksIDImportRunsPost(ctx context.Context, request OptAPIImportTasksIDImportRunsPostReq, params APIImportTasksIDImportRunsPostParams) (res APIImportTasksIDImportRunsPostRes, err error) {
+func (c *Client) sendAPIImporttasksIDCancelPost(ctx context.Context, request APIImporttasksIDCancelPostReq, params APIImporttasksIDCancelPostParams) (res APIImporttasksIDCancelPostRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		semconv.HTTPRequestMethodKey.String("POST"),
-		semconv.URLTemplateKey.String("/api/ImportTasks/{id}/importRuns"),
+		semconv.URLTemplateKey.String("/api/importtasks/{id}/cancel"),
 	}
 	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
 
@@ -243,7 +244,7 @@ func (c *Client) sendAPIImportTasksIDImportRunsPost(ctx context.Context, request
 	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
 
 	// Start a span for this request.
-	ctx, span := c.cfg.Tracer.Start(ctx, APIImportTasksIDImportRunsPostOperation,
+	ctx, span := c.cfg.Tracer.Start(ctx, APIImporttasksIDCancelPostOperation,
 		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
@@ -261,7 +262,7 @@ func (c *Client) sendAPIImportTasksIDImportRunsPost(ctx context.Context, request
 	stage = "BuildURL"
 	u := uri.Clone(c.requestURL(ctx))
 	var pathParts [3]string
-	pathParts[0] = "/api/ImportTasks/"
+	pathParts[0] = "/api/importtasks/"
 	{
 		// Encode "id" parameter.
 		e := uri.NewPathEncoder(uri.PathEncoderConfig{
@@ -280,7 +281,7 @@ func (c *Client) sendAPIImportTasksIDImportRunsPost(ctx context.Context, request
 		}
 		pathParts[1] = encoded
 	}
-	pathParts[2] = "/importRuns"
+	pathParts[2] = "/cancel"
 	uri.AddPathParts(u, pathParts[:]...)
 
 	stage = "EncodeRequest"
@@ -288,7 +289,7 @@ func (c *Client) sendAPIImportTasksIDImportRunsPost(ctx context.Context, request
 	if err != nil {
 		return res, errors.Wrap(err, "create request")
 	}
-	if err := encodeAPIImportTasksIDImportRunsPostRequest(request, r); err != nil {
+	if err := encodeAPIImporttasksIDCancelPostRequest(request, r); err != nil {
 		return res, errors.Wrap(err, "encode request")
 	}
 
@@ -297,7 +298,7 @@ func (c *Client) sendAPIImportTasksIDImportRunsPost(ctx context.Context, request
 		var satisfied bitset
 		{
 			stage = "Security:Smart"
-			switch err := c.securitySmart(ctx, APIImportTasksIDImportRunsPostOperation, r); {
+			switch err := c.securitySmart(ctx, APIImporttasksIDCancelPostOperation, r); {
 			case err == nil: // if NO error
 				satisfied[0] |= 1 << 0
 			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
@@ -334,7 +335,7 @@ func (c *Client) sendAPIImportTasksIDImportRunsPost(ctx context.Context, request
 	defer body.Close()
 
 	stage = "DecodeResponse"
-	result, err := decodeAPIImportTasksIDImportRunsPostResponse(resp)
+	result, err := decodeAPIImporttasksIDCancelPostResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}
@@ -342,20 +343,21 @@ func (c *Client) sendAPIImportTasksIDImportRunsPost(ctx context.Context, request
 	return result, nil
 }
 
-// APIImportTasksIDImportRunsRunIdStatusGet invokes GET /api/ImportTasks/{id}/importRuns/{runId}/status operation.
+// APIImporttasksIDImportrunsPost invokes POST /api/importtasks/{id}/importruns operation.
 //
-// Gets the status of a specific import run.
+// Starts a new import run for the given import task.
+// Creates a new import execution ("run") resource.
 //
-// GET /api/ImportTasks/{id}/importRuns/{runId}/status
-func (c *Client) APIImportTasksIDImportRunsRunIdStatusGet(ctx context.Context, params APIImportTasksIDImportRunsRunIdStatusGetParams) (APIImportTasksIDImportRunsRunIdStatusGetRes, error) {
-	res, err := c.sendAPIImportTasksIDImportRunsRunIdStatusGet(ctx, params)
+// POST /api/importtasks/{id}/importruns
+func (c *Client) APIImporttasksIDImportrunsPost(ctx context.Context, request OptAPIImporttasksIDImportrunsPostReq, params APIImporttasksIDImportrunsPostParams) (APIImporttasksIDImportrunsPostRes, error) {
+	res, err := c.sendAPIImporttasksIDImportrunsPost(ctx, request, params)
 	return res, err
 }
 
-func (c *Client) sendAPIImportTasksIDImportRunsRunIdStatusGet(ctx context.Context, params APIImportTasksIDImportRunsRunIdStatusGetParams) (res APIImportTasksIDImportRunsRunIdStatusGetRes, err error) {
+func (c *Client) sendAPIImporttasksIDImportrunsPost(ctx context.Context, request OptAPIImporttasksIDImportrunsPostReq, params APIImporttasksIDImportrunsPostParams) (res APIImporttasksIDImportrunsPostRes, err error) {
 	otelAttrs := []attribute.KeyValue{
-		semconv.HTTPRequestMethodKey.String("GET"),
-		semconv.URLTemplateKey.String("/api/ImportTasks/{id}/importRuns/{runId}/status"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.URLTemplateKey.String("/api/importtasks/{id}/importruns"),
 	}
 	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
 
@@ -371,7 +373,7 @@ func (c *Client) sendAPIImportTasksIDImportRunsRunIdStatusGet(ctx context.Contex
 	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
 
 	// Start a span for this request.
-	ctx, span := c.cfg.Tracer.Start(ctx, APIImportTasksIDImportRunsRunIdStatusGetOperation,
+	ctx, span := c.cfg.Tracer.Start(ctx, APIImporttasksIDImportrunsPostOperation,
 		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
@@ -388,8 +390,8 @@ func (c *Client) sendAPIImportTasksIDImportRunsRunIdStatusGet(ctx context.Contex
 
 	stage = "BuildURL"
 	u := uri.Clone(c.requestURL(ctx))
-	var pathParts [5]string
-	pathParts[0] = "/api/ImportTasks/"
+	var pathParts [3]string
+	pathParts[0] = "/api/importtasks/"
 	{
 		// Encode "id" parameter.
 		e := uri.NewPathEncoder(uri.PathEncoderConfig{
@@ -408,7 +410,136 @@ func (c *Client) sendAPIImportTasksIDImportRunsRunIdStatusGet(ctx context.Contex
 		}
 		pathParts[1] = encoded
 	}
-	pathParts[2] = "/importRuns/"
+	pathParts[2] = "/importruns"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeAPIImporttasksIDImportrunsPostRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			stage = "Security:Smart"
+			switch err := c.securitySmart(ctx, APIImporttasksIDImportrunsPostOperation, r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 0
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"Smart\"")
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
+		}
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeAPIImporttasksIDImportrunsPostResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// APIImporttasksIDImportrunsRunIdStatusGet invokes GET /api/importtasks/{id}/importruns/{runId}/status operation.
+//
+// If the import has started in ACTApro (TaskId is present), the status is fetched from ACTApro.
+// Otherwise, the local status from the database is returned.
+//
+// GET /api/importtasks/{id}/importruns/{runId}/status
+func (c *Client) APIImporttasksIDImportrunsRunIdStatusGet(ctx context.Context, params APIImporttasksIDImportrunsRunIdStatusGetParams) (APIImporttasksIDImportrunsRunIdStatusGetRes, error) {
+	res, err := c.sendAPIImporttasksIDImportrunsRunIdStatusGet(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendAPIImporttasksIDImportrunsRunIdStatusGet(ctx context.Context, params APIImporttasksIDImportrunsRunIdStatusGetParams) (res APIImporttasksIDImportrunsRunIdStatusGetRes, err error) {
+	otelAttrs := []attribute.KeyValue{
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.URLTemplateKey.String("/api/importtasks/{id}/importruns/{runId}/status"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, APIImporttasksIDImportrunsRunIdStatusGetOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [5]string
+	pathParts[0] = "/api/importtasks/"
+	{
+		// Encode "id" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "id",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.StringToString(params.ID))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[1] = encoded
+	}
+	pathParts[2] = "/importruns/"
 	{
 		// Encode "runId" parameter.
 		e := uri.NewPathEncoder(uri.PathEncoderConfig{
@@ -441,7 +572,7 @@ func (c *Client) sendAPIImportTasksIDImportRunsRunIdStatusGet(ctx context.Contex
 		var satisfied bitset
 		{
 			stage = "Security:Smart"
-			switch err := c.securitySmart(ctx, APIImportTasksIDImportRunsRunIdStatusGetOperation, r); {
+			switch err := c.securitySmart(ctx, APIImporttasksIDImportrunsRunIdStatusGetOperation, r); {
 			case err == nil: // if NO error
 				satisfied[0] |= 1 << 0
 			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
@@ -478,7 +609,7 @@ func (c *Client) sendAPIImportTasksIDImportRunsRunIdStatusGet(ctx context.Contex
 	defer body.Close()
 
 	stage = "DecodeResponse"
-	result, err := decodeAPIImportTasksIDImportRunsRunIdStatusGetResponse(resp)
+	result, err := decodeAPIImporttasksIDImportrunsRunIdStatusGetResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}
@@ -486,147 +617,21 @@ func (c *Client) sendAPIImportTasksIDImportRunsRunIdStatusGet(ctx context.Contex
 	return result, nil
 }
 
-// APIImportTasksIDPatch invokes PATCH /api/ImportTasks/{id} operation.
+// APIImporttasksIDStatusGet invokes GET /api/importtasks/{id}/status operation.
 //
-// Updates the status of an existing import task.
+// This endpoint returns the status of the import task analysis phase only.
+// For import run progress and results, use the import run status endpoint.
 //
-// PATCH /api/ImportTasks/{id}
-func (c *Client) APIImportTasksIDPatch(ctx context.Context, request APIImportTasksIDPatchReq, params APIImportTasksIDPatchParams) (APIImportTasksIDPatchRes, error) {
-	res, err := c.sendAPIImportTasksIDPatch(ctx, request, params)
+// GET /api/importtasks/{id}/status
+func (c *Client) APIImporttasksIDStatusGet(ctx context.Context, params APIImporttasksIDStatusGetParams) (APIImporttasksIDStatusGetRes, error) {
+	res, err := c.sendAPIImporttasksIDStatusGet(ctx, params)
 	return res, err
 }
 
-func (c *Client) sendAPIImportTasksIDPatch(ctx context.Context, request APIImportTasksIDPatchReq, params APIImportTasksIDPatchParams) (res APIImportTasksIDPatchRes, err error) {
-	otelAttrs := []attribute.KeyValue{
-		semconv.HTTPRequestMethodKey.String("PATCH"),
-		semconv.URLTemplateKey.String("/api/ImportTasks/{id}"),
-	}
-	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
-
-	// Run stopwatch.
-	startTime := time.Now()
-	defer func() {
-		// Use floating point division here for higher precision (instead of Millisecond method).
-		elapsedDuration := time.Since(startTime)
-		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
-	}()
-
-	// Increment request counter.
-	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
-
-	// Start a span for this request.
-	ctx, span := c.cfg.Tracer.Start(ctx, APIImportTasksIDPatchOperation,
-		trace.WithAttributes(otelAttrs...),
-		clientSpanKind,
-	)
-	// Track stage for error reporting.
-	var stage string
-	defer func() {
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, stage)
-			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
-		}
-		span.End()
-	}()
-
-	stage = "BuildURL"
-	u := uri.Clone(c.requestURL(ctx))
-	var pathParts [2]string
-	pathParts[0] = "/api/ImportTasks/"
-	{
-		// Encode "id" parameter.
-		e := uri.NewPathEncoder(uri.PathEncoderConfig{
-			Param:   "id",
-			Style:   uri.PathStyleSimple,
-			Explode: false,
-		})
-		if err := func() error {
-			return e.EncodeValue(conv.StringToString(params.ID))
-		}(); err != nil {
-			return res, errors.Wrap(err, "encode path")
-		}
-		encoded, err := e.Result()
-		if err != nil {
-			return res, errors.Wrap(err, "encode path")
-		}
-		pathParts[1] = encoded
-	}
-	uri.AddPathParts(u, pathParts[:]...)
-
-	stage = "EncodeRequest"
-	r, err := ht.NewRequest(ctx, "PATCH", u)
-	if err != nil {
-		return res, errors.Wrap(err, "create request")
-	}
-	if err := encodeAPIImportTasksIDPatchRequest(request, r); err != nil {
-		return res, errors.Wrap(err, "encode request")
-	}
-
-	{
-		type bitset = [1]uint8
-		var satisfied bitset
-		{
-			stage = "Security:Smart"
-			switch err := c.securitySmart(ctx, APIImportTasksIDPatchOperation, r); {
-			case err == nil: // if NO error
-				satisfied[0] |= 1 << 0
-			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
-				// Skip this security.
-			default:
-				return res, errors.Wrap(err, "security \"Smart\"")
-			}
-		}
-
-		if ok := func() bool {
-		nextRequirement:
-			for _, requirement := range []bitset{
-				{0b00000001},
-			} {
-				for i, mask := range requirement {
-					if satisfied[i]&mask != mask {
-						continue nextRequirement
-					}
-				}
-				return true
-			}
-			return false
-		}(); !ok {
-			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
-		}
-	}
-
-	stage = "SendRequest"
-	resp, err := c.cfg.Client.Do(r)
-	if err != nil {
-		return res, errors.Wrap(err, "do request")
-	}
-	body := resp.Body
-	defer body.Close()
-
-	stage = "DecodeResponse"
-	result, err := decodeAPIImportTasksIDPatchResponse(resp)
-	if err != nil {
-		return res, errors.Wrap(err, "decode response")
-	}
-
-	return result, nil
-}
-
-// APIImportTasksIDStatusGet invokes GET /api/ImportTasks/{id}/status operation.
-//
-// Query the status of an ongoing analysis or import.
-//
-// GET /api/ImportTasks/{id}/status
-func (c *Client) APIImportTasksIDStatusGet(ctx context.Context, params APIImportTasksIDStatusGetParams) (*ImportTaskStatusResponse, error) {
-	res, err := c.sendAPIImportTasksIDStatusGet(ctx, params)
-	return res, err
-}
-
-func (c *Client) sendAPIImportTasksIDStatusGet(ctx context.Context, params APIImportTasksIDStatusGetParams) (res *ImportTaskStatusResponse, err error) {
+func (c *Client) sendAPIImporttasksIDStatusGet(ctx context.Context, params APIImporttasksIDStatusGetParams) (res APIImporttasksIDStatusGetRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		semconv.HTTPRequestMethodKey.String("GET"),
-		semconv.URLTemplateKey.String("/api/ImportTasks/{id}/status"),
+		semconv.URLTemplateKey.String("/api/importtasks/{id}/status"),
 	}
 	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
 
@@ -642,7 +647,7 @@ func (c *Client) sendAPIImportTasksIDStatusGet(ctx context.Context, params APIIm
 	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
 
 	// Start a span for this request.
-	ctx, span := c.cfg.Tracer.Start(ctx, APIImportTasksIDStatusGetOperation,
+	ctx, span := c.cfg.Tracer.Start(ctx, APIImporttasksIDStatusGetOperation,
 		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
@@ -660,7 +665,7 @@ func (c *Client) sendAPIImportTasksIDStatusGet(ctx context.Context, params APIIm
 	stage = "BuildURL"
 	u := uri.Clone(c.requestURL(ctx))
 	var pathParts [3]string
-	pathParts[0] = "/api/ImportTasks/"
+	pathParts[0] = "/api/importtasks/"
 	{
 		// Encode "id" parameter.
 		e := uri.NewPathEncoder(uri.PathEncoderConfig{
@@ -693,7 +698,7 @@ func (c *Client) sendAPIImportTasksIDStatusGet(ctx context.Context, params APIIm
 		var satisfied bitset
 		{
 			stage = "Security:Smart"
-			switch err := c.securitySmart(ctx, APIImportTasksIDStatusGetOperation, r); {
+			switch err := c.securitySmart(ctx, APIImporttasksIDStatusGetOperation, r); {
 			case err == nil: // if NO error
 				satisfied[0] |= 1 << 0
 			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
@@ -730,7 +735,7 @@ func (c *Client) sendAPIImportTasksIDStatusGet(ctx context.Context, params APIIm
 	defer body.Close()
 
 	stage = "DecodeResponse"
-	result, err := decodeAPIImportTasksIDStatusGetResponse(resp)
+	result, err := decodeAPIImporttasksIDStatusGetResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}
@@ -738,20 +743,20 @@ func (c *Client) sendAPIImportTasksIDStatusGet(ctx context.Context, params APIIm
 	return result, nil
 }
 
-// APIImportTasksPost invokes POST /api/ImportTasks operation.
+// APIImporttasksPost invokes POST /api/importtasks operation.
 //
 // Creates a new import task.
 //
-// POST /api/ImportTasks
-func (c *Client) APIImportTasksPost(ctx context.Context, request OptAPIImportTasksPostReq) (APIImportTasksPostRes, error) {
-	res, err := c.sendAPIImportTasksPost(ctx, request)
+// POST /api/importtasks
+func (c *Client) APIImporttasksPost(ctx context.Context, request OptAPIImporttasksPostReq) (APIImporttasksPostRes, error) {
+	res, err := c.sendAPIImporttasksPost(ctx, request)
 	return res, err
 }
 
-func (c *Client) sendAPIImportTasksPost(ctx context.Context, request OptAPIImportTasksPostReq) (res APIImportTasksPostRes, err error) {
+func (c *Client) sendAPIImporttasksPost(ctx context.Context, request OptAPIImporttasksPostReq) (res APIImporttasksPostRes, err error) {
 	otelAttrs := []attribute.KeyValue{
 		semconv.HTTPRequestMethodKey.String("POST"),
-		semconv.URLTemplateKey.String("/api/ImportTasks"),
+		semconv.URLTemplateKey.String("/api/importtasks"),
 	}
 	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
 
@@ -767,7 +772,7 @@ func (c *Client) sendAPIImportTasksPost(ctx context.Context, request OptAPIImpor
 	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
 
 	// Start a span for this request.
-	ctx, span := c.cfg.Tracer.Start(ctx, APIImportTasksPostOperation,
+	ctx, span := c.cfg.Tracer.Start(ctx, APIImporttasksPostOperation,
 		trace.WithAttributes(otelAttrs...),
 		clientSpanKind,
 	)
@@ -785,7 +790,7 @@ func (c *Client) sendAPIImportTasksPost(ctx context.Context, request OptAPIImpor
 	stage = "BuildURL"
 	u := uri.Clone(c.requestURL(ctx))
 	var pathParts [1]string
-	pathParts[0] = "/api/ImportTasks"
+	pathParts[0] = "/api/importtasks"
 	uri.AddPathParts(u, pathParts[:]...)
 
 	stage = "EncodeRequest"
@@ -793,7 +798,7 @@ func (c *Client) sendAPIImportTasksPost(ctx context.Context, request OptAPIImpor
 	if err != nil {
 		return res, errors.Wrap(err, "create request")
 	}
-	if err := encodeAPIImportTasksPostRequest(request, r); err != nil {
+	if err := encodeAPIImporttasksPostRequest(request, r); err != nil {
 		return res, errors.Wrap(err, "encode request")
 	}
 
@@ -802,7 +807,7 @@ func (c *Client) sendAPIImportTasksPost(ctx context.Context, request OptAPIImpor
 		var satisfied bitset
 		{
 			stage = "Security:Smart"
-			switch err := c.securitySmart(ctx, APIImportTasksPostOperation, r); {
+			switch err := c.securitySmart(ctx, APIImporttasksPostOperation, r); {
 			case err == nil: // if NO error
 				satisfied[0] |= 1 << 0
 			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
@@ -839,7 +844,7 @@ func (c *Client) sendAPIImportTasksPost(ctx context.Context, request OptAPIImpor
 	defer body.Close()
 
 	stage = "DecodeResponse"
-	result, err := decodeAPIImportTasksPostResponse(resp)
+	result, err := decodeAPIImporttasksPostResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/internal/apis/gen/oas_interfaces_gen.go
+++ b/internal/apis/gen/oas_interfaces_gen.go
@@ -5,22 +5,26 @@ type APIHealthzGetRes interface {
 	aPIHealthzGetRes()
 }
 
-type APIImportTasksIDImportRunsPostRes interface {
-	aPIImportTasksIDImportRunsPostRes()
+type APIImporttasksIDCancelPostReq interface {
+	aPIImporttasksIDCancelPostReq()
 }
 
-type APIImportTasksIDImportRunsRunIdStatusGetRes interface {
-	aPIImportTasksIDImportRunsRunIdStatusGetRes()
+type APIImporttasksIDCancelPostRes interface {
+	aPIImporttasksIDCancelPostRes()
 }
 
-type APIImportTasksIDPatchReq interface {
-	aPIImportTasksIDPatchReq()
+type APIImporttasksIDImportrunsPostRes interface {
+	aPIImporttasksIDImportrunsPostRes()
 }
 
-type APIImportTasksIDPatchRes interface {
-	aPIImportTasksIDPatchRes()
+type APIImporttasksIDImportrunsRunIdStatusGetRes interface {
+	aPIImporttasksIDImportrunsRunIdStatusGetRes()
 }
 
-type APIImportTasksPostRes interface {
-	aPIImportTasksPostRes()
+type APIImporttasksIDStatusGetRes interface {
+	aPIImporttasksIDStatusGetRes()
+}
+
+type APIImporttasksPostRes interface {
+	aPIImporttasksPostRes()
 }

--- a/internal/apis/gen/oas_json_gen.go
+++ b/internal/apis/gen/oas_json_gen.go
@@ -5,11 +5,9 @@ package gen
 import (
 	"math/bits"
 	"strconv"
-	"time"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
-	"github.com/ogen-go/ogen/json"
 	"github.com/ogen-go/ogen/validate"
 )
 
@@ -89,17 +87,17 @@ func (s *APIHealthzGetServiceUnavailable) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDImportRunsPostNotFound as json.
-func (s *APIImportTasksIDImportRunsPostNotFound) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDCancelPostConflict as json.
+func (s *APIImporttasksIDCancelPostConflict) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDImportRunsPostNotFound from json.
-func (s *APIImportTasksIDImportRunsPostNotFound) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDCancelPostConflict from json.
+func (s *APIImporttasksIDCancelPostConflict) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDImportRunsPostNotFound to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDCancelPostConflict to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -110,34 +108,34 @@ func (s *APIImportTasksIDImportRunsPostNotFound) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDImportRunsPostNotFound(unwrapped)
+	*s = APIImporttasksIDCancelPostConflict(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDImportRunsPostNotFound) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDCancelPostConflict) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDImportRunsPostNotFound) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDCancelPostConflict) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDImportRunsPostUnauthorized as json.
-func (s *APIImportTasksIDImportRunsPostUnauthorized) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDCancelPostInternalServerError as json.
+func (s *APIImporttasksIDCancelPostInternalServerError) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDImportRunsPostUnauthorized from json.
-func (s *APIImportTasksIDImportRunsPostUnauthorized) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDCancelPostInternalServerError from json.
+func (s *APIImporttasksIDCancelPostInternalServerError) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDImportRunsPostUnauthorized to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDCancelPostInternalServerError to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -148,34 +146,34 @@ func (s *APIImportTasksIDImportRunsPostUnauthorized) Decode(d *jx.Decoder) error
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDImportRunsPostUnauthorized(unwrapped)
+	*s = APIImporttasksIDCancelPostInternalServerError(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDImportRunsPostUnauthorized) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDCancelPostInternalServerError) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDImportRunsPostUnauthorized) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDCancelPostInternalServerError) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDImportRunsPostUnsupportedMediaType as json.
-func (s *APIImportTasksIDImportRunsPostUnsupportedMediaType) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDCancelPostNotFound as json.
+func (s *APIImporttasksIDCancelPostNotFound) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDImportRunsPostUnsupportedMediaType from json.
-func (s *APIImportTasksIDImportRunsPostUnsupportedMediaType) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDCancelPostNotFound from json.
+func (s *APIImporttasksIDCancelPostNotFound) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDImportRunsPostUnsupportedMediaType to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDCancelPostNotFound to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -186,34 +184,34 @@ func (s *APIImportTasksIDImportRunsPostUnsupportedMediaType) Decode(d *jx.Decode
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDImportRunsPostUnsupportedMediaType(unwrapped)
+	*s = APIImporttasksIDCancelPostNotFound(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDImportRunsPostUnsupportedMediaType) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDCancelPostNotFound) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDImportRunsPostUnsupportedMediaType) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDCancelPostNotFound) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDImportRunsRunIdStatusGetNotFound as json.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetNotFound) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDCancelPostUnauthorized as json.
+func (s *APIImporttasksIDCancelPostUnauthorized) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDImportRunsRunIdStatusGetNotFound from json.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetNotFound) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDCancelPostUnauthorized from json.
+func (s *APIImporttasksIDCancelPostUnauthorized) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDImportRunsRunIdStatusGetNotFound to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDCancelPostUnauthorized to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -224,34 +222,34 @@ func (s *APIImportTasksIDImportRunsRunIdStatusGetNotFound) Decode(d *jx.Decoder)
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDImportRunsRunIdStatusGetNotFound(unwrapped)
+	*s = APIImporttasksIDCancelPostUnauthorized(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetNotFound) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDCancelPostUnauthorized) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetNotFound) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDCancelPostUnauthorized) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDImportRunsRunIdStatusGetUnauthorized as json.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDImportrunsPostBadRequest as json.
+func (s *APIImporttasksIDImportrunsPostBadRequest) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDImportRunsRunIdStatusGetUnauthorized from json.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsPostBadRequest from json.
+func (s *APIImporttasksIDImportrunsPostBadRequest) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDImportRunsRunIdStatusGetUnauthorized to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsPostBadRequest to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -262,34 +260,34 @@ func (s *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) Decode(d *jx.Deco
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDImportRunsRunIdStatusGetUnauthorized(unwrapped)
+	*s = APIImporttasksIDImportrunsPostBadRequest(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsPostBadRequest) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsPostBadRequest) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDPatchConflict as json.
-func (s *APIImportTasksIDPatchConflict) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDImportrunsPostNotFound as json.
+func (s *APIImporttasksIDImportrunsPostNotFound) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDPatchConflict from json.
-func (s *APIImportTasksIDPatchConflict) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsPostNotFound from json.
+func (s *APIImporttasksIDImportrunsPostNotFound) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDPatchConflict to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsPostNotFound to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -300,34 +298,34 @@ func (s *APIImportTasksIDPatchConflict) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDPatchConflict(unwrapped)
+	*s = APIImporttasksIDImportrunsPostNotFound(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDPatchConflict) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsPostNotFound) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDPatchConflict) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsPostNotFound) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksIDPatchNotFound as json.
-func (s *APIImportTasksIDPatchNotFound) Encode(e *jx.Encoder) {
+// Encode encodes APIImporttasksIDImportrunsPostUnauthorized as json.
+func (s *APIImporttasksIDImportrunsPostUnauthorized) Encode(e *jx.Encoder) {
 	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksIDPatchNotFound from json.
-func (s *APIImportTasksIDPatchNotFound) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsPostUnauthorized from json.
+func (s *APIImporttasksIDImportrunsPostUnauthorized) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksIDPatchNotFound to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsPostUnauthorized to nil")
 	}
 	var unwrapped ProblemDetails
 	if err := func() error {
@@ -338,36 +336,36 @@ func (s *APIImportTasksIDPatchNotFound) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksIDPatchNotFound(unwrapped)
+	*s = APIImporttasksIDImportrunsPostUnauthorized(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksIDPatchNotFound) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsPostUnauthorized) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksIDPatchNotFound) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsPostUnauthorized) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksPostBadRequest as json.
-func (s *APIImportTasksPostBadRequest) Encode(e *jx.Encoder) {
-	unwrapped := (*CreateImportTaskResponse)(s)
+// Encode encodes APIImporttasksIDImportrunsPostUnsupportedMediaType as json.
+func (s *APIImporttasksIDImportrunsPostUnsupportedMediaType) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksPostBadRequest from json.
-func (s *APIImportTasksPostBadRequest) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsPostUnsupportedMediaType from json.
+func (s *APIImporttasksIDImportrunsPostUnsupportedMediaType) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksPostBadRequest to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsPostUnsupportedMediaType to nil")
 	}
-	var unwrapped CreateImportTaskResponse
+	var unwrapped ProblemDetails
 	if err := func() error {
 		if err := unwrapped.Decode(d); err != nil {
 			return err
@@ -376,36 +374,36 @@ func (s *APIImportTasksPostBadRequest) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksPostBadRequest(unwrapped)
+	*s = APIImporttasksIDImportrunsPostUnsupportedMediaType(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksPostBadRequest) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsPostUnsupportedMediaType) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksPostBadRequest) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsPostUnsupportedMediaType) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksPostCreated as json.
-func (s *APIImportTasksPostCreated) Encode(e *jx.Encoder) {
-	unwrapped := (*CreateImportTaskResponse)(s)
+// Encode encodes APIImporttasksIDImportrunsRunIdStatusGetInternalServerError as json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksPostCreated from json.
-func (s *APIImportTasksPostCreated) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsRunIdStatusGetInternalServerError from json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetInternalServerError) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksPostCreated to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsRunIdStatusGetInternalServerError to nil")
 	}
-	var unwrapped CreateImportTaskResponse
+	var unwrapped ProblemDetails
 	if err := func() error {
 		if err := unwrapped.Decode(d); err != nil {
 			return err
@@ -414,36 +412,36 @@ func (s *APIImportTasksPostCreated) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksPostCreated(unwrapped)
+	*s = APIImporttasksIDImportrunsRunIdStatusGetInternalServerError(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksPostCreated) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetInternalServerError) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksPostCreated) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetInternalServerError) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksPostInternalServerError as json.
-func (s *APIImportTasksPostInternalServerError) Encode(e *jx.Encoder) {
-	unwrapped := (*CreateImportTaskResponse)(s)
+// Encode encodes APIImporttasksIDImportrunsRunIdStatusGetNotFound as json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetNotFound) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksPostInternalServerError from json.
-func (s *APIImportTasksPostInternalServerError) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsRunIdStatusGetNotFound from json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetNotFound) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksPostInternalServerError to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsRunIdStatusGetNotFound to nil")
 	}
-	var unwrapped CreateImportTaskResponse
+	var unwrapped ProblemDetails
 	if err := func() error {
 		if err := unwrapped.Decode(d); err != nil {
 			return err
@@ -452,36 +450,36 @@ func (s *APIImportTasksPostInternalServerError) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksPostInternalServerError(unwrapped)
+	*s = APIImporttasksIDImportrunsRunIdStatusGetNotFound(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksPostInternalServerError) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetNotFound) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksPostInternalServerError) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetNotFound) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode encodes APIImportTasksPostUnsupportedMediaType as json.
-func (s *APIImportTasksPostUnsupportedMediaType) Encode(e *jx.Encoder) {
-	unwrapped := (*CreateImportTaskResponse)(s)
+// Encode encodes APIImporttasksIDImportrunsRunIdStatusGetUnauthorized as json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
 
 	unwrapped.Encode(e)
 }
 
-// Decode decodes APIImportTasksPostUnsupportedMediaType from json.
-func (s *APIImportTasksPostUnsupportedMediaType) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDImportrunsRunIdStatusGetUnauthorized from json.
+func (s *APIImporttasksIDImportrunsRunIdStatusGetUnauthorized) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode APIImportTasksPostUnsupportedMediaType to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDImportrunsRunIdStatusGetUnauthorized to nil")
 	}
-	var unwrapped CreateImportTaskResponse
+	var unwrapped ProblemDetails
 	if err := func() error {
 		if err := unwrapped.Decode(d); err != nil {
 			return err
@@ -490,676 +488,285 @@ func (s *APIImportTasksPostUnsupportedMediaType) Decode(d *jx.Decoder) error {
 	}(); err != nil {
 		return errors.Wrap(err, "alias")
 	}
-	*s = APIImportTasksPostUnsupportedMediaType(unwrapped)
+	*s = APIImporttasksIDImportrunsRunIdStatusGetUnauthorized(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *APIImportTasksPostUnsupportedMediaType) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetUnauthorized) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *APIImportTasksPostUnsupportedMediaType) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDImportrunsRunIdStatusGetUnauthorized) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
 
-// Encode implements json.Marshaler.
-func (s *AnalysisRecordDto) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
+// Encode encodes APIImporttasksIDStatusGetInternalServerError as json.
+func (s *APIImporttasksIDStatusGetInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
 }
 
-// encodeFields encodes fields.
-func (s *AnalysisRecordDto) encodeFields(e *jx.Encoder) {
-	{
-		if s.AnalysisRecordId.Set {
-			e.FieldStart("analysisRecordId")
-			s.AnalysisRecordId.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("rowVersion")
-		e.Base64(s.RowVersion)
-	}
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.ComparisonDate.Set {
-			e.FieldStart("comparisonDate")
-			s.ComparisonDate.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.TargetPrimaryKey.Set {
-			e.FieldStart("targetPrimaryKey")
-			s.TargetPrimaryKey.Encode(e)
-		}
-	}
-	{
-		if s.DocKey.Set {
-			e.FieldStart("docKey")
-			s.DocKey.Encode(e)
-		}
-	}
-	{
-		if s.ReferenceCode.Set {
-			e.FieldStart("referenceCode")
-			s.ReferenceCode.Encode(e)
-		}
-	}
-	{
-		if s.Level.Set {
-			e.FieldStart("level")
-			s.Level.Encode(e)
-		}
-	}
-	{
-		if s.SourcePrimaryKey.Set {
-			e.FieldStart("sourcePrimaryKey")
-			s.SourcePrimaryKey.Encode(e)
-		}
-	}
-	{
-		if s.PositionNumber.Set {
-			e.FieldStart("positionNumber")
-			s.PositionNumber.Encode(e)
-		}
-	}
-	{
-		if s.SourceTitle.Set {
-			e.FieldStart("sourceTitle")
-			s.SourceTitle.Encode(e)
-		}
-	}
-	{
-		if s.DestinationTitle.Set {
-			e.FieldStart("destinationTitle")
-			s.DestinationTitle.Encode(e)
-		}
-	}
-	{
-		if s.SourceField1.Set {
-			e.FieldStart("sourceField1")
-			s.SourceField1.Encode(e)
-		}
-	}
-	{
-		if s.DestinationField1.Set {
-			e.FieldStart("destinationField1")
-			s.DestinationField1.Encode(e)
-		}
-	}
-	{
-		if s.SourceField2.Set {
-			e.FieldStart("sourceField2")
-			s.SourceField2.Encode(e)
-		}
-	}
-	{
-		if s.DestinationField2.Set {
-			e.FieldStart("destinationField2")
-			s.DestinationField2.Encode(e)
-		}
-	}
-	{
-		if s.SourceField3.Set {
-			e.FieldStart("sourceField3")
-			s.SourceField3.Encode(e)
-		}
-	}
-	{
-		if s.DestinationField3.Set {
-			e.FieldStart("destinationField3")
-			s.DestinationField3.Encode(e)
-		}
-	}
-	{
-		if s.SourceField4.Set {
-			e.FieldStart("sourceField4")
-			s.SourceField4.Encode(e)
-		}
-	}
-	{
-		if s.DestinationField4.Set {
-			e.FieldStart("destinationField4")
-			s.DestinationField4.Encode(e)
-		}
-	}
-	{
-		if s.SourceField5.Set {
-			e.FieldStart("sourceField5")
-			s.SourceField5.Encode(e)
-		}
-	}
-	{
-		if s.DestinationField5.Set {
-			e.FieldStart("destinationField5")
-			s.DestinationField5.Encode(e)
-		}
-	}
-	{
-		if s.TitleIsDifferent.Set {
-			e.FieldStart("titleIsDifferent")
-			s.TitleIsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Field1IsDifferent.Set {
-			e.FieldStart("field1IsDifferent")
-			s.Field1IsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Field2IsDifferent.Set {
-			e.FieldStart("field2IsDifferent")
-			s.Field2IsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Field3IsDifferent.Set {
-			e.FieldStart("field3IsDifferent")
-			s.Field3IsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Field4IsDifferent.Set {
-			e.FieldStart("field4IsDifferent")
-			s.Field4IsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Field5IsDifferent.Set {
-			e.FieldStart("field5IsDifferent")
-			s.Field5IsDifferent.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
-	}
-	{
-		if s.ErrorMessage.Set {
-			e.FieldStart("errorMessage")
-			s.ErrorMessage.Encode(e)
-		}
-	}
-	{
-		if s.ContainerDocKey.Set {
-			e.FieldStart("containerDocKey")
-			s.ContainerDocKey.Encode(e)
-		}
-	}
-	{
-		if s.CreatedBy.Set {
-			e.FieldStart("createdBy")
-			s.CreatedBy.Encode(e)
-		}
-	}
-	{
-		if s.CreatedOn.Set {
-			e.FieldStart("createdOn")
-			s.CreatedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ModifiedBy.Set {
-			e.FieldStart("modifiedBy")
-			s.ModifiedBy.Encode(e)
-		}
-	}
-	{
-		if s.ModifiedOn.Set {
-			e.FieldStart("modifiedOn")
-			s.ModifiedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ImportTask.Set {
-			e.FieldStart("importTask")
-			s.ImportTask.Encode(e)
-		}
-	}
-}
-
-var jsonFieldsNameOfAnalysisRecordDto = [36]string{
-	0:  "analysisRecordId",
-	1:  "rowVersion",
-	2:  "importTaskId",
-	3:  "comparisonDate",
-	4:  "targetPrimaryKey",
-	5:  "docKey",
-	6:  "referenceCode",
-	7:  "level",
-	8:  "sourcePrimaryKey",
-	9:  "positionNumber",
-	10: "sourceTitle",
-	11: "destinationTitle",
-	12: "sourceField1",
-	13: "destinationField1",
-	14: "sourceField2",
-	15: "destinationField2",
-	16: "sourceField3",
-	17: "destinationField3",
-	18: "sourceField4",
-	19: "destinationField4",
-	20: "sourceField5",
-	21: "destinationField5",
-	22: "titleIsDifferent",
-	23: "field1IsDifferent",
-	24: "field2IsDifferent",
-	25: "field3IsDifferent",
-	26: "field4IsDifferent",
-	27: "field5IsDifferent",
-	28: "status",
-	29: "errorMessage",
-	30: "containerDocKey",
-	31: "createdBy",
-	32: "createdOn",
-	33: "modifiedBy",
-	34: "modifiedOn",
-	35: "importTask",
-}
-
-// Decode decodes AnalysisRecordDto from json.
-func (s *AnalysisRecordDto) Decode(d *jx.Decoder) error {
+// Decode decodes APIImporttasksIDStatusGetInternalServerError from json.
+func (s *APIImporttasksIDStatusGetInternalServerError) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode AnalysisRecordDto to nil")
+		return errors.New("invalid: unable to decode APIImporttasksIDStatusGetInternalServerError to nil")
 	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "analysisRecordId":
-			if err := func() error {
-				s.AnalysisRecordId.Reset()
-				if err := s.AnalysisRecordId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"analysisRecordId\"")
-			}
-		case "rowVersion":
-			if err := func() error {
-				v, err := d.Base64()
-				s.RowVersion = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"rowVersion\"")
-			}
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "comparisonDate":
-			if err := func() error {
-				s.ComparisonDate.Reset()
-				if err := s.ComparisonDate.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"comparisonDate\"")
-			}
-		case "targetPrimaryKey":
-			if err := func() error {
-				s.TargetPrimaryKey.Reset()
-				if err := s.TargetPrimaryKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"targetPrimaryKey\"")
-			}
-		case "docKey":
-			if err := func() error {
-				s.DocKey.Reset()
-				if err := s.DocKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"docKey\"")
-			}
-		case "referenceCode":
-			if err := func() error {
-				s.ReferenceCode.Reset()
-				if err := s.ReferenceCode.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"referenceCode\"")
-			}
-		case "level":
-			if err := func() error {
-				s.Level.Reset()
-				if err := s.Level.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"level\"")
-			}
-		case "sourcePrimaryKey":
-			if err := func() error {
-				s.SourcePrimaryKey.Reset()
-				if err := s.SourcePrimaryKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourcePrimaryKey\"")
-			}
-		case "positionNumber":
-			if err := func() error {
-				s.PositionNumber.Reset()
-				if err := s.PositionNumber.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"positionNumber\"")
-			}
-		case "sourceTitle":
-			if err := func() error {
-				s.SourceTitle.Reset()
-				if err := s.SourceTitle.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceTitle\"")
-			}
-		case "destinationTitle":
-			if err := func() error {
-				s.DestinationTitle.Reset()
-				if err := s.DestinationTitle.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationTitle\"")
-			}
-		case "sourceField1":
-			if err := func() error {
-				s.SourceField1.Reset()
-				if err := s.SourceField1.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceField1\"")
-			}
-		case "destinationField1":
-			if err := func() error {
-				s.DestinationField1.Reset()
-				if err := s.DestinationField1.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationField1\"")
-			}
-		case "sourceField2":
-			if err := func() error {
-				s.SourceField2.Reset()
-				if err := s.SourceField2.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceField2\"")
-			}
-		case "destinationField2":
-			if err := func() error {
-				s.DestinationField2.Reset()
-				if err := s.DestinationField2.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationField2\"")
-			}
-		case "sourceField3":
-			if err := func() error {
-				s.SourceField3.Reset()
-				if err := s.SourceField3.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceField3\"")
-			}
-		case "destinationField3":
-			if err := func() error {
-				s.DestinationField3.Reset()
-				if err := s.DestinationField3.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationField3\"")
-			}
-		case "sourceField4":
-			if err := func() error {
-				s.SourceField4.Reset()
-				if err := s.SourceField4.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceField4\"")
-			}
-		case "destinationField4":
-			if err := func() error {
-				s.DestinationField4.Reset()
-				if err := s.DestinationField4.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationField4\"")
-			}
-		case "sourceField5":
-			if err := func() error {
-				s.SourceField5.Reset()
-				if err := s.SourceField5.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"sourceField5\"")
-			}
-		case "destinationField5":
-			if err := func() error {
-				s.DestinationField5.Reset()
-				if err := s.DestinationField5.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"destinationField5\"")
-			}
-		case "titleIsDifferent":
-			if err := func() error {
-				s.TitleIsDifferent.Reset()
-				if err := s.TitleIsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"titleIsDifferent\"")
-			}
-		case "field1IsDifferent":
-			if err := func() error {
-				s.Field1IsDifferent.Reset()
-				if err := s.Field1IsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"field1IsDifferent\"")
-			}
-		case "field2IsDifferent":
-			if err := func() error {
-				s.Field2IsDifferent.Reset()
-				if err := s.Field2IsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"field2IsDifferent\"")
-			}
-		case "field3IsDifferent":
-			if err := func() error {
-				s.Field3IsDifferent.Reset()
-				if err := s.Field3IsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"field3IsDifferent\"")
-			}
-		case "field4IsDifferent":
-			if err := func() error {
-				s.Field4IsDifferent.Reset()
-				if err := s.Field4IsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"field4IsDifferent\"")
-			}
-		case "field5IsDifferent":
-			if err := func() error {
-				s.Field5IsDifferent.Reset()
-				if err := s.Field5IsDifferent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"field5IsDifferent\"")
-			}
-		case "status":
-			if err := func() error {
-				s.Status.Reset()
-				if err := s.Status.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "errorMessage":
-			if err := func() error {
-				s.ErrorMessage.Reset()
-				if err := s.ErrorMessage.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"errorMessage\"")
-			}
-		case "containerDocKey":
-			if err := func() error {
-				s.ContainerDocKey.Reset()
-				if err := s.ContainerDocKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"containerDocKey\"")
-			}
-		case "createdBy":
-			if err := func() error {
-				s.CreatedBy.Reset()
-				if err := s.CreatedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdBy\"")
-			}
-		case "createdOn":
-			if err := func() error {
-				s.CreatedOn.Reset()
-				if err := s.CreatedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdOn\"")
-			}
-		case "modifiedBy":
-			if err := func() error {
-				s.ModifiedBy.Reset()
-				if err := s.ModifiedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedBy\"")
-			}
-		case "modifiedOn":
-			if err := func() error {
-				s.ModifiedOn.Reset()
-				if err := s.ModifiedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedOn\"")
-			}
-		case "importTask":
-			if err := func() error {
-				s.ImportTask.Reset()
-				if err := s.ImportTask.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTask\"")
-			}
-		default:
-			return errors.Errorf("unexpected field %q", k)
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
 		}
 		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AnalysisRecordDto")
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
 	}
-
+	*s = APIImporttasksIDStatusGetInternalServerError(unwrapped)
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *AnalysisRecordDto) MarshalJSON() ([]byte, error) {
+func (s *APIImporttasksIDStatusGetInternalServerError) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AnalysisRecordDto) UnmarshalJSON(data []byte) error {
+func (s *APIImporttasksIDStatusGetInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksIDStatusGetNotFound as json.
+func (s *APIImporttasksIDStatusGetNotFound) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksIDStatusGetNotFound from json.
+func (s *APIImporttasksIDStatusGetNotFound) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksIDStatusGetNotFound to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksIDStatusGetNotFound(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksIDStatusGetNotFound) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksIDStatusGetNotFound) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksIDStatusGetUnauthorized as json.
+func (s *APIImporttasksIDStatusGetUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksIDStatusGetUnauthorized from json.
+func (s *APIImporttasksIDStatusGetUnauthorized) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksIDStatusGetUnauthorized to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksIDStatusGetUnauthorized(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksIDStatusGetUnauthorized) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksIDStatusGetUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksPostBadRequest as json.
+func (s *APIImporttasksPostBadRequest) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksPostBadRequest from json.
+func (s *APIImporttasksPostBadRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksPostBadRequest to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksPostBadRequest(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksPostBadRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksPostBadRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksPostInternalServerError as json.
+func (s *APIImporttasksPostInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksPostInternalServerError from json.
+func (s *APIImporttasksPostInternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksPostInternalServerError to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksPostInternalServerError(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksPostInternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksPostInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksPostUnauthorized as json.
+func (s *APIImporttasksPostUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksPostUnauthorized from json.
+func (s *APIImporttasksPostUnauthorized) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksPostUnauthorized to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksPostUnauthorized(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksPostUnauthorized) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksPostUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes APIImporttasksPostUnsupportedMediaType as json.
+func (s *APIImporttasksPostUnsupportedMediaType) Encode(e *jx.Encoder) {
+	unwrapped := (*ProblemDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes APIImporttasksPostUnsupportedMediaType from json.
+func (s *APIImporttasksPostUnsupportedMediaType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode APIImporttasksPostUnsupportedMediaType to nil")
+	}
+	var unwrapped ProblemDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = APIImporttasksPostUnsupportedMediaType(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *APIImporttasksPostUnsupportedMediaType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *APIImporttasksPostUnsupportedMediaType) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -1218,13 +825,22 @@ func (s *CancelImportTaskRequest) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *CancelImportTaskRequest) encodeFields(e *jx.Encoder) {
 	{
-		e.FieldStart("status")
-		s.Status.Encode(e)
+		if s.Reason.Set {
+			e.FieldStart("reason")
+			s.Reason.Encode(e)
+		}
+	}
+	{
+		if s.CancelledBy.Set {
+			e.FieldStart("cancelledBy")
+			s.CancelledBy.Encode(e)
+		}
 	}
 }
 
-var jsonFieldsNameOfCancelImportTaskRequest = [1]string{
-	0: "status",
+var jsonFieldsNameOfCancelImportTaskRequest = [2]string{
+	0: "reason",
+	1: "cancelledBy",
 }
 
 // Decode decodes CancelImportTaskRequest from json.
@@ -1232,19 +848,28 @@ func (s *CancelImportTaskRequest) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode CancelImportTaskRequest to nil")
 	}
-	var requiredBitSet [1]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "status":
-			requiredBitSet[0] |= 1 << 0
+		case "reason":
 			if err := func() error {
-				if err := s.Status.Decode(d); err != nil {
+				s.Reason.Reset()
+				if err := s.Reason.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
+				return errors.Wrap(err, "decode field \"reason\"")
+			}
+		case "cancelledBy":
+			if err := func() error {
+				s.CancelledBy.Reset()
+				if err := s.CancelledBy.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"cancelledBy\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -1252,38 +877,6 @@ func (s *CancelImportTaskRequest) Decode(d *jx.Decoder) error {
 		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CancelImportTaskRequest")
-	}
-	// Validate required fields.
-	var failures []validate.FieldError
-	for i, mask := range [1]uint8{
-		0b00000001,
-	} {
-		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
-			// Mask only required fields and check equality to mask using XOR.
-			//
-			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
-			// Bits of fields which would be set are actually bits of missed fields.
-			missed := bits.OnesCount8(result)
-			for bitN := 0; bitN < missed; bitN++ {
-				bitIdx := bits.TrailingZeros8(result)
-				fieldIdx := i*8 + bitIdx
-				var name string
-				if fieldIdx < len(jsonFieldsNameOfCancelImportTaskRequest) {
-					name = jsonFieldsNameOfCancelImportTaskRequest[fieldIdx]
-				} else {
-					name = strconv.Itoa(fieldIdx)
-				}
-				failures = append(failures, validate.FieldError{
-					Name:  name,
-					Error: validate.ErrFieldRequired,
-				})
-				// Reset bit.
-				result &^= 1 << bitIdx
-			}
-		}
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
 	}
 
 	return nil
@@ -1312,36 +905,13 @@ func (s *CreateImportRunResponse) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *CreateImportRunResponse) encodeFields(e *jx.Encoder) {
 	{
-		if s.Success.Set {
-			e.FieldStart("success")
-			s.Success.Encode(e)
-		}
-	}
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.ImportRunId.Set {
-			e.FieldStart("importRunId")
-			s.ImportRunId.Encode(e)
-		}
-	}
-	{
-		if s.Error.Set {
-			e.FieldStart("error")
-			s.Error.Encode(e)
-		}
+		e.FieldStart("importRunId")
+		e.Str(s.ImportRunId)
 	}
 }
 
-var jsonFieldsNameOfCreateImportRunResponse = [4]string{
-	0: "success",
-	1: "importTaskId",
-	2: "importRunId",
-	3: "error",
+var jsonFieldsNameOfCreateImportRunResponse = [1]string{
+	0: "importRunId",
 }
 
 // Decode decodes CreateImportRunResponse from json.
@@ -1349,48 +919,21 @@ func (s *CreateImportRunResponse) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode CreateImportRunResponse to nil")
 	}
+	var requiredBitSet [1]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "success":
-			if err := func() error {
-				s.Success.Reset()
-				if err := s.Success.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"success\"")
-			}
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
 		case "importRunId":
+			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				s.ImportRunId.Reset()
-				if err := s.ImportRunId.Decode(d); err != nil {
+				v, err := d.Str()
+				s.ImportRunId = string(v)
+				if err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"importRunId\"")
-			}
-		case "error":
-			if err := func() error {
-				s.Error.Reset()
-				if err := s.Error.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"error\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -1398,6 +941,38 @@ func (s *CreateImportRunResponse) Decode(d *jx.Decoder) error {
 		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CreateImportRunResponse")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfCreateImportRunResponse) {
+					name = jsonFieldsNameOfCreateImportRunResponse[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
 	}
 
 	return nil
@@ -1426,29 +1001,13 @@ func (s *CreateImportTaskResponse) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *CreateImportTaskResponse) encodeFields(e *jx.Encoder) {
 	{
-		if s.Success.Set {
-			e.FieldStart("success")
-			s.Success.Encode(e)
-		}
-	}
-	{
-		if s.Error.Set {
-			e.FieldStart("error")
-			s.Error.Encode(e)
-		}
-	}
-	{
-		if s.ID.Set {
-			e.FieldStart("id")
-			s.ID.Encode(e)
-		}
+		e.FieldStart("importTaskId")
+		e.Str(s.ImportTaskId)
 	}
 }
 
-var jsonFieldsNameOfCreateImportTaskResponse = [3]string{
-	0: "success",
-	1: "error",
-	2: "id",
+var jsonFieldsNameOfCreateImportTaskResponse = [1]string{
+	0: "importTaskId",
 }
 
 // Decode decodes CreateImportTaskResponse from json.
@@ -1456,38 +1015,21 @@ func (s *CreateImportTaskResponse) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode CreateImportTaskResponse to nil")
 	}
+	var requiredBitSet [1]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "success":
+		case "importTaskId":
+			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				s.Success.Reset()
-				if err := s.Success.Decode(d); err != nil {
+				v, err := d.Str()
+				s.ImportTaskId = string(v)
+				if err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"success\"")
-			}
-		case "error":
-			if err := func() error {
-				s.Error.Reset()
-				if err := s.Error.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"error\"")
-			}
-		case "id":
-			if err := func() error {
-				s.ID.Reset()
-				if err := s.ID.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"id\"")
+				return errors.Wrap(err, "decode field \"importTaskId\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -1495,6 +1037,38 @@ func (s *CreateImportTaskResponse) Decode(d *jx.Decoder) error {
 		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode CreateImportTaskResponse")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfCreateImportTaskResponse) {
+					name = jsonFieldsNameOfCreateImportTaskResponse[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
 	}
 
 	return nil
@@ -1514,656 +1088,6 @@ func (s *CreateImportTaskResponse) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s *DefaultValueDto) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *DefaultValueDto) encodeFields(e *jx.Encoder) {
-	{
-		if s.DefaultValueId.Set {
-			e.FieldStart("defaultValueId")
-			s.DefaultValueId.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("rowVersion")
-		e.Base64(s.RowVersion)
-	}
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.AccessionDocKey.Set {
-			e.FieldStart("accessionDocKey")
-			s.AccessionDocKey.Encode(e)
-		}
-	}
-	{
-		if s.AccessionIdName.Set {
-			e.FieldStart("accessionIdName")
-			s.AccessionIdName.Encode(e)
-		}
-	}
-	{
-		if s.InsertNodeDocKey.Set {
-			e.FieldStart("insertNodeDocKey")
-			s.InsertNodeDocKey.Encode(e)
-		}
-	}
-	{
-		if s.InsertNodeIdName.Set {
-			e.FieldStart("insertNodeIdName")
-			s.InsertNodeIdName.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
-	}
-	{
-		if s.ProtectionBaseDate.Set {
-			e.FieldStart("protectionBaseDate")
-			s.ProtectionBaseDate.Encode(e)
-		}
-	}
-	{
-		if s.ProtectionCategory.Set {
-			e.FieldStart("protectionCategory")
-			s.ProtectionCategory.Encode(e)
-		}
-	}
-	{
-		if s.ProtectionDuration.Set {
-			e.FieldStart("protectionDuration")
-			s.ProtectionDuration.Encode(e)
-		}
-	}
-	{
-		if s.MetadataCanBePublished.Set {
-			e.FieldStart("metadataCanBePublished")
-			s.MetadataCanBePublished.Encode(e)
-		}
-	}
-	{
-		if s.Accessibility.Set {
-			e.FieldStart("accessibility")
-			s.Accessibility.Encode(e)
-		}
-	}
-	{
-		if s.Usability.Set {
-			e.FieldStart("usability")
-			s.Usability.Encode(e)
-		}
-	}
-	{
-		if s.PermissionType.Set {
-			e.FieldStart("permissionType")
-			s.PermissionType.Encode(e)
-		}
-	}
-	{
-		if s.CreatedBy.Set {
-			e.FieldStart("createdBy")
-			s.CreatedBy.Encode(e)
-		}
-	}
-	{
-		if s.CreatedOn.Set {
-			e.FieldStart("createdOn")
-			s.CreatedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ModifiedBy.Set {
-			e.FieldStart("modifiedBy")
-			s.ModifiedBy.Encode(e)
-		}
-	}
-	{
-		if s.ModifiedOn.Set {
-			e.FieldStart("modifiedOn")
-			s.ModifiedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ImportTask.Set {
-			e.FieldStart("importTask")
-			s.ImportTask.Encode(e)
-		}
-	}
-}
-
-var jsonFieldsNameOfDefaultValueDto = [20]string{
-	0:  "defaultValueId",
-	1:  "rowVersion",
-	2:  "importTaskId",
-	3:  "accessionDocKey",
-	4:  "accessionIdName",
-	5:  "insertNodeDocKey",
-	6:  "insertNodeIdName",
-	7:  "status",
-	8:  "protectionBaseDate",
-	9:  "protectionCategory",
-	10: "protectionDuration",
-	11: "metadataCanBePublished",
-	12: "accessibility",
-	13: "usability",
-	14: "permissionType",
-	15: "createdBy",
-	16: "createdOn",
-	17: "modifiedBy",
-	18: "modifiedOn",
-	19: "importTask",
-}
-
-// Decode decodes DefaultValueDto from json.
-func (s *DefaultValueDto) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode DefaultValueDto to nil")
-	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "defaultValueId":
-			if err := func() error {
-				s.DefaultValueId.Reset()
-				if err := s.DefaultValueId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"defaultValueId\"")
-			}
-		case "rowVersion":
-			if err := func() error {
-				v, err := d.Base64()
-				s.RowVersion = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"rowVersion\"")
-			}
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "accessionDocKey":
-			if err := func() error {
-				s.AccessionDocKey.Reset()
-				if err := s.AccessionDocKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"accessionDocKey\"")
-			}
-		case "accessionIdName":
-			if err := func() error {
-				s.AccessionIdName.Reset()
-				if err := s.AccessionIdName.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"accessionIdName\"")
-			}
-		case "insertNodeDocKey":
-			if err := func() error {
-				s.InsertNodeDocKey.Reset()
-				if err := s.InsertNodeDocKey.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"insertNodeDocKey\"")
-			}
-		case "insertNodeIdName":
-			if err := func() error {
-				s.InsertNodeIdName.Reset()
-				if err := s.InsertNodeIdName.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"insertNodeIdName\"")
-			}
-		case "status":
-			if err := func() error {
-				s.Status.Reset()
-				if err := s.Status.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "protectionBaseDate":
-			if err := func() error {
-				s.ProtectionBaseDate.Reset()
-				if err := s.ProtectionBaseDate.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"protectionBaseDate\"")
-			}
-		case "protectionCategory":
-			if err := func() error {
-				s.ProtectionCategory.Reset()
-				if err := s.ProtectionCategory.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"protectionCategory\"")
-			}
-		case "protectionDuration":
-			if err := func() error {
-				s.ProtectionDuration.Reset()
-				if err := s.ProtectionDuration.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"protectionDuration\"")
-			}
-		case "metadataCanBePublished":
-			if err := func() error {
-				s.MetadataCanBePublished.Reset()
-				if err := s.MetadataCanBePublished.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"metadataCanBePublished\"")
-			}
-		case "accessibility":
-			if err := func() error {
-				s.Accessibility.Reset()
-				if err := s.Accessibility.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"accessibility\"")
-			}
-		case "usability":
-			if err := func() error {
-				s.Usability.Reset()
-				if err := s.Usability.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"usability\"")
-			}
-		case "permissionType":
-			if err := func() error {
-				s.PermissionType.Reset()
-				if err := s.PermissionType.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"permissionType\"")
-			}
-		case "createdBy":
-			if err := func() error {
-				s.CreatedBy.Reset()
-				if err := s.CreatedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdBy\"")
-			}
-		case "createdOn":
-			if err := func() error {
-				s.CreatedOn.Reset()
-				if err := s.CreatedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdOn\"")
-			}
-		case "modifiedBy":
-			if err := func() error {
-				s.ModifiedBy.Reset()
-				if err := s.ModifiedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedBy\"")
-			}
-		case "modifiedOn":
-			if err := func() error {
-				s.ModifiedOn.Reset()
-				if err := s.ModifiedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedOn\"")
-			}
-		case "importTask":
-			if err := func() error {
-				s.ImportTask.Reset()
-				if err := s.ImportTask.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTask\"")
-			}
-		default:
-			return errors.Errorf("unexpected field %q", k)
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode DefaultValueDto")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s *DefaultValueDto) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *DefaultValueDto) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s *DocumentDto) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *DocumentDto) encodeFields(e *jx.Encoder) {
-	{
-		if s.DocumentId.Set {
-			e.FieldStart("documentId")
-			s.DocumentId.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("rowVersion")
-		e.Base64(s.RowVersion)
-	}
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.FileName.Set {
-			e.FieldStart("fileName")
-			s.FileName.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("dataBlob")
-		e.Base64(s.DataBlob)
-	}
-	{
-		if s.UploadDate.Set {
-			e.FieldStart("uploadDate")
-			s.UploadDate.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.XmlSourceType.Set {
-			e.FieldStart("xmlSourceType")
-			s.XmlSourceType.Encode(e)
-		}
-	}
-	{
-		if s.FileSize.Set {
-			e.FieldStart("fileSize")
-			s.FileSize.Encode(e)
-		}
-	}
-	{
-		if s.CreatedBy.Set {
-			e.FieldStart("createdBy")
-			s.CreatedBy.Encode(e)
-		}
-	}
-	{
-		if s.CreatedOn.Set {
-			e.FieldStart("createdOn")
-			s.CreatedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ModifiedBy.Set {
-			e.FieldStart("modifiedBy")
-			s.ModifiedBy.Encode(e)
-		}
-	}
-	{
-		if s.ModifiedOn.Set {
-			e.FieldStart("modifiedOn")
-			s.ModifiedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ImportTask.Set {
-			e.FieldStart("importTask")
-			s.ImportTask.Encode(e)
-		}
-	}
-}
-
-var jsonFieldsNameOfDocumentDto = [13]string{
-	0:  "documentId",
-	1:  "rowVersion",
-	2:  "importTaskId",
-	3:  "fileName",
-	4:  "dataBlob",
-	5:  "uploadDate",
-	6:  "xmlSourceType",
-	7:  "fileSize",
-	8:  "createdBy",
-	9:  "createdOn",
-	10: "modifiedBy",
-	11: "modifiedOn",
-	12: "importTask",
-}
-
-// Decode decodes DocumentDto from json.
-func (s *DocumentDto) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode DocumentDto to nil")
-	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "documentId":
-			if err := func() error {
-				s.DocumentId.Reset()
-				if err := s.DocumentId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"documentId\"")
-			}
-		case "rowVersion":
-			if err := func() error {
-				v, err := d.Base64()
-				s.RowVersion = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"rowVersion\"")
-			}
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "fileName":
-			if err := func() error {
-				s.FileName.Reset()
-				if err := s.FileName.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"fileName\"")
-			}
-		case "dataBlob":
-			if err := func() error {
-				v, err := d.Base64()
-				s.DataBlob = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"dataBlob\"")
-			}
-		case "uploadDate":
-			if err := func() error {
-				s.UploadDate.Reset()
-				if err := s.UploadDate.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"uploadDate\"")
-			}
-		case "xmlSourceType":
-			if err := func() error {
-				s.XmlSourceType.Reset()
-				if err := s.XmlSourceType.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"xmlSourceType\"")
-			}
-		case "fileSize":
-			if err := func() error {
-				s.FileSize.Reset()
-				if err := s.FileSize.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"fileSize\"")
-			}
-		case "createdBy":
-			if err := func() error {
-				s.CreatedBy.Reset()
-				if err := s.CreatedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdBy\"")
-			}
-		case "createdOn":
-			if err := func() error {
-				s.CreatedOn.Reset()
-				if err := s.CreatedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdOn\"")
-			}
-		case "modifiedBy":
-			if err := func() error {
-				s.ModifiedBy.Reset()
-				if err := s.ModifiedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedBy\"")
-			}
-		case "modifiedOn":
-			if err := func() error {
-				s.ModifiedOn.Reset()
-				if err := s.ModifiedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedOn\"")
-			}
-		case "importTask":
-			if err := func() error {
-				s.ImportTask.Reset()
-				if err := s.ImportTask.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTask\"")
-			}
-		default:
-			return errors.Errorf("unexpected field %q", k)
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode DocumentDto")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s *DocumentDto) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *DocumentDto) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *HealthCheckResult) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -2173,6 +1097,12 @@ func (s *HealthCheckResult) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *HealthCheckResult) encodeFields(e *jx.Encoder) {
 	{
+		if s.DurationMs.Set {
+			e.FieldStart("durationMs")
+			s.DurationMs.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("name")
 		e.Str(s.Name)
 	}
@@ -2180,18 +1110,12 @@ func (s *HealthCheckResult) encodeFields(e *jx.Encoder) {
 		e.FieldStart("status")
 		e.Str(s.Status)
 	}
-	{
-		if s.DurationMs.Set {
-			e.FieldStart("durationMs")
-			s.DurationMs.Encode(e)
-		}
-	}
 }
 
 var jsonFieldsNameOfHealthCheckResult = [3]string{
-	0: "name",
-	1: "status",
-	2: "durationMs",
+	0: "durationMs",
+	1: "name",
+	2: "status",
 }
 
 // Decode decodes HealthCheckResult from json.
@@ -2203,8 +1127,18 @@ func (s *HealthCheckResult) Decode(d *jx.Decoder) error {
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
+		case "durationMs":
+			if err := func() error {
+				s.DurationMs.Reset()
+				if err := s.DurationMs.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"durationMs\"")
+			}
 		case "name":
-			requiredBitSet[0] |= 1 << 0
+			requiredBitSet[0] |= 1 << 1
 			if err := func() error {
 				v, err := d.Str()
 				s.Name = string(v)
@@ -2216,7 +1150,7 @@ func (s *HealthCheckResult) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"name\"")
 			}
 		case "status":
-			requiredBitSet[0] |= 1 << 1
+			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
 				v, err := d.Str()
 				s.Status = string(v)
@@ -2226,16 +1160,6 @@ func (s *HealthCheckResult) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "durationMs":
-			if err := func() error {
-				s.DurationMs.Reset()
-				if err := s.DurationMs.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"durationMs\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -2247,7 +1171,7 @@ func (s *HealthCheckResult) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000110,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -2303,20 +1227,20 @@ func (s *HealthStatusResult) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *HealthStatusResult) encodeFields(e *jx.Encoder) {
 	{
-		e.FieldStart("status")
-		e.Str(s.Status)
-	}
-	{
 		if s.Checks.Set {
 			e.FieldStart("checks")
 			s.Checks.Encode(e)
 		}
 	}
+	{
+		e.FieldStart("status")
+		e.Str(s.Status)
+	}
 }
 
 var jsonFieldsNameOfHealthStatusResult = [2]string{
-	0: "status",
-	1: "checks",
+	0: "checks",
+	1: "status",
 }
 
 // Decode decodes HealthStatusResult from json.
@@ -2328,18 +1252,6 @@ func (s *HealthStatusResult) Decode(d *jx.Decoder) error {
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "status":
-			requiredBitSet[0] |= 1 << 0
-			if err := func() error {
-				v, err := d.Str()
-				s.Status = string(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
 		case "checks":
 			if err := func() error {
 				s.Checks.Reset()
@@ -2349,6 +1261,18 @@ func (s *HealthStatusResult) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"checks\"")
+			}
+		case "status":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.Status = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"status\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -2360,7 +1284,7 @@ func (s *HealthStatusResult) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000001,
+		0b00000010,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -2402,323 +1326,6 @@ func (s *HealthStatusResult) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *HealthStatusResult) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s *ImportDto) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *ImportDto) encodeFields(e *jx.Encoder) {
-	{
-		if s.ImportId.Set {
-			e.FieldStart("importId")
-			s.ImportId.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("rowVersion")
-		e.Base64(s.RowVersion)
-	}
-	{
-		if s.TaskId.Set {
-			e.FieldStart("taskId")
-			s.TaskId.Encode(e)
-		}
-	}
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
-	}
-	{
-		if s.Description.Set {
-			e.FieldStart("description")
-			s.Description.Encode(e)
-		}
-	}
-	{
-		if s.ProcessedDocumentCount.Set {
-			e.FieldStart("processedDocumentCount")
-			s.ProcessedDocumentCount.Encode(e)
-		}
-	}
-	{
-		if s.TotalDocumentCount.Set {
-			e.FieldStart("totalDocumentCount")
-			s.TotalDocumentCount.Encode(e)
-		}
-	}
-	{
-		if s.ImportDate.Set {
-			e.FieldStart("importDate")
-			s.ImportDate.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ImportFileBlob.Set {
-			e.FieldStart("importFileBlob")
-			s.ImportFileBlob.Encode(e)
-		}
-	}
-	{
-		if s.IsSuccessful.Set {
-			e.FieldStart("isSuccessful")
-			s.IsSuccessful.Encode(e)
-		}
-	}
-	{
-		if s.CreatedBy.Set {
-			e.FieldStart("createdBy")
-			s.CreatedBy.Encode(e)
-		}
-	}
-	{
-		if s.CreatedOn.Set {
-			e.FieldStart("createdOn")
-			s.CreatedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ModifiedBy.Set {
-			e.FieldStart("modifiedBy")
-			s.ModifiedBy.Encode(e)
-		}
-	}
-	{
-		if s.ModifiedOn.Set {
-			e.FieldStart("modifiedOn")
-			s.ModifiedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ImportTask.Set {
-			e.FieldStart("importTask")
-			s.ImportTask.Encode(e)
-		}
-	}
-}
-
-var jsonFieldsNameOfImportDto = [16]string{
-	0:  "importId",
-	1:  "rowVersion",
-	2:  "taskId",
-	3:  "importTaskId",
-	4:  "status",
-	5:  "description",
-	6:  "processedDocumentCount",
-	7:  "totalDocumentCount",
-	8:  "importDate",
-	9:  "importFileBlob",
-	10: "isSuccessful",
-	11: "createdBy",
-	12: "createdOn",
-	13: "modifiedBy",
-	14: "modifiedOn",
-	15: "importTask",
-}
-
-// Decode decodes ImportDto from json.
-func (s *ImportDto) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ImportDto to nil")
-	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "importId":
-			if err := func() error {
-				s.ImportId.Reset()
-				if err := s.ImportId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importId\"")
-			}
-		case "rowVersion":
-			if err := func() error {
-				v, err := d.Base64()
-				s.RowVersion = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"rowVersion\"")
-			}
-		case "taskId":
-			if err := func() error {
-				s.TaskId.Reset()
-				if err := s.TaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"taskId\"")
-			}
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "status":
-			if err := func() error {
-				s.Status.Reset()
-				if err := s.Status.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "description":
-			if err := func() error {
-				s.Description.Reset()
-				if err := s.Description.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"description\"")
-			}
-		case "processedDocumentCount":
-			if err := func() error {
-				s.ProcessedDocumentCount.Reset()
-				if err := s.ProcessedDocumentCount.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"processedDocumentCount\"")
-			}
-		case "totalDocumentCount":
-			if err := func() error {
-				s.TotalDocumentCount.Reset()
-				if err := s.TotalDocumentCount.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"totalDocumentCount\"")
-			}
-		case "importDate":
-			if err := func() error {
-				s.ImportDate.Reset()
-				if err := s.ImportDate.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importDate\"")
-			}
-		case "importFileBlob":
-			if err := func() error {
-				s.ImportFileBlob.Reset()
-				if err := s.ImportFileBlob.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importFileBlob\"")
-			}
-		case "isSuccessful":
-			if err := func() error {
-				s.IsSuccessful.Reset()
-				if err := s.IsSuccessful.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"isSuccessful\"")
-			}
-		case "createdBy":
-			if err := func() error {
-				s.CreatedBy.Reset()
-				if err := s.CreatedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdBy\"")
-			}
-		case "createdOn":
-			if err := func() error {
-				s.CreatedOn.Reset()
-				if err := s.CreatedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdOn\"")
-			}
-		case "modifiedBy":
-			if err := func() error {
-				s.ModifiedBy.Reset()
-				if err := s.ModifiedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedBy\"")
-			}
-		case "modifiedOn":
-			if err := func() error {
-				s.ModifiedOn.Reset()
-				if err := s.ModifiedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedOn\"")
-			}
-		case "importTask":
-			if err := func() error {
-				s.ImportTask.Reset()
-				if err := s.ImportTask.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTask\"")
-			}
-		default:
-			return errors.Errorf("unexpected field %q", k)
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ImportDto")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s *ImportDto) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ImportDto) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -2773,22 +1380,8 @@ func (s *ImportRunStatusResponse) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *ImportRunStatusResponse) encodeFields(e *jx.Encoder) {
 	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		if s.ImportRunId.Set {
-			e.FieldStart("importRunId")
-			s.ImportRunId.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
+		e.FieldStart("status")
+		s.Status.Encode(e)
 	}
 	{
 		if s.ProgressPercent.Set {
@@ -2797,19 +1390,31 @@ func (s *ImportRunStatusResponse) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.Error.Set {
-			e.FieldStart("error")
-			s.Error.Encode(e)
+		if s.ImportResult.Set {
+			e.FieldStart("importResult")
+			s.ImportResult.Encode(e)
+		}
+	}
+	{
+		if s.ProcessedDocumentCount.Set {
+			e.FieldStart("processedDocumentCount")
+			s.ProcessedDocumentCount.Encode(e)
+		}
+	}
+	{
+		if s.TotalDocumentCount.Set {
+			e.FieldStart("totalDocumentCount")
+			s.TotalDocumentCount.Encode(e)
 		}
 	}
 }
 
 var jsonFieldsNameOfImportRunStatusResponse = [5]string{
-	0: "importTaskId",
-	1: "importRunId",
-	2: "status",
-	3: "progressPercent",
-	4: "error",
+	0: "status",
+	1: "progressPercent",
+	2: "importResult",
+	3: "processedDocumentCount",
+	4: "totalDocumentCount",
 }
 
 // Decode decodes ImportRunStatusResponse from json.
@@ -2817,32 +1422,13 @@ func (s *ImportRunStatusResponse) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode ImportRunStatusResponse to nil")
 	}
+	var requiredBitSet [1]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "importRunId":
-			if err := func() error {
-				s.ImportRunId.Reset()
-				if err := s.ImportRunId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importRunId\"")
-			}
 		case "status":
+			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				s.Status.Reset()
 				if err := s.Status.Decode(d); err != nil {
 					return err
 				}
@@ -2860,15 +1446,35 @@ func (s *ImportRunStatusResponse) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"progressPercent\"")
 			}
-		case "error":
+		case "importResult":
 			if err := func() error {
-				s.Error.Reset()
-				if err := s.Error.Decode(d); err != nil {
+				s.ImportResult.Reset()
+				if err := s.ImportResult.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"error\"")
+				return errors.Wrap(err, "decode field \"importResult\"")
+			}
+		case "processedDocumentCount":
+			if err := func() error {
+				s.ProcessedDocumentCount.Reset()
+				if err := s.ProcessedDocumentCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"processedDocumentCount\"")
+			}
+		case "totalDocumentCount":
+			if err := func() error {
+				s.TotalDocumentCount.Reset()
+				if err := s.TotalDocumentCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"totalDocumentCount\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -2876,6 +1482,38 @@ func (s *ImportRunStatusResponse) Decode(d *jx.Decoder) error {
 		return nil
 	}); err != nil {
 		return errors.Wrap(err, "decode ImportRunStatusResponse")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfImportRunStatusResponse) {
+					name = jsonFieldsNameOfImportRunStatusResponse[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
 	}
 
 	return nil
@@ -2894,414 +1532,58 @@ func (s *ImportRunStatusResponse) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode implements json.Marshaler.
-func (s *ImportTaskDto) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
+// Encode encodes ImportStatus as json.
+func (s ImportStatus) Encode(e *jx.Encoder) {
+	e.Str(string(s))
 }
 
-// encodeFields encodes fields.
-func (s *ImportTaskDto) encodeFields(e *jx.Encoder) {
-	{
-		if s.ImportTaskId.Set {
-			e.FieldStart("importTaskId")
-			s.ImportTaskId.Encode(e)
-		}
-	}
-	{
-		e.FieldStart("rowVersion")
-		e.Base64(s.RowVersion)
-	}
-	{
-		if s.TaskType.Set {
-			e.FieldStart("taskType")
-			s.TaskType.Encode(e)
-		}
-	}
-	{
-		if s.Name.Set {
-			e.FieldStart("name")
-			s.Name.Encode(e)
-		}
-	}
-	{
-		if s.NoAutomaticImport.Set {
-			e.FieldStart("noAutomaticImport")
-			s.NoAutomaticImport.Encode(e)
-		}
-	}
-	{
-		if s.RequiresContainers.Set {
-			e.FieldStart("requiresContainers")
-			s.RequiresContainers.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
-	}
-	{
-		if s.AnalysisErrorMessage.Set {
-			e.FieldStart("analysisErrorMessage")
-			s.AnalysisErrorMessage.Encode(e)
-		}
-	}
-	{
-		if s.AnalysisResult.Set {
-			e.FieldStart("analysisResult")
-			s.AnalysisResult.Encode(e)
-		}
-	}
-	{
-		if s.AnalysisProgressInPercent.Set {
-			e.FieldStart("analysisProgressInPercent")
-			s.AnalysisProgressInPercent.Encode(e)
-		}
-	}
-	{
-		if s.ImportResult.Set {
-			e.FieldStart("importResult")
-			s.ImportResult.Encode(e)
-		}
-	}
-	{
-		if s.CreatedBy.Set {
-			e.FieldStart("createdBy")
-			s.CreatedBy.Encode(e)
-		}
-	}
-	{
-		if s.CreatedOn.Set {
-			e.FieldStart("createdOn")
-			s.CreatedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.ModifiedBy.Set {
-			e.FieldStart("modifiedBy")
-			s.ModifiedBy.Encode(e)
-		}
-	}
-	{
-		if s.ModifiedOn.Set {
-			e.FieldStart("modifiedOn")
-			s.ModifiedOn.Encode(e, json.EncodeDateTime)
-		}
-	}
-	{
-		if s.AnalysisRecords != nil {
-			e.FieldStart("analysisRecords")
-			e.ArrStart()
-			for _, elem := range s.AnalysisRecords {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
-		}
-	}
-	{
-		if s.DefaultValues != nil {
-			e.FieldStart("defaultValues")
-			e.ArrStart()
-			for _, elem := range s.DefaultValues {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
-		}
-	}
-	{
-		if s.Documents != nil {
-			e.FieldStart("documents")
-			e.ArrStart()
-			for _, elem := range s.Documents {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
-		}
-	}
-	{
-		if s.Imports != nil {
-			e.FieldStart("imports")
-			e.ArrStart()
-			for _, elem := range s.Imports {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
-		}
-	}
-}
-
-var jsonFieldsNameOfImportTaskDto = [19]string{
-	0:  "importTaskId",
-	1:  "rowVersion",
-	2:  "taskType",
-	3:  "name",
-	4:  "noAutomaticImport",
-	5:  "requiresContainers",
-	6:  "status",
-	7:  "analysisErrorMessage",
-	8:  "analysisResult",
-	9:  "analysisProgressInPercent",
-	10: "importResult",
-	11: "createdBy",
-	12: "createdOn",
-	13: "modifiedBy",
-	14: "modifiedOn",
-	15: "analysisRecords",
-	16: "defaultValues",
-	17: "documents",
-	18: "imports",
-}
-
-// Decode decodes ImportTaskDto from json.
-func (s *ImportTaskDto) Decode(d *jx.Decoder) error {
+// Decode decodes ImportStatus from json.
+func (s *ImportStatus) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode ImportTaskDto to nil")
+		return errors.New("invalid: unable to decode ImportStatus to nil")
 	}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "importTaskId":
-			if err := func() error {
-				s.ImportTaskId.Reset()
-				if err := s.ImportTaskId.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importTaskId\"")
-			}
-		case "rowVersion":
-			if err := func() error {
-				v, err := d.Base64()
-				s.RowVersion = []byte(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"rowVersion\"")
-			}
-		case "taskType":
-			if err := func() error {
-				s.TaskType.Reset()
-				if err := s.TaskType.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"taskType\"")
-			}
-		case "name":
-			if err := func() error {
-				s.Name.Reset()
-				if err := s.Name.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"name\"")
-			}
-		case "noAutomaticImport":
-			if err := func() error {
-				s.NoAutomaticImport.Reset()
-				if err := s.NoAutomaticImport.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"noAutomaticImport\"")
-			}
-		case "requiresContainers":
-			if err := func() error {
-				s.RequiresContainers.Reset()
-				if err := s.RequiresContainers.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"requiresContainers\"")
-			}
-		case "status":
-			if err := func() error {
-				s.Status.Reset()
-				if err := s.Status.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "analysisErrorMessage":
-			if err := func() error {
-				s.AnalysisErrorMessage.Reset()
-				if err := s.AnalysisErrorMessage.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"analysisErrorMessage\"")
-			}
-		case "analysisResult":
-			if err := func() error {
-				s.AnalysisResult.Reset()
-				if err := s.AnalysisResult.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"analysisResult\"")
-			}
-		case "analysisProgressInPercent":
-			if err := func() error {
-				s.AnalysisProgressInPercent.Reset()
-				if err := s.AnalysisProgressInPercent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"analysisProgressInPercent\"")
-			}
-		case "importResult":
-			if err := func() error {
-				s.ImportResult.Reset()
-				if err := s.ImportResult.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importResult\"")
-			}
-		case "createdBy":
-			if err := func() error {
-				s.CreatedBy.Reset()
-				if err := s.CreatedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdBy\"")
-			}
-		case "createdOn":
-			if err := func() error {
-				s.CreatedOn.Reset()
-				if err := s.CreatedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"createdOn\"")
-			}
-		case "modifiedBy":
-			if err := func() error {
-				s.ModifiedBy.Reset()
-				if err := s.ModifiedBy.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedBy\"")
-			}
-		case "modifiedOn":
-			if err := func() error {
-				s.ModifiedOn.Reset()
-				if err := s.ModifiedOn.Decode(d, json.DecodeDateTime); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"modifiedOn\"")
-			}
-		case "analysisRecords":
-			if err := func() error {
-				s.AnalysisRecords = make([]AnalysisRecordDto, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem AnalysisRecordDto
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.AnalysisRecords = append(s.AnalysisRecords, elem)
-					return nil
-				}); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"analysisRecords\"")
-			}
-		case "defaultValues":
-			if err := func() error {
-				s.DefaultValues = make([]DefaultValueDto, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem DefaultValueDto
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.DefaultValues = append(s.DefaultValues, elem)
-					return nil
-				}); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"defaultValues\"")
-			}
-		case "documents":
-			if err := func() error {
-				s.Documents = make([]DocumentDto, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem DocumentDto
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.Documents = append(s.Documents, elem)
-					return nil
-				}); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"documents\"")
-			}
-		case "imports":
-			if err := func() error {
-				s.Imports = make([]ImportDto, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem ImportDto
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.Imports = append(s.Imports, elem)
-					return nil
-				}); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"imports\"")
-			}
-		default:
-			return errors.Errorf("unexpected field %q", k)
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ImportTaskDto")
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ImportStatus(v) {
+	case ImportStatusRequestStart:
+		*s = ImportStatusRequestStart
+	case ImportStatusRequestCancel:
+		*s = ImportStatusRequestCancel
+	case ImportStatusStarted:
+		*s = ImportStatusStarted
+	case ImportStatusFailed:
+		*s = ImportStatusFailed
+	case ImportStatusCanceled:
+		*s = ImportStatusCanceled
+	case ImportStatusCompleted:
+		*s = ImportStatusCompleted
+	case ImportStatusUndoStarted:
+		*s = ImportStatusUndoStarted
+	case ImportStatusUndoCompleted:
+		*s = ImportStatusUndoCompleted
+	case ImportStatusCreated:
+		*s = ImportStatusCreated
+	case ImportStatusPreparing:
+		*s = ImportStatusPreparing
+	default:
+		*s = ImportStatus(v)
 	}
 
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *ImportTaskDto) MarshalJSON() ([]byte, error) {
+func (s ImportStatus) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ImportTaskDto) UnmarshalJSON(data []byte) error {
+func (s *ImportStatus) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -3380,39 +1662,25 @@ func (s *ImportTaskStatusResponse) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.AnalysisErrorMessage.Set {
+			e.FieldStart("analysisErrorMessage")
+			s.AnalysisErrorMessage.Encode(e)
+		}
+	}
+	{
 		if s.ImportResult.Set {
 			e.FieldStart("importResult")
 			s.ImportResult.Encode(e)
 		}
 	}
-	{
-		if s.ImportProgressInPercent.Set {
-			e.FieldStart("importProgressInPercent")
-			s.ImportProgressInPercent.Encode(e)
-		}
-	}
-	{
-		if s.ProcessedDocumentCount.Set {
-			e.FieldStart("processedDocumentCount")
-			s.ProcessedDocumentCount.Encode(e)
-		}
-	}
-	{
-		if s.TotalDocumentCount.Set {
-			e.FieldStart("totalDocumentCount")
-			s.TotalDocumentCount.Encode(e)
-		}
-	}
 }
 
-var jsonFieldsNameOfImportTaskStatusResponse = [7]string{
+var jsonFieldsNameOfImportTaskStatusResponse = [5]string{
 	0: "status",
 	1: "analysisResult",
 	2: "analysisProgressInPercent",
-	3: "importResult",
-	4: "importProgressInPercent",
-	5: "processedDocumentCount",
-	6: "totalDocumentCount",
+	3: "analysisErrorMessage",
+	4: "importResult",
 }
 
 // Decode decodes ImportTaskStatusResponse from json.
@@ -3454,6 +1722,16 @@ func (s *ImportTaskStatusResponse) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"analysisProgressInPercent\"")
 			}
+		case "analysisErrorMessage":
+			if err := func() error {
+				s.AnalysisErrorMessage.Reset()
+				if err := s.AnalysisErrorMessage.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"analysisErrorMessage\"")
+			}
 		case "importResult":
 			if err := func() error {
 				s.ImportResult.Reset()
@@ -3463,36 +1741,6 @@ func (s *ImportTaskStatusResponse) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"importResult\"")
-			}
-		case "importProgressInPercent":
-			if err := func() error {
-				s.ImportProgressInPercent.Reset()
-				if err := s.ImportProgressInPercent.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"importProgressInPercent\"")
-			}
-		case "processedDocumentCount":
-			if err := func() error {
-				s.ProcessedDocumentCount.Reset()
-				if err := s.ProcessedDocumentCount.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"processedDocumentCount\"")
-			}
-		case "totalDocumentCount":
-			if err := func() error {
-				s.TotalDocumentCount.Reset()
-				if err := s.TotalDocumentCount.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"totalDocumentCount\"")
 			}
 		default:
 			return errors.Errorf("unexpected field %q", k)
@@ -3583,76 +1831,6 @@ func (s *OptAnalysisResult) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes bool as json.
-func (o OptBool) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	e.Bool(bool(o.Value))
-}
-
-// Decode decodes bool from json.
-func (o *OptBool) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptBool to nil")
-	}
-	o.Set = true
-	v, err := d.Bool()
-	if err != nil {
-		return err
-	}
-	o.Value = bool(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptBool) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptBool) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes time.Time as json.
-func (o OptDateTime) Encode(e *jx.Encoder, format func(*jx.Encoder, time.Time)) {
-	if !o.Set {
-		return
-	}
-	format(e, o.Value)
-}
-
-// Decode decodes time.Time from json.
-func (o *OptDateTime) Decode(d *jx.Decoder, format func(*jx.Decoder) (time.Time, error)) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptDateTime to nil")
-	}
-	o.Set = true
-	v, err := format(d)
-	if err != nil {
-		return err
-	}
-	o.Value = v
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptDateTime) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e, json.EncodeDateTime)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptDateTime) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d, json.DecodeDateTime)
-}
-
 // Encode encodes float64 as json.
 func (o OptFloat64) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -3719,262 +1897,6 @@ func (s OptImportResult) MarshalJSON() ([]byte, error) {
 func (s *OptImportResult) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
-}
-
-// Encode encodes ImportTaskDto as json.
-func (o OptImportTaskDto) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes ImportTaskDto from json.
-func (o *OptImportTaskDto) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptImportTaskDto to nil")
-	}
-	o.Set = true
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptImportTaskDto) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptImportTaskDto) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes int32 as json.
-func (o OptInt32) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	e.Int32(int32(o.Value))
-}
-
-// Decode decodes int32 from json.
-func (o *OptInt32) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptInt32 to nil")
-	}
-	o.Set = true
-	v, err := d.Int32()
-	if err != nil {
-		return err
-	}
-	o.Value = int32(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptInt32) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptInt32) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes int64 as json.
-func (o OptInt64) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	e.Int64(int64(o.Value))
-}
-
-// Decode decodes int64 from json.
-func (o *OptInt64) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptInt64 to nil")
-	}
-	o.Set = true
-	v, err := d.Int64()
-	if err != nil {
-		return err
-	}
-	o.Value = int64(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptInt64) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptInt64) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes bool as json.
-func (o OptNilBool) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	if o.Null {
-		e.Null()
-		return
-	}
-	e.Bool(bool(o.Value))
-}
-
-// Decode decodes bool from json.
-func (o *OptNilBool) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptNilBool to nil")
-	}
-	if d.Next() == jx.Null {
-		if err := d.Null(); err != nil {
-			return err
-		}
-
-		var v bool
-		o.Value = v
-		o.Set = true
-		o.Null = true
-		return nil
-	}
-	o.Set = true
-	o.Null = false
-	v, err := d.Bool()
-	if err != nil {
-		return err
-	}
-	o.Value = bool(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptNilBool) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptNilBool) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes []byte as json.
-func (o OptNilByte) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	if o.Null {
-		e.Null()
-		return
-	}
-	e.Base64([]byte(o.Value))
-}
-
-// Decode decodes []byte from json.
-func (o *OptNilByte) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptNilByte to nil")
-	}
-	if d.Next() == jx.Null {
-		if err := d.Null(); err != nil {
-			return err
-		}
-
-		var v []byte
-		o.Value = v
-		o.Set = true
-		o.Null = true
-		return nil
-	}
-	o.Set = true
-	o.Null = false
-	v, err := d.Base64()
-	if err != nil {
-		return err
-	}
-	o.Value = []byte(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptNilByte) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptNilByte) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes time.Time as json.
-func (o OptNilDateTime) Encode(e *jx.Encoder, format func(*jx.Encoder, time.Time)) {
-	if !o.Set {
-		return
-	}
-	if o.Null {
-		e.Null()
-		return
-	}
-	format(e, o.Value)
-}
-
-// Decode decodes time.Time from json.
-func (o *OptNilDateTime) Decode(d *jx.Decoder, format func(*jx.Decoder) (time.Time, error)) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptNilDateTime to nil")
-	}
-	if d.Next() == jx.Null {
-		if err := d.Null(); err != nil {
-			return err
-		}
-
-		var v time.Time
-		o.Value = v
-		o.Set = true
-		o.Null = true
-		return nil
-	}
-	o.Set = true
-	o.Null = false
-	v, err := format(d)
-	if err != nil {
-		return err
-	}
-	o.Value = v
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptNilDateTime) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e, json.EncodeDateTime)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptNilDateTime) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d, json.DecodeDateTime)
 }
 
 // Encode encodes []HealthCheckResult as json.
@@ -4136,110 +2058,6 @@ func (s OptNilString) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptNilString) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes string as json.
-func (o OptString) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	e.Str(string(o.Value))
-}
-
-// Decode decodes string from json.
-func (o *OptString) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptString to nil")
-	}
-	o.Set = true
-	v, err := d.Str()
-	if err != nil {
-		return err
-	}
-	o.Value = string(v)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptString) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptString) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes uuid.UUID as json.
-func (o OptUUID) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	json.EncodeUUID(e, o.Value)
-}
-
-// Decode decodes uuid.UUID from json.
-func (o *OptUUID) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptUUID to nil")
-	}
-	o.Set = true
-	v, err := json.DecodeUUID(d)
-	if err != nil {
-		return err
-	}
-	o.Value = v
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptUUID) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptUUID) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes ValidationProblemDetailsErrors as json.
-func (o OptValidationProblemDetailsErrors) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes ValidationProblemDetailsErrors from json.
-func (o *OptValidationProblemDetailsErrors) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptValidationProblemDetailsErrors to nil")
-	}
-	o.Set = true
-	o.Value = make(ValidationProblemDetailsErrors)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptValidationProblemDetailsErrors) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptValidationProblemDetailsErrors) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -4448,299 +2266,6 @@ func (s ProblemDetailsAdditional) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *ProblemDetailsAdditional) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s *ValidationProblemDetails) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *ValidationProblemDetails) encodeFields(e *jx.Encoder) {
-	{
-		if s.Type.Set {
-			e.FieldStart("type")
-			s.Type.Encode(e)
-		}
-	}
-	{
-		if s.Title.Set {
-			e.FieldStart("title")
-			s.Title.Encode(e)
-		}
-	}
-	{
-		if s.Status.Set {
-			e.FieldStart("status")
-			s.Status.Encode(e)
-		}
-	}
-	{
-		if s.Detail.Set {
-			e.FieldStart("detail")
-			s.Detail.Encode(e)
-		}
-	}
-	{
-		if s.Instance.Set {
-			e.FieldStart("instance")
-			s.Instance.Encode(e)
-		}
-	}
-	{
-		if s.Errors.Set {
-			e.FieldStart("errors")
-			s.Errors.Encode(e)
-		}
-	}
-	for k, elem := range s.AdditionalProps {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-var jsonFieldsNameOfValidationProblemDetails = [6]string{
-	0: "type",
-	1: "title",
-	2: "status",
-	3: "detail",
-	4: "instance",
-	5: "errors",
-}
-
-// Decode decodes ValidationProblemDetails from json.
-func (s *ValidationProblemDetails) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ValidationProblemDetails to nil")
-	}
-	s.AdditionalProps = map[string]jx.Raw{}
-
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		switch string(k) {
-		case "type":
-			if err := func() error {
-				s.Type.Reset()
-				if err := s.Type.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"type\"")
-			}
-		case "title":
-			if err := func() error {
-				s.Title.Reset()
-				if err := s.Title.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"title\"")
-			}
-		case "status":
-			if err := func() error {
-				s.Status.Reset()
-				if err := s.Status.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"status\"")
-			}
-		case "detail":
-			if err := func() error {
-				s.Detail.Reset()
-				if err := s.Detail.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"detail\"")
-			}
-		case "instance":
-			if err := func() error {
-				s.Instance.Reset()
-				if err := s.Instance.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"instance\"")
-			}
-		case "errors":
-			if err := func() error {
-				s.Errors.Reset()
-				if err := s.Errors.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"errors\"")
-			}
-		default:
-			var elem jx.Raw
-			if err := func() error {
-				v, err := d.RawAppend(nil)
-				elem = jx.Raw(v)
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrapf(err, "decode field %q", k)
-			}
-			s.AdditionalProps[string(k)] = elem
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ValidationProblemDetails")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s *ValidationProblemDetails) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ValidationProblemDetails) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s ValidationProblemDetailsAdditional) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s ValidationProblemDetailsAdditional) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes ValidationProblemDetailsAdditional from json.
-func (s *ValidationProblemDetailsAdditional) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ValidationProblemDetailsAdditional to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ValidationProblemDetailsAdditional")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s ValidationProblemDetailsAdditional) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ValidationProblemDetailsAdditional) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s ValidationProblemDetailsErrors) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s ValidationProblemDetailsErrors) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		e.ArrStart()
-		for _, elem := range elem {
-			e.Str(elem)
-		}
-		e.ArrEnd()
-	}
-}
-
-// Decode decodes ValidationProblemDetailsErrors from json.
-func (s *ValidationProblemDetailsErrors) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ValidationProblemDetailsErrors to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem []string
-		if err := func() error {
-			elem = make([]string, 0)
-			if err := d.Arr(func(d *jx.Decoder) error {
-				var elemElem string
-				v, err := d.Str()
-				elemElem = string(v)
-				if err != nil {
-					return err
-				}
-				elem = append(elem, elemElem)
-				return nil
-			}); err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ValidationProblemDetailsErrors")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s ValidationProblemDetailsErrors) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ValidationProblemDetailsErrors) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/apis/gen/oas_operations_gen.go
+++ b/internal/apis/gen/oas_operations_gen.go
@@ -7,9 +7,9 @@ type OperationName = string
 
 const (
 	APIHealthzGetOperation                            OperationName = "APIHealthzGet"
-	APIImportTasksIDImportRunsPostOperation           OperationName = "APIImportTasksIDImportRunsPost"
-	APIImportTasksIDImportRunsRunIdStatusGetOperation OperationName = "APIImportTasksIDImportRunsRunIdStatusGet"
-	APIImportTasksIDPatchOperation                    OperationName = "APIImportTasksIDPatch"
-	APIImportTasksIDStatusGetOperation                OperationName = "APIImportTasksIDStatusGet"
-	APIImportTasksPostOperation                       OperationName = "APIImportTasksPost"
+	APIImporttasksIDCancelPostOperation               OperationName = "APIImporttasksIDCancelPost"
+	APIImporttasksIDImportrunsPostOperation           OperationName = "APIImporttasksIDImportrunsPost"
+	APIImporttasksIDImportrunsRunIdStatusGetOperation OperationName = "APIImporttasksIDImportrunsRunIdStatusGet"
+	APIImporttasksIDStatusGetOperation                OperationName = "APIImporttasksIDStatusGet"
+	APIImporttasksPostOperation                       OperationName = "APIImporttasksPost"
 )

--- a/internal/apis/gen/oas_parameters_gen.go
+++ b/internal/apis/gen/oas_parameters_gen.go
@@ -2,26 +2,28 @@
 
 package gen
 
-// APIImportTasksIDImportRunsPostParams is parameters of POST /api/ImportTasks/{id}/importRuns operation.
-type APIImportTasksIDImportRunsPostParams struct {
+// APIImporttasksIDCancelPostParams is parameters of POST /api/importtasks/{id}/cancel operation.
+type APIImporttasksIDCancelPostParams struct {
+	// The unique identifier of the import task to cancel.
+	ID string
+}
+
+// APIImporttasksIDImportrunsPostParams is parameters of POST /api/importtasks/{id}/importruns operation.
+type APIImporttasksIDImportrunsPostParams struct {
 	// ImportTask identifier.
 	ID string
 }
 
-// APIImportTasksIDImportRunsRunIdStatusGetParams is parameters of GET /api/ImportTasks/{id}/importRuns/{runId}/status operation.
-type APIImportTasksIDImportRunsRunIdStatusGetParams struct {
-	ID    string
+// APIImporttasksIDImportrunsRunIdStatusGetParams is parameters of GET /api/importtasks/{id}/importruns/{runId}/status operation.
+type APIImporttasksIDImportrunsRunIdStatusGetParams struct {
+	// The import task identifier.
+	ID string
+	// The import run identifier.
 	RunId string
 }
 
-// APIImportTasksIDPatchParams is parameters of PATCH /api/ImportTasks/{id} operation.
-type APIImportTasksIDPatchParams struct {
-	// The unique identifier of the import task to be updated.
-	ID string
-}
-
-// APIImportTasksIDStatusGetParams is parameters of GET /api/ImportTasks/{id}/status operation.
-type APIImportTasksIDStatusGetParams struct {
+// APIImporttasksIDStatusGetParams is parameters of GET /api/importtasks/{id}/status operation.
+type APIImporttasksIDStatusGetParams struct {
 	// The id of the import task to query.
 	ID string
 }

--- a/internal/apis/gen/oas_request_encoders_gen.go
+++ b/internal/apis/gen/oas_request_encoders_gen.go
@@ -15,53 +15,12 @@ import (
 	"github.com/ogen-go/ogen/uri"
 )
 
-func encodeAPIImportTasksIDImportRunsPostRequest(
-	req OptAPIImportTasksIDImportRunsPostReq,
-	r *http.Request,
-) error {
-	const contentType = "multipart/form-data"
-	if !req.Set {
-		// Keep request with empty body if value is not set.
-		return nil
-	}
-	request := req.Value
-
-	q := uri.NewFormEncoder(map[string]string{})
-	{
-		// Encode "importBehaviour" form field.
-		cfg := uri.QueryParameterEncodingConfig{
-			Name:    "importBehaviour",
-			Style:   uri.QueryStyleForm,
-			Explode: true,
-		}
-		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
-			if val, ok := request.ImportBehaviour.Get(); ok {
-				return e.EncodeValue(conv.StringToString(string(val)))
-			}
-			return nil
-		}); err != nil {
-			return errors.Wrap(err, "encode query")
-		}
-	}
-	body, boundary := ht.CreateMultipartBody(func(w *multipart.Writer) error {
-		if err := request.File.WriteMultipart("file", w); err != nil {
-			return errors.Wrap(err, "write \"file\"")
-		}
-		if err := q.WriteMultipart(w); err != nil {
-			return errors.Wrap(err, "write multipart")
-		}
-		return nil
-	})
-	ht.SetCloserBody(r, body, mime.FormatMediaType(contentType, map[string]string{"boundary": boundary}))
-	return nil
-}
-
-func encodeAPIImportTasksIDPatchRequest(
-	req APIImportTasksIDPatchReq,
+func encodeAPIImporttasksIDCancelPostRequest(
+	req APIImporttasksIDCancelPostReq,
 	r *http.Request,
 ) error {
 	switch req := req.(type) {
-	case *APIImportTasksIDPatchReqEmptyBody:
+	case *APIImporttasksIDCancelPostReqEmptyBody:
 		// Empty body case.
 		return nil
 	case *CancelImportTaskRequestWithContentType:
@@ -93,8 +52,62 @@ func encodeAPIImportTasksIDPatchRequest(
 	}
 }
 
-func encodeAPIImportTasksPostRequest(
-	req OptAPIImportTasksPostReq,
+func encodeAPIImporttasksIDImportrunsPostRequest(
+	req OptAPIImporttasksIDImportrunsPostReq,
+	r *http.Request,
+) error {
+	const contentType = "multipart/form-data"
+	if !req.Set {
+		// Keep request with empty body if value is not set.
+		return nil
+	}
+	request := req.Value
+
+	q := uri.NewFormEncoder(map[string]string{})
+	{
+		// Encode "importBehaviour" form field.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "importBehaviour",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := request.ImportBehaviour.Get(); ok {
+				return e.EncodeValue(conv.StringToString(string(val)))
+			}
+			return nil
+		}); err != nil {
+			return errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "username" form field.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "username",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			return e.EncodeValue(conv.StringToString(request.Username))
+		}); err != nil {
+			return errors.Wrap(err, "encode query")
+		}
+	}
+	body, boundary := ht.CreateMultipartBody(func(w *multipart.Writer) error {
+		if err := request.File.WriteMultipart("file", w); err != nil {
+			return errors.Wrap(err, "write \"file\"")
+		}
+		if err := q.WriteMultipart(w); err != nil {
+			return errors.Wrap(err, "write multipart")
+		}
+		return nil
+	})
+	ht.SetCloserBody(r, body, mime.FormatMediaType(contentType, map[string]string{"boundary": boundary}))
+	return nil
+}
+
+func encodeAPIImporttasksPostRequest(
+	req OptAPIImporttasksPostReq,
 	r *http.Request,
 ) error {
 	const contentType = "multipart/form-data"

--- a/internal/apis/gen/oas_response_decoders_gen.go
+++ b/internal/apis/gen/oas_response_decoders_gen.go
@@ -107,7 +107,156 @@ func decodeAPIHealthzGetResponse(resp *http.Response) (res APIHealthzGetRes, _ e
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
 
-func decodeAPIImportTasksIDImportRunsPostResponse(resp *http.Response) (res APIImportTasksIDImportRunsPostRes, _ error) {
+func decodeAPIImporttasksIDCancelPostResponse(resp *http.Response) (res APIImporttasksIDCancelPostRes, _ error) {
+	switch resp.StatusCode {
+	case 204:
+		// Code 204.
+		return &APIImporttasksIDCancelPostNoContent{}, nil
+	case 401:
+		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksIDCancelPostUnauthorized
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksIDCancelPostNotFound
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 409:
+		// Code 409.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksIDCancelPostConflict
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 500:
+		// Code 500.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksIDCancelPostInternalServerError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
+func decodeAPIImporttasksIDImportrunsPostResponse(resp *http.Response) (res APIImporttasksIDImportrunsPostRes, _ error) {
 	switch resp.StatusCode {
 	case 201:
 		// Code 201.
@@ -158,7 +307,153 @@ func decodeAPIImportTasksIDImportRunsPostResponse(resp *http.Response) (res APII
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response ValidationProblemDetails
+			var response APIImporttasksIDImportrunsPostBadRequest
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksIDImportrunsPostUnauthorized
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksIDImportrunsPostNotFound
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 415:
+		// Code 415.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksIDImportrunsPostUnsupportedMediaType
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
+func decodeAPIImporttasksIDImportrunsRunIdStatusGetResponse(resp *http.Response) (res APIImporttasksIDImportrunsRunIdStatusGetRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response ImportRunStatusResponse
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -202,7 +497,7 @@ func decodeAPIImportTasksIDImportRunsPostResponse(resp *http.Response) (res APII
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response APIImportTasksIDImportRunsPostUnauthorized
+			var response APIImporttasksIDImportrunsRunIdStatusGetUnauthorized
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -237,7 +532,7 @@ func decodeAPIImportTasksIDImportRunsPostResponse(resp *http.Response) (res APII
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response APIImportTasksIDImportRunsPostNotFound
+			var response APIImporttasksIDImportrunsRunIdStatusGetNotFound
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -258,8 +553,8 @@ func decodeAPIImportTasksIDImportRunsPostResponse(resp *http.Response) (res APII
 		default:
 			return res, validate.InvalidContentType(ct)
 		}
-	case 415:
-		// Code 415.
+	case 500:
+		// Code 500.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 		if err != nil {
 			return res, errors.Wrap(err, "parse media type")
@@ -272,7 +567,7 @@ func decodeAPIImportTasksIDImportRunsPostResponse(resp *http.Response) (res APII
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response APIImportTasksIDImportRunsPostUnsupportedMediaType
+			var response APIImporttasksIDImportrunsRunIdStatusGetInternalServerError
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -297,229 +592,7 @@ func decodeAPIImportTasksIDImportRunsPostResponse(resp *http.Response) (res APII
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
 
-func decodeAPIImportTasksIDImportRunsRunIdStatusGetResponse(resp *http.Response) (res APIImportTasksIDImportRunsRunIdStatusGetRes, _ error) {
-	switch resp.StatusCode {
-	case 200:
-		// Code 200.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response ImportRunStatusResponse
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 401:
-		// Code 401.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response APIImportTasksIDImportRunsRunIdStatusGetUnauthorized
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 404:
-		// Code 404.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response APIImportTasksIDImportRunsRunIdStatusGetNotFound
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	}
-	return res, validate.UnexpectedStatusCodeWithResponse(resp)
-}
-
-func decodeAPIImportTasksIDPatchResponse(resp *http.Response) (res APIImportTasksIDPatchRes, _ error) {
-	switch resp.StatusCode {
-	case 200:
-		// Code 200.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response ImportTaskDto
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 404:
-		// Code 404.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response APIImportTasksIDPatchNotFound
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 409:
-		// Code 409.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response APIImportTasksIDPatchConflict
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	}
-	return res, validate.UnexpectedStatusCodeWithResponse(resp)
-}
-
-func decodeAPIImportTasksIDStatusGetResponse(resp *http.Response) (res *ImportTaskStatusResponse, _ error) {
+func decodeAPIImporttasksIDStatusGetResponse(resp *http.Response) (res APIImporttasksIDStatusGetRes, _ error) {
 	switch resp.StatusCode {
 	case 200:
 		// Code 200.
@@ -565,82 +638,6 @@ func decodeAPIImportTasksIDStatusGetResponse(resp *http.Response) (res *ImportTa
 		default:
 			return res, validate.InvalidContentType(ct)
 		}
-	}
-	return res, validate.UnexpectedStatusCodeWithResponse(resp)
-}
-
-func decodeAPIImportTasksPostResponse(resp *http.Response) (res APIImportTasksPostRes, _ error) {
-	switch resp.StatusCode {
-	case 201:
-		// Code 201.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response APIImportTasksPostCreated
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
-	case 400:
-		// Code 400.
-		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-		if err != nil {
-			return res, errors.Wrap(err, "parse media type")
-		}
-		switch {
-		case ct == "application/json":
-			buf, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return res, err
-			}
-			d := jx.DecodeBytes(buf)
-
-			var response APIImportTasksPostBadRequest
-			if err := func() error {
-				if err := response.Decode(d); err != nil {
-					return err
-				}
-				if err := d.Skip(); err != io.EOF {
-					return errors.New("unexpected trailing data")
-				}
-				return nil
-			}(); err != nil {
-				err = &ogenerrors.DecodeBodyError{
-					ContentType: ct,
-					Body:        buf,
-					Err:         err,
-				}
-				return res, err
-			}
-			return &response, nil
-		default:
-			return res, validate.InvalidContentType(ct)
-		}
 	case 401:
 		// Code 401.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
@@ -655,7 +652,7 @@ func decodeAPIImportTasksPostResponse(resp *http.Response) (res APIImportTasksPo
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response ProblemDetails
+			var response APIImporttasksIDStatusGetUnauthorized
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -676,8 +673,8 @@ func decodeAPIImportTasksPostResponse(resp *http.Response) (res APIImportTasksPo
 		default:
 			return res, validate.InvalidContentType(ct)
 		}
-	case 415:
-		// Code 415.
+	case 404:
+		// Code 404.
 		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 		if err != nil {
 			return res, errors.Wrap(err, "parse media type")
@@ -690,7 +687,7 @@ func decodeAPIImportTasksPostResponse(resp *http.Response) (res APIImportTasksPo
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response APIImportTasksPostUnsupportedMediaType
+			var response APIImporttasksIDStatusGetNotFound
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -725,7 +722,188 @@ func decodeAPIImportTasksPostResponse(resp *http.Response) (res APIImportTasksPo
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response APIImportTasksPostInternalServerError
+			var response APIImporttasksIDStatusGetInternalServerError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
+func decodeAPIImporttasksPostResponse(resp *http.Response) (res APIImporttasksPostRes, _ error) {
+	switch resp.StatusCode {
+	case 201:
+		// Code 201.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response CreateImportTaskResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 400:
+		// Code 400.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksPostBadRequest
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksPostUnauthorized
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 415:
+		// Code 415.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksPostUnsupportedMediaType
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 500:
+		// Code 500.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response APIImporttasksPostInternalServerError
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err

--- a/internal/apis/gen/oas_schemas_gen.go
+++ b/internal/apis/gen/oas_schemas_gen.go
@@ -3,11 +3,8 @@
 package gen
 
 import (
-	"time"
-
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
-	"github.com/google/uuid"
 	ht "github.com/ogen-go/ogen/http"
 )
 
@@ -19,80 +16,121 @@ type APIHealthzGetServiceUnavailable HealthStatusResult
 
 func (*APIHealthzGetServiceUnavailable) aPIHealthzGetRes() {}
 
-type APIImportTasksIDImportRunsPostNotFound ProblemDetails
+type APIImporttasksIDCancelPostConflict ProblemDetails
 
-func (*APIImportTasksIDImportRunsPostNotFound) aPIImportTasksIDImportRunsPostRes() {}
+func (*APIImporttasksIDCancelPostConflict) aPIImporttasksIDCancelPostRes() {}
 
-type APIImportTasksIDImportRunsPostReq struct {
+type APIImporttasksIDCancelPostInternalServerError ProblemDetails
+
+func (*APIImporttasksIDCancelPostInternalServerError) aPIImporttasksIDCancelPostRes() {}
+
+// APIImporttasksIDCancelPostNoContent is response for APIImporttasksIDCancelPost operation.
+type APIImporttasksIDCancelPostNoContent struct{}
+
+func (*APIImporttasksIDCancelPostNoContent) aPIImporttasksIDCancelPostRes() {}
+
+type APIImporttasksIDCancelPostNotFound ProblemDetails
+
+func (*APIImporttasksIDCancelPostNotFound) aPIImporttasksIDCancelPostRes() {}
+
+type APIImporttasksIDCancelPostReqEmptyBody struct{}
+
+func (*APIImporttasksIDCancelPostReqEmptyBody) aPIImporttasksIDCancelPostReq() {}
+
+type APIImporttasksIDCancelPostUnauthorized ProblemDetails
+
+func (*APIImporttasksIDCancelPostUnauthorized) aPIImporttasksIDCancelPostRes() {}
+
+type APIImporttasksIDImportrunsPostBadRequest ProblemDetails
+
+func (*APIImporttasksIDImportrunsPostBadRequest) aPIImporttasksIDImportrunsPostRes() {}
+
+type APIImporttasksIDImportrunsPostNotFound ProblemDetails
+
+func (*APIImporttasksIDImportrunsPostNotFound) aPIImporttasksIDImportrunsPostRes() {}
+
+type APIImporttasksIDImportrunsPostReq struct {
 	// The METS file required for the import.
-	// (To be decided: Or a zip file containing the METS and the metadata.xml file?)).
 	File            ht.MultipartFile       `json:"file"`
 	ImportBehaviour OptImportBehaviourType `json:"importBehaviour"`
+	// The username that is logged as the creator of the import task. Can be the email for example.
+	Username string `json:"username"`
 }
 
 // GetFile returns the value of File.
-func (s *APIImportTasksIDImportRunsPostReq) GetFile() ht.MultipartFile {
+func (s *APIImporttasksIDImportrunsPostReq) GetFile() ht.MultipartFile {
 	return s.File
 }
 
 // GetImportBehaviour returns the value of ImportBehaviour.
-func (s *APIImportTasksIDImportRunsPostReq) GetImportBehaviour() OptImportBehaviourType {
+func (s *APIImporttasksIDImportrunsPostReq) GetImportBehaviour() OptImportBehaviourType {
 	return s.ImportBehaviour
 }
 
+// GetUsername returns the value of Username.
+func (s *APIImporttasksIDImportrunsPostReq) GetUsername() string {
+	return s.Username
+}
+
 // SetFile sets the value of File.
-func (s *APIImportTasksIDImportRunsPostReq) SetFile(val ht.MultipartFile) {
+func (s *APIImporttasksIDImportrunsPostReq) SetFile(val ht.MultipartFile) {
 	s.File = val
 }
 
 // SetImportBehaviour sets the value of ImportBehaviour.
-func (s *APIImportTasksIDImportRunsPostReq) SetImportBehaviour(val OptImportBehaviourType) {
+func (s *APIImporttasksIDImportrunsPostReq) SetImportBehaviour(val OptImportBehaviourType) {
 	s.ImportBehaviour = val
 }
 
-type APIImportTasksIDImportRunsPostUnauthorized ProblemDetails
-
-func (*APIImportTasksIDImportRunsPostUnauthorized) aPIImportTasksIDImportRunsPostRes() {}
-
-type APIImportTasksIDImportRunsPostUnsupportedMediaType ProblemDetails
-
-func (*APIImportTasksIDImportRunsPostUnsupportedMediaType) aPIImportTasksIDImportRunsPostRes() {}
-
-type APIImportTasksIDImportRunsRunIdStatusGetNotFound ProblemDetails
-
-func (*APIImportTasksIDImportRunsRunIdStatusGetNotFound) aPIImportTasksIDImportRunsRunIdStatusGetRes() {
+// SetUsername sets the value of Username.
+func (s *APIImporttasksIDImportrunsPostReq) SetUsername(val string) {
+	s.Username = val
 }
 
-type APIImportTasksIDImportRunsRunIdStatusGetUnauthorized ProblemDetails
+type APIImporttasksIDImportrunsPostUnauthorized ProblemDetails
 
-func (*APIImportTasksIDImportRunsRunIdStatusGetUnauthorized) aPIImportTasksIDImportRunsRunIdStatusGetRes() {
+func (*APIImporttasksIDImportrunsPostUnauthorized) aPIImporttasksIDImportrunsPostRes() {}
+
+type APIImporttasksIDImportrunsPostUnsupportedMediaType ProblemDetails
+
+func (*APIImporttasksIDImportrunsPostUnsupportedMediaType) aPIImporttasksIDImportrunsPostRes() {}
+
+type APIImporttasksIDImportrunsRunIdStatusGetInternalServerError ProblemDetails
+
+func (*APIImporttasksIDImportrunsRunIdStatusGetInternalServerError) aPIImporttasksIDImportrunsRunIdStatusGetRes() {
 }
 
-type APIImportTasksIDPatchConflict ProblemDetails
+type APIImporttasksIDImportrunsRunIdStatusGetNotFound ProblemDetails
 
-func (*APIImportTasksIDPatchConflict) aPIImportTasksIDPatchRes() {}
+func (*APIImporttasksIDImportrunsRunIdStatusGetNotFound) aPIImporttasksIDImportrunsRunIdStatusGetRes() {
+}
 
-type APIImportTasksIDPatchNotFound ProblemDetails
+type APIImporttasksIDImportrunsRunIdStatusGetUnauthorized ProblemDetails
 
-func (*APIImportTasksIDPatchNotFound) aPIImportTasksIDPatchRes() {}
+func (*APIImporttasksIDImportrunsRunIdStatusGetUnauthorized) aPIImporttasksIDImportrunsRunIdStatusGetRes() {
+}
 
-type APIImportTasksIDPatchReqEmptyBody struct{}
+type APIImporttasksIDStatusGetInternalServerError ProblemDetails
 
-func (*APIImportTasksIDPatchReqEmptyBody) aPIImportTasksIDPatchReq() {}
+func (*APIImporttasksIDStatusGetInternalServerError) aPIImporttasksIDStatusGetRes() {}
 
-type APIImportTasksPostBadRequest CreateImportTaskResponse
+type APIImporttasksIDStatusGetNotFound ProblemDetails
 
-func (*APIImportTasksPostBadRequest) aPIImportTasksPostRes() {}
+func (*APIImporttasksIDStatusGetNotFound) aPIImporttasksIDStatusGetRes() {}
 
-type APIImportTasksPostCreated CreateImportTaskResponse
+type APIImporttasksIDStatusGetUnauthorized ProblemDetails
 
-func (*APIImportTasksPostCreated) aPIImportTasksPostRes() {}
+func (*APIImporttasksIDStatusGetUnauthorized) aPIImporttasksIDStatusGetRes() {}
 
-type APIImportTasksPostInternalServerError CreateImportTaskResponse
+type APIImporttasksPostBadRequest ProblemDetails
 
-func (*APIImportTasksPostInternalServerError) aPIImportTasksPostRes() {}
+func (*APIImporttasksPostBadRequest) aPIImporttasksPostRes() {}
 
-type APIImportTasksPostReq struct {
+type APIImporttasksPostInternalServerError ProblemDetails
+
+func (*APIImporttasksPostInternalServerError) aPIImporttasksPostRes() {}
+
+type APIImporttasksPostReq struct {
 	// The metadata.xml file according to eCH-0160.
 	File    ht.MultipartFile `json:"file"`
 	SipType SipType          `json:"sipType"`
@@ -101,438 +139,42 @@ type APIImportTasksPostReq struct {
 }
 
 // GetFile returns the value of File.
-func (s *APIImportTasksPostReq) GetFile() ht.MultipartFile {
+func (s *APIImporttasksPostReq) GetFile() ht.MultipartFile {
 	return s.File
 }
 
 // GetSipType returns the value of SipType.
-func (s *APIImportTasksPostReq) GetSipType() SipType {
+func (s *APIImporttasksPostReq) GetSipType() SipType {
 	return s.SipType
 }
 
 // GetUsername returns the value of Username.
-func (s *APIImportTasksPostReq) GetUsername() string {
+func (s *APIImporttasksPostReq) GetUsername() string {
 	return s.Username
 }
 
 // SetFile sets the value of File.
-func (s *APIImportTasksPostReq) SetFile(val ht.MultipartFile) {
+func (s *APIImporttasksPostReq) SetFile(val ht.MultipartFile) {
 	s.File = val
 }
 
 // SetSipType sets the value of SipType.
-func (s *APIImportTasksPostReq) SetSipType(val SipType) {
+func (s *APIImporttasksPostReq) SetSipType(val SipType) {
 	s.SipType = val
 }
 
 // SetUsername sets the value of Username.
-func (s *APIImportTasksPostReq) SetUsername(val string) {
+func (s *APIImporttasksPostReq) SetUsername(val string) {
 	s.Username = val
 }
 
-type APIImportTasksPostUnsupportedMediaType CreateImportTaskResponse
+type APIImporttasksPostUnauthorized ProblemDetails
 
-func (*APIImportTasksPostUnsupportedMediaType) aPIImportTasksPostRes() {}
+func (*APIImporttasksPostUnauthorized) aPIImporttasksPostRes() {}
 
-// Ref: #/components/schemas/AnalysisRecordDto
-type AnalysisRecordDto struct {
-	AnalysisRecordId  OptInt32         `json:"analysisRecordId"`
-	RowVersion        []byte           `json:"rowVersion"`
-	ImportTaskId      OptInt32         `json:"importTaskId"`
-	ComparisonDate    OptDateTime      `json:"comparisonDate"`
-	TargetPrimaryKey  OptUUID          `json:"targetPrimaryKey"`
-	DocKey            OptNilString     `json:"docKey"`
-	ReferenceCode     OptNilString     `json:"referenceCode"`
-	Level             OptNilString     `json:"level"`
-	SourcePrimaryKey  OptNilString     `json:"sourcePrimaryKey"`
-	PositionNumber    OptString        `json:"positionNumber"`
-	SourceTitle       OptString        `json:"sourceTitle"`
-	DestinationTitle  OptNilString     `json:"destinationTitle"`
-	SourceField1      OptNilString     `json:"sourceField1"`
-	DestinationField1 OptNilString     `json:"destinationField1"`
-	SourceField2      OptNilString     `json:"sourceField2"`
-	DestinationField2 OptNilString     `json:"destinationField2"`
-	SourceField3      OptNilString     `json:"sourceField3"`
-	DestinationField3 OptNilString     `json:"destinationField3"`
-	SourceField4      OptNilString     `json:"sourceField4"`
-	DestinationField4 OptNilString     `json:"destinationField4"`
-	SourceField5      OptNilString     `json:"sourceField5"`
-	DestinationField5 OptNilString     `json:"destinationField5"`
-	TitleIsDifferent  OptBool          `json:"titleIsDifferent"`
-	Field1IsDifferent OptBool          `json:"field1IsDifferent"`
-	Field2IsDifferent OptBool          `json:"field2IsDifferent"`
-	Field3IsDifferent OptBool          `json:"field3IsDifferent"`
-	Field4IsDifferent OptBool          `json:"field4IsDifferent"`
-	Field5IsDifferent OptBool          `json:"field5IsDifferent"`
-	Status            OptNilString     `json:"status"`
-	ErrorMessage      OptNilString     `json:"errorMessage"`
-	ContainerDocKey   OptNilString     `json:"containerDocKey"`
-	CreatedBy         OptString        `json:"createdBy"`
-	CreatedOn         OptDateTime      `json:"createdOn"`
-	ModifiedBy        OptNilString     `json:"modifiedBy"`
-	ModifiedOn        OptNilDateTime   `json:"modifiedOn"`
-	ImportTask        OptImportTaskDto `json:"importTask"`
-}
+type APIImporttasksPostUnsupportedMediaType ProblemDetails
 
-// GetAnalysisRecordId returns the value of AnalysisRecordId.
-func (s *AnalysisRecordDto) GetAnalysisRecordId() OptInt32 {
-	return s.AnalysisRecordId
-}
-
-// GetRowVersion returns the value of RowVersion.
-func (s *AnalysisRecordDto) GetRowVersion() []byte {
-	return s.RowVersion
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *AnalysisRecordDto) GetImportTaskId() OptInt32 {
-	return s.ImportTaskId
-}
-
-// GetComparisonDate returns the value of ComparisonDate.
-func (s *AnalysisRecordDto) GetComparisonDate() OptDateTime {
-	return s.ComparisonDate
-}
-
-// GetTargetPrimaryKey returns the value of TargetPrimaryKey.
-func (s *AnalysisRecordDto) GetTargetPrimaryKey() OptUUID {
-	return s.TargetPrimaryKey
-}
-
-// GetDocKey returns the value of DocKey.
-func (s *AnalysisRecordDto) GetDocKey() OptNilString {
-	return s.DocKey
-}
-
-// GetReferenceCode returns the value of ReferenceCode.
-func (s *AnalysisRecordDto) GetReferenceCode() OptNilString {
-	return s.ReferenceCode
-}
-
-// GetLevel returns the value of Level.
-func (s *AnalysisRecordDto) GetLevel() OptNilString {
-	return s.Level
-}
-
-// GetSourcePrimaryKey returns the value of SourcePrimaryKey.
-func (s *AnalysisRecordDto) GetSourcePrimaryKey() OptNilString {
-	return s.SourcePrimaryKey
-}
-
-// GetPositionNumber returns the value of PositionNumber.
-func (s *AnalysisRecordDto) GetPositionNumber() OptString {
-	return s.PositionNumber
-}
-
-// GetSourceTitle returns the value of SourceTitle.
-func (s *AnalysisRecordDto) GetSourceTitle() OptString {
-	return s.SourceTitle
-}
-
-// GetDestinationTitle returns the value of DestinationTitle.
-func (s *AnalysisRecordDto) GetDestinationTitle() OptNilString {
-	return s.DestinationTitle
-}
-
-// GetSourceField1 returns the value of SourceField1.
-func (s *AnalysisRecordDto) GetSourceField1() OptNilString {
-	return s.SourceField1
-}
-
-// GetDestinationField1 returns the value of DestinationField1.
-func (s *AnalysisRecordDto) GetDestinationField1() OptNilString {
-	return s.DestinationField1
-}
-
-// GetSourceField2 returns the value of SourceField2.
-func (s *AnalysisRecordDto) GetSourceField2() OptNilString {
-	return s.SourceField2
-}
-
-// GetDestinationField2 returns the value of DestinationField2.
-func (s *AnalysisRecordDto) GetDestinationField2() OptNilString {
-	return s.DestinationField2
-}
-
-// GetSourceField3 returns the value of SourceField3.
-func (s *AnalysisRecordDto) GetSourceField3() OptNilString {
-	return s.SourceField3
-}
-
-// GetDestinationField3 returns the value of DestinationField3.
-func (s *AnalysisRecordDto) GetDestinationField3() OptNilString {
-	return s.DestinationField3
-}
-
-// GetSourceField4 returns the value of SourceField4.
-func (s *AnalysisRecordDto) GetSourceField4() OptNilString {
-	return s.SourceField4
-}
-
-// GetDestinationField4 returns the value of DestinationField4.
-func (s *AnalysisRecordDto) GetDestinationField4() OptNilString {
-	return s.DestinationField4
-}
-
-// GetSourceField5 returns the value of SourceField5.
-func (s *AnalysisRecordDto) GetSourceField5() OptNilString {
-	return s.SourceField5
-}
-
-// GetDestinationField5 returns the value of DestinationField5.
-func (s *AnalysisRecordDto) GetDestinationField5() OptNilString {
-	return s.DestinationField5
-}
-
-// GetTitleIsDifferent returns the value of TitleIsDifferent.
-func (s *AnalysisRecordDto) GetTitleIsDifferent() OptBool {
-	return s.TitleIsDifferent
-}
-
-// GetField1IsDifferent returns the value of Field1IsDifferent.
-func (s *AnalysisRecordDto) GetField1IsDifferent() OptBool {
-	return s.Field1IsDifferent
-}
-
-// GetField2IsDifferent returns the value of Field2IsDifferent.
-func (s *AnalysisRecordDto) GetField2IsDifferent() OptBool {
-	return s.Field2IsDifferent
-}
-
-// GetField3IsDifferent returns the value of Field3IsDifferent.
-func (s *AnalysisRecordDto) GetField3IsDifferent() OptBool {
-	return s.Field3IsDifferent
-}
-
-// GetField4IsDifferent returns the value of Field4IsDifferent.
-func (s *AnalysisRecordDto) GetField4IsDifferent() OptBool {
-	return s.Field4IsDifferent
-}
-
-// GetField5IsDifferent returns the value of Field5IsDifferent.
-func (s *AnalysisRecordDto) GetField5IsDifferent() OptBool {
-	return s.Field5IsDifferent
-}
-
-// GetStatus returns the value of Status.
-func (s *AnalysisRecordDto) GetStatus() OptNilString {
-	return s.Status
-}
-
-// GetErrorMessage returns the value of ErrorMessage.
-func (s *AnalysisRecordDto) GetErrorMessage() OptNilString {
-	return s.ErrorMessage
-}
-
-// GetContainerDocKey returns the value of ContainerDocKey.
-func (s *AnalysisRecordDto) GetContainerDocKey() OptNilString {
-	return s.ContainerDocKey
-}
-
-// GetCreatedBy returns the value of CreatedBy.
-func (s *AnalysisRecordDto) GetCreatedBy() OptString {
-	return s.CreatedBy
-}
-
-// GetCreatedOn returns the value of CreatedOn.
-func (s *AnalysisRecordDto) GetCreatedOn() OptDateTime {
-	return s.CreatedOn
-}
-
-// GetModifiedBy returns the value of ModifiedBy.
-func (s *AnalysisRecordDto) GetModifiedBy() OptNilString {
-	return s.ModifiedBy
-}
-
-// GetModifiedOn returns the value of ModifiedOn.
-func (s *AnalysisRecordDto) GetModifiedOn() OptNilDateTime {
-	return s.ModifiedOn
-}
-
-// GetImportTask returns the value of ImportTask.
-func (s *AnalysisRecordDto) GetImportTask() OptImportTaskDto {
-	return s.ImportTask
-}
-
-// SetAnalysisRecordId sets the value of AnalysisRecordId.
-func (s *AnalysisRecordDto) SetAnalysisRecordId(val OptInt32) {
-	s.AnalysisRecordId = val
-}
-
-// SetRowVersion sets the value of RowVersion.
-func (s *AnalysisRecordDto) SetRowVersion(val []byte) {
-	s.RowVersion = val
-}
-
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *AnalysisRecordDto) SetImportTaskId(val OptInt32) {
-	s.ImportTaskId = val
-}
-
-// SetComparisonDate sets the value of ComparisonDate.
-func (s *AnalysisRecordDto) SetComparisonDate(val OptDateTime) {
-	s.ComparisonDate = val
-}
-
-// SetTargetPrimaryKey sets the value of TargetPrimaryKey.
-func (s *AnalysisRecordDto) SetTargetPrimaryKey(val OptUUID) {
-	s.TargetPrimaryKey = val
-}
-
-// SetDocKey sets the value of DocKey.
-func (s *AnalysisRecordDto) SetDocKey(val OptNilString) {
-	s.DocKey = val
-}
-
-// SetReferenceCode sets the value of ReferenceCode.
-func (s *AnalysisRecordDto) SetReferenceCode(val OptNilString) {
-	s.ReferenceCode = val
-}
-
-// SetLevel sets the value of Level.
-func (s *AnalysisRecordDto) SetLevel(val OptNilString) {
-	s.Level = val
-}
-
-// SetSourcePrimaryKey sets the value of SourcePrimaryKey.
-func (s *AnalysisRecordDto) SetSourcePrimaryKey(val OptNilString) {
-	s.SourcePrimaryKey = val
-}
-
-// SetPositionNumber sets the value of PositionNumber.
-func (s *AnalysisRecordDto) SetPositionNumber(val OptString) {
-	s.PositionNumber = val
-}
-
-// SetSourceTitle sets the value of SourceTitle.
-func (s *AnalysisRecordDto) SetSourceTitle(val OptString) {
-	s.SourceTitle = val
-}
-
-// SetDestinationTitle sets the value of DestinationTitle.
-func (s *AnalysisRecordDto) SetDestinationTitle(val OptNilString) {
-	s.DestinationTitle = val
-}
-
-// SetSourceField1 sets the value of SourceField1.
-func (s *AnalysisRecordDto) SetSourceField1(val OptNilString) {
-	s.SourceField1 = val
-}
-
-// SetDestinationField1 sets the value of DestinationField1.
-func (s *AnalysisRecordDto) SetDestinationField1(val OptNilString) {
-	s.DestinationField1 = val
-}
-
-// SetSourceField2 sets the value of SourceField2.
-func (s *AnalysisRecordDto) SetSourceField2(val OptNilString) {
-	s.SourceField2 = val
-}
-
-// SetDestinationField2 sets the value of DestinationField2.
-func (s *AnalysisRecordDto) SetDestinationField2(val OptNilString) {
-	s.DestinationField2 = val
-}
-
-// SetSourceField3 sets the value of SourceField3.
-func (s *AnalysisRecordDto) SetSourceField3(val OptNilString) {
-	s.SourceField3 = val
-}
-
-// SetDestinationField3 sets the value of DestinationField3.
-func (s *AnalysisRecordDto) SetDestinationField3(val OptNilString) {
-	s.DestinationField3 = val
-}
-
-// SetSourceField4 sets the value of SourceField4.
-func (s *AnalysisRecordDto) SetSourceField4(val OptNilString) {
-	s.SourceField4 = val
-}
-
-// SetDestinationField4 sets the value of DestinationField4.
-func (s *AnalysisRecordDto) SetDestinationField4(val OptNilString) {
-	s.DestinationField4 = val
-}
-
-// SetSourceField5 sets the value of SourceField5.
-func (s *AnalysisRecordDto) SetSourceField5(val OptNilString) {
-	s.SourceField5 = val
-}
-
-// SetDestinationField5 sets the value of DestinationField5.
-func (s *AnalysisRecordDto) SetDestinationField5(val OptNilString) {
-	s.DestinationField5 = val
-}
-
-// SetTitleIsDifferent sets the value of TitleIsDifferent.
-func (s *AnalysisRecordDto) SetTitleIsDifferent(val OptBool) {
-	s.TitleIsDifferent = val
-}
-
-// SetField1IsDifferent sets the value of Field1IsDifferent.
-func (s *AnalysisRecordDto) SetField1IsDifferent(val OptBool) {
-	s.Field1IsDifferent = val
-}
-
-// SetField2IsDifferent sets the value of Field2IsDifferent.
-func (s *AnalysisRecordDto) SetField2IsDifferent(val OptBool) {
-	s.Field2IsDifferent = val
-}
-
-// SetField3IsDifferent sets the value of Field3IsDifferent.
-func (s *AnalysisRecordDto) SetField3IsDifferent(val OptBool) {
-	s.Field3IsDifferent = val
-}
-
-// SetField4IsDifferent sets the value of Field4IsDifferent.
-func (s *AnalysisRecordDto) SetField4IsDifferent(val OptBool) {
-	s.Field4IsDifferent = val
-}
-
-// SetField5IsDifferent sets the value of Field5IsDifferent.
-func (s *AnalysisRecordDto) SetField5IsDifferent(val OptBool) {
-	s.Field5IsDifferent = val
-}
-
-// SetStatus sets the value of Status.
-func (s *AnalysisRecordDto) SetStatus(val OptNilString) {
-	s.Status = val
-}
-
-// SetErrorMessage sets the value of ErrorMessage.
-func (s *AnalysisRecordDto) SetErrorMessage(val OptNilString) {
-	s.ErrorMessage = val
-}
-
-// SetContainerDocKey sets the value of ContainerDocKey.
-func (s *AnalysisRecordDto) SetContainerDocKey(val OptNilString) {
-	s.ContainerDocKey = val
-}
-
-// SetCreatedBy sets the value of CreatedBy.
-func (s *AnalysisRecordDto) SetCreatedBy(val OptString) {
-	s.CreatedBy = val
-}
-
-// SetCreatedOn sets the value of CreatedOn.
-func (s *AnalysisRecordDto) SetCreatedOn(val OptDateTime) {
-	s.CreatedOn = val
-}
-
-// SetModifiedBy sets the value of ModifiedBy.
-func (s *AnalysisRecordDto) SetModifiedBy(val OptNilString) {
-	s.ModifiedBy = val
-}
-
-// SetModifiedOn sets the value of ModifiedOn.
-func (s *AnalysisRecordDto) SetModifiedOn(val OptNilDateTime) {
-	s.ModifiedOn = val
-}
-
-// SetImportTask sets the value of ImportTask.
-func (s *AnalysisRecordDto) SetImportTask(val OptImportTaskDto) {
-	s.ImportTask = val
-}
+func (*APIImporttasksPostUnsupportedMediaType) aPIImporttasksPostRes() {}
 
 // Enum values:
 // - `AlleGleich`: The title of all series are the same
@@ -595,22 +237,36 @@ func (s *AnalysisResult) UnmarshalText(data []byte) error {
 	}
 }
 
+// Request to cancel an import task.
 // Ref: #/components/schemas/CancelImportTaskRequest
 type CancelImportTaskRequest struct {
-	Status ImportTaskStatus `json:"status"`
+	// Optional reason for canceling the import task.
+	Reason OptNilString `json:"reason"`
+	// The user who initiated the cancellation.
+	CancelledBy OptNilString `json:"cancelledBy"`
 }
 
-// GetStatus returns the value of Status.
-func (s *CancelImportTaskRequest) GetStatus() ImportTaskStatus {
-	return s.Status
+// GetReason returns the value of Reason.
+func (s *CancelImportTaskRequest) GetReason() OptNilString {
+	return s.Reason
 }
 
-// SetStatus sets the value of Status.
-func (s *CancelImportTaskRequest) SetStatus(val ImportTaskStatus) {
-	s.Status = val
+// GetCancelledBy returns the value of CancelledBy.
+func (s *CancelImportTaskRequest) GetCancelledBy() OptNilString {
+	return s.CancelledBy
 }
 
-func (*CancelImportTaskRequest) aPIImportTasksIDPatchReq() {}
+// SetReason sets the value of Reason.
+func (s *CancelImportTaskRequest) SetReason(val OptNilString) {
+	s.Reason = val
+}
+
+// SetCancelledBy sets the value of CancelledBy.
+func (s *CancelImportTaskRequest) SetCancelledBy(val OptNilString) {
+	s.CancelledBy = val
+}
+
+func (*CancelImportTaskRequest) aPIImporttasksIDCancelPostReq() {}
 
 // CancelImportTaskRequestWithContentType wraps CancelImportTaskRequest with Content-Type.
 type CancelImportTaskRequestWithContentType struct {
@@ -638,482 +294,60 @@ func (s *CancelImportTaskRequestWithContentType) SetContent(val CancelImportTask
 	s.Content = val
 }
 
-func (*CancelImportTaskRequestWithContentType) aPIImportTasksIDPatchReq() {}
+func (*CancelImportTaskRequestWithContentType) aPIImporttasksIDCancelPostReq() {}
 
+// Response returned when an import run is successfully created.
 // Ref: #/components/schemas/CreateImportRunResponse
 type CreateImportRunResponse struct {
-	// Gets a value indicating whether the creation of the import run was successful.
-	Success OptBool `json:"success"`
-	// Gets the identifier of the import task associated with the response.
-	ImportTaskId OptString `json:"importTaskId"`
 	// Gets the unique identifier for the created import run.
-	ImportRunId OptNilString `json:"importRunId"`
-	// Gets or initializes the error message associated with the result of the import run creation.
-	Error OptNilString `json:"error"`
-}
-
-// GetSuccess returns the value of Success.
-func (s *CreateImportRunResponse) GetSuccess() OptBool {
-	return s.Success
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *CreateImportRunResponse) GetImportTaskId() OptString {
-	return s.ImportTaskId
+	ImportRunId string `json:"importRunId"`
 }
 
 // GetImportRunId returns the value of ImportRunId.
-func (s *CreateImportRunResponse) GetImportRunId() OptNilString {
+func (s *CreateImportRunResponse) GetImportRunId() string {
 	return s.ImportRunId
 }
 
-// GetError returns the value of Error.
-func (s *CreateImportRunResponse) GetError() OptNilString {
-	return s.Error
-}
-
-// SetSuccess sets the value of Success.
-func (s *CreateImportRunResponse) SetSuccess(val OptBool) {
-	s.Success = val
-}
-
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *CreateImportRunResponse) SetImportTaskId(val OptString) {
-	s.ImportTaskId = val
-}
-
 // SetImportRunId sets the value of ImportRunId.
-func (s *CreateImportRunResponse) SetImportRunId(val OptNilString) {
+func (s *CreateImportRunResponse) SetImportRunId(val string) {
 	s.ImportRunId = val
 }
 
-// SetError sets the value of Error.
-func (s *CreateImportRunResponse) SetError(val OptNilString) {
-	s.Error = val
-}
+func (*CreateImportRunResponse) aPIImporttasksIDImportrunsPostRes() {}
 
-func (*CreateImportRunResponse) aPIImportTasksIDImportRunsPostRes() {}
-
+// Response returned when an import task is successfully created.
 // Ref: #/components/schemas/CreateImportTaskResponse
 type CreateImportTaskResponse struct {
-	// Gets a value indicating whether the creation of the import task was successful.
-	Success OptBool `json:"success"`
-	// Gets or initializes the error message associated with the result of the import task creation.
-	Error OptNilString `json:"error"`
 	// Gets the unique identifier for the created import task.
-	ID OptNilString `json:"id"`
-}
-
-// GetSuccess returns the value of Success.
-func (s *CreateImportTaskResponse) GetSuccess() OptBool {
-	return s.Success
-}
-
-// GetError returns the value of Error.
-func (s *CreateImportTaskResponse) GetError() OptNilString {
-	return s.Error
-}
-
-// GetID returns the value of ID.
-func (s *CreateImportTaskResponse) GetID() OptNilString {
-	return s.ID
-}
-
-// SetSuccess sets the value of Success.
-func (s *CreateImportTaskResponse) SetSuccess(val OptBool) {
-	s.Success = val
-}
-
-// SetError sets the value of Error.
-func (s *CreateImportTaskResponse) SetError(val OptNilString) {
-	s.Error = val
-}
-
-// SetID sets the value of ID.
-func (s *CreateImportTaskResponse) SetID(val OptNilString) {
-	s.ID = val
-}
-
-// Ref: #/components/schemas/DefaultValueDto
-type DefaultValueDto struct {
-	DefaultValueId         OptInt32         `json:"defaultValueId"`
-	RowVersion             []byte           `json:"rowVersion"`
-	ImportTaskId           OptInt32         `json:"importTaskId"`
-	AccessionDocKey        OptString        `json:"accessionDocKey"`
-	AccessionIdName        OptString        `json:"accessionIdName"`
-	InsertNodeDocKey       OptString        `json:"insertNodeDocKey"`
-	InsertNodeIdName       OptString        `json:"insertNodeIdName"`
-	Status                 OptNilString     `json:"status"`
-	ProtectionBaseDate     OptNilString     `json:"protectionBaseDate"`
-	ProtectionCategory     OptNilString     `json:"protectionCategory"`
-	ProtectionDuration     OptNilInt32      `json:"protectionDuration"`
-	MetadataCanBePublished OptNilBool       `json:"metadataCanBePublished"`
-	Accessibility          OptNilString     `json:"accessibility"`
-	Usability              OptNilString     `json:"usability"`
-	PermissionType         OptNilString     `json:"permissionType"`
-	CreatedBy              OptString        `json:"createdBy"`
-	CreatedOn              OptDateTime      `json:"createdOn"`
-	ModifiedBy             OptNilString     `json:"modifiedBy"`
-	ModifiedOn             OptNilDateTime   `json:"modifiedOn"`
-	ImportTask             OptImportTaskDto `json:"importTask"`
-}
-
-// GetDefaultValueId returns the value of DefaultValueId.
-func (s *DefaultValueDto) GetDefaultValueId() OptInt32 {
-	return s.DefaultValueId
-}
-
-// GetRowVersion returns the value of RowVersion.
-func (s *DefaultValueDto) GetRowVersion() []byte {
-	return s.RowVersion
+	ImportTaskId string `json:"importTaskId"`
 }
 
 // GetImportTaskId returns the value of ImportTaskId.
-func (s *DefaultValueDto) GetImportTaskId() OptInt32 {
+func (s *CreateImportTaskResponse) GetImportTaskId() string {
 	return s.ImportTaskId
 }
 
-// GetAccessionDocKey returns the value of AccessionDocKey.
-func (s *DefaultValueDto) GetAccessionDocKey() OptString {
-	return s.AccessionDocKey
-}
-
-// GetAccessionIdName returns the value of AccessionIdName.
-func (s *DefaultValueDto) GetAccessionIdName() OptString {
-	return s.AccessionIdName
-}
-
-// GetInsertNodeDocKey returns the value of InsertNodeDocKey.
-func (s *DefaultValueDto) GetInsertNodeDocKey() OptString {
-	return s.InsertNodeDocKey
-}
-
-// GetInsertNodeIdName returns the value of InsertNodeIdName.
-func (s *DefaultValueDto) GetInsertNodeIdName() OptString {
-	return s.InsertNodeIdName
-}
-
-// GetStatus returns the value of Status.
-func (s *DefaultValueDto) GetStatus() OptNilString {
-	return s.Status
-}
-
-// GetProtectionBaseDate returns the value of ProtectionBaseDate.
-func (s *DefaultValueDto) GetProtectionBaseDate() OptNilString {
-	return s.ProtectionBaseDate
-}
-
-// GetProtectionCategory returns the value of ProtectionCategory.
-func (s *DefaultValueDto) GetProtectionCategory() OptNilString {
-	return s.ProtectionCategory
-}
-
-// GetProtectionDuration returns the value of ProtectionDuration.
-func (s *DefaultValueDto) GetProtectionDuration() OptNilInt32 {
-	return s.ProtectionDuration
-}
-
-// GetMetadataCanBePublished returns the value of MetadataCanBePublished.
-func (s *DefaultValueDto) GetMetadataCanBePublished() OptNilBool {
-	return s.MetadataCanBePublished
-}
-
-// GetAccessibility returns the value of Accessibility.
-func (s *DefaultValueDto) GetAccessibility() OptNilString {
-	return s.Accessibility
-}
-
-// GetUsability returns the value of Usability.
-func (s *DefaultValueDto) GetUsability() OptNilString {
-	return s.Usability
-}
-
-// GetPermissionType returns the value of PermissionType.
-func (s *DefaultValueDto) GetPermissionType() OptNilString {
-	return s.PermissionType
-}
-
-// GetCreatedBy returns the value of CreatedBy.
-func (s *DefaultValueDto) GetCreatedBy() OptString {
-	return s.CreatedBy
-}
-
-// GetCreatedOn returns the value of CreatedOn.
-func (s *DefaultValueDto) GetCreatedOn() OptDateTime {
-	return s.CreatedOn
-}
-
-// GetModifiedBy returns the value of ModifiedBy.
-func (s *DefaultValueDto) GetModifiedBy() OptNilString {
-	return s.ModifiedBy
-}
-
-// GetModifiedOn returns the value of ModifiedOn.
-func (s *DefaultValueDto) GetModifiedOn() OptNilDateTime {
-	return s.ModifiedOn
-}
-
-// GetImportTask returns the value of ImportTask.
-func (s *DefaultValueDto) GetImportTask() OptImportTaskDto {
-	return s.ImportTask
-}
-
-// SetDefaultValueId sets the value of DefaultValueId.
-func (s *DefaultValueDto) SetDefaultValueId(val OptInt32) {
-	s.DefaultValueId = val
-}
-
-// SetRowVersion sets the value of RowVersion.
-func (s *DefaultValueDto) SetRowVersion(val []byte) {
-	s.RowVersion = val
-}
-
 // SetImportTaskId sets the value of ImportTaskId.
-func (s *DefaultValueDto) SetImportTaskId(val OptInt32) {
+func (s *CreateImportTaskResponse) SetImportTaskId(val string) {
 	s.ImportTaskId = val
 }
 
-// SetAccessionDocKey sets the value of AccessionDocKey.
-func (s *DefaultValueDto) SetAccessionDocKey(val OptString) {
-	s.AccessionDocKey = val
-}
-
-// SetAccessionIdName sets the value of AccessionIdName.
-func (s *DefaultValueDto) SetAccessionIdName(val OptString) {
-	s.AccessionIdName = val
-}
-
-// SetInsertNodeDocKey sets the value of InsertNodeDocKey.
-func (s *DefaultValueDto) SetInsertNodeDocKey(val OptString) {
-	s.InsertNodeDocKey = val
-}
-
-// SetInsertNodeIdName sets the value of InsertNodeIdName.
-func (s *DefaultValueDto) SetInsertNodeIdName(val OptString) {
-	s.InsertNodeIdName = val
-}
-
-// SetStatus sets the value of Status.
-func (s *DefaultValueDto) SetStatus(val OptNilString) {
-	s.Status = val
-}
-
-// SetProtectionBaseDate sets the value of ProtectionBaseDate.
-func (s *DefaultValueDto) SetProtectionBaseDate(val OptNilString) {
-	s.ProtectionBaseDate = val
-}
-
-// SetProtectionCategory sets the value of ProtectionCategory.
-func (s *DefaultValueDto) SetProtectionCategory(val OptNilString) {
-	s.ProtectionCategory = val
-}
-
-// SetProtectionDuration sets the value of ProtectionDuration.
-func (s *DefaultValueDto) SetProtectionDuration(val OptNilInt32) {
-	s.ProtectionDuration = val
-}
-
-// SetMetadataCanBePublished sets the value of MetadataCanBePublished.
-func (s *DefaultValueDto) SetMetadataCanBePublished(val OptNilBool) {
-	s.MetadataCanBePublished = val
-}
-
-// SetAccessibility sets the value of Accessibility.
-func (s *DefaultValueDto) SetAccessibility(val OptNilString) {
-	s.Accessibility = val
-}
-
-// SetUsability sets the value of Usability.
-func (s *DefaultValueDto) SetUsability(val OptNilString) {
-	s.Usability = val
-}
-
-// SetPermissionType sets the value of PermissionType.
-func (s *DefaultValueDto) SetPermissionType(val OptNilString) {
-	s.PermissionType = val
-}
-
-// SetCreatedBy sets the value of CreatedBy.
-func (s *DefaultValueDto) SetCreatedBy(val OptString) {
-	s.CreatedBy = val
-}
-
-// SetCreatedOn sets the value of CreatedOn.
-func (s *DefaultValueDto) SetCreatedOn(val OptDateTime) {
-	s.CreatedOn = val
-}
-
-// SetModifiedBy sets the value of ModifiedBy.
-func (s *DefaultValueDto) SetModifiedBy(val OptNilString) {
-	s.ModifiedBy = val
-}
-
-// SetModifiedOn sets the value of ModifiedOn.
-func (s *DefaultValueDto) SetModifiedOn(val OptNilDateTime) {
-	s.ModifiedOn = val
-}
-
-// SetImportTask sets the value of ImportTask.
-func (s *DefaultValueDto) SetImportTask(val OptImportTaskDto) {
-	s.ImportTask = val
-}
-
-// Ref: #/components/schemas/DocumentDto
-type DocumentDto struct {
-	DocumentId    OptInt32         `json:"documentId"`
-	RowVersion    []byte           `json:"rowVersion"`
-	ImportTaskId  OptInt32         `json:"importTaskId"`
-	FileName      OptString        `json:"fileName"`
-	DataBlob      []byte           `json:"dataBlob"`
-	UploadDate    OptDateTime      `json:"uploadDate"`
-	XmlSourceType OptNilString     `json:"xmlSourceType"`
-	FileSize      OptInt64         `json:"fileSize"`
-	CreatedBy     OptString        `json:"createdBy"`
-	CreatedOn     OptDateTime      `json:"createdOn"`
-	ModifiedBy    OptNilString     `json:"modifiedBy"`
-	ModifiedOn    OptNilDateTime   `json:"modifiedOn"`
-	ImportTask    OptImportTaskDto `json:"importTask"`
-}
-
-// GetDocumentId returns the value of DocumentId.
-func (s *DocumentDto) GetDocumentId() OptInt32 {
-	return s.DocumentId
-}
-
-// GetRowVersion returns the value of RowVersion.
-func (s *DocumentDto) GetRowVersion() []byte {
-	return s.RowVersion
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *DocumentDto) GetImportTaskId() OptInt32 {
-	return s.ImportTaskId
-}
-
-// GetFileName returns the value of FileName.
-func (s *DocumentDto) GetFileName() OptString {
-	return s.FileName
-}
-
-// GetDataBlob returns the value of DataBlob.
-func (s *DocumentDto) GetDataBlob() []byte {
-	return s.DataBlob
-}
-
-// GetUploadDate returns the value of UploadDate.
-func (s *DocumentDto) GetUploadDate() OptDateTime {
-	return s.UploadDate
-}
-
-// GetXmlSourceType returns the value of XmlSourceType.
-func (s *DocumentDto) GetXmlSourceType() OptNilString {
-	return s.XmlSourceType
-}
-
-// GetFileSize returns the value of FileSize.
-func (s *DocumentDto) GetFileSize() OptInt64 {
-	return s.FileSize
-}
-
-// GetCreatedBy returns the value of CreatedBy.
-func (s *DocumentDto) GetCreatedBy() OptString {
-	return s.CreatedBy
-}
-
-// GetCreatedOn returns the value of CreatedOn.
-func (s *DocumentDto) GetCreatedOn() OptDateTime {
-	return s.CreatedOn
-}
-
-// GetModifiedBy returns the value of ModifiedBy.
-func (s *DocumentDto) GetModifiedBy() OptNilString {
-	return s.ModifiedBy
-}
-
-// GetModifiedOn returns the value of ModifiedOn.
-func (s *DocumentDto) GetModifiedOn() OptNilDateTime {
-	return s.ModifiedOn
-}
-
-// GetImportTask returns the value of ImportTask.
-func (s *DocumentDto) GetImportTask() OptImportTaskDto {
-	return s.ImportTask
-}
-
-// SetDocumentId sets the value of DocumentId.
-func (s *DocumentDto) SetDocumentId(val OptInt32) {
-	s.DocumentId = val
-}
-
-// SetRowVersion sets the value of RowVersion.
-func (s *DocumentDto) SetRowVersion(val []byte) {
-	s.RowVersion = val
-}
-
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *DocumentDto) SetImportTaskId(val OptInt32) {
-	s.ImportTaskId = val
-}
-
-// SetFileName sets the value of FileName.
-func (s *DocumentDto) SetFileName(val OptString) {
-	s.FileName = val
-}
-
-// SetDataBlob sets the value of DataBlob.
-func (s *DocumentDto) SetDataBlob(val []byte) {
-	s.DataBlob = val
-}
-
-// SetUploadDate sets the value of UploadDate.
-func (s *DocumentDto) SetUploadDate(val OptDateTime) {
-	s.UploadDate = val
-}
-
-// SetXmlSourceType sets the value of XmlSourceType.
-func (s *DocumentDto) SetXmlSourceType(val OptNilString) {
-	s.XmlSourceType = val
-}
-
-// SetFileSize sets the value of FileSize.
-func (s *DocumentDto) SetFileSize(val OptInt64) {
-	s.FileSize = val
-}
-
-// SetCreatedBy sets the value of CreatedBy.
-func (s *DocumentDto) SetCreatedBy(val OptString) {
-	s.CreatedBy = val
-}
-
-// SetCreatedOn sets the value of CreatedOn.
-func (s *DocumentDto) SetCreatedOn(val OptDateTime) {
-	s.CreatedOn = val
-}
-
-// SetModifiedBy sets the value of ModifiedBy.
-func (s *DocumentDto) SetModifiedBy(val OptNilString) {
-	s.ModifiedBy = val
-}
-
-// SetModifiedOn sets the value of ModifiedOn.
-func (s *DocumentDto) SetModifiedOn(val OptNilDateTime) {
-	s.ModifiedOn = val
-}
-
-// SetImportTask sets the value of ImportTask.
-func (s *DocumentDto) SetImportTask(val OptImportTaskDto) {
-	s.ImportTask = val
-}
+func (*CreateImportTaskResponse) aPIImporttasksPostRes() {}
 
 // The detailed status of an internal service used by the API.
 // Ref: #/components/schemas/HealthCheckResult
 type HealthCheckResult struct {
+	// How much time passed in querying the service status.
+	DurationMs OptFloat64 `json:"durationMs"`
 	// The name of the service.
 	Name string `json:"name"`
 	// The current status of the service.
 	Status string `json:"status"`
-	// How much time passed in querying the service status.
-	DurationMs OptFloat64 `json:"durationMs"`
+}
+
+// GetDurationMs returns the value of DurationMs.
+func (s *HealthCheckResult) GetDurationMs() OptFloat64 {
+	return s.DurationMs
 }
 
 // GetName returns the value of Name.
@@ -1126,9 +360,9 @@ func (s *HealthCheckResult) GetStatus() string {
 	return s.Status
 }
 
-// GetDurationMs returns the value of DurationMs.
-func (s *HealthCheckResult) GetDurationMs() OptFloat64 {
-	return s.DurationMs
+// SetDurationMs sets the value of DurationMs.
+func (s *HealthCheckResult) SetDurationMs(val OptFloat64) {
+	s.DurationMs = val
 }
 
 // SetName sets the value of Name.
@@ -1141,23 +375,13 @@ func (s *HealthCheckResult) SetStatus(val string) {
 	s.Status = val
 }
 
-// SetDurationMs sets the value of DurationMs.
-func (s *HealthCheckResult) SetDurationMs(val OptFloat64) {
-	s.DurationMs = val
-}
-
 // The resulting status with health details on different services.
 // Ref: #/components/schemas/HealthStatusResult
 type HealthStatusResult struct {
-	// The overall status.
-	Status string `json:"status"`
 	// A list with services and it's health statuses.
 	Checks OptNilHealthCheckResultArray `json:"checks"`
-}
-
-// GetStatus returns the value of Status.
-func (s *HealthStatusResult) GetStatus() string {
-	return s.Status
+	// The overall status.
+	Status string `json:"status"`
 }
 
 // GetChecks returns the value of Checks.
@@ -1165,14 +389,19 @@ func (s *HealthStatusResult) GetChecks() OptNilHealthCheckResultArray {
 	return s.Checks
 }
 
-// SetStatus sets the value of Status.
-func (s *HealthStatusResult) SetStatus(val string) {
-	s.Status = val
+// GetStatus returns the value of Status.
+func (s *HealthStatusResult) GetStatus() string {
+	return s.Status
 }
 
 // SetChecks sets the value of Checks.
 func (s *HealthStatusResult) SetChecks(val OptNilHealthCheckResultArray) {
 	s.Checks = val
+}
+
+// SetStatus sets the value of Status.
+func (s *HealthStatusResult) SetStatus(val string) {
+	s.Status = val
 }
 
 // Enum values:
@@ -1220,186 +449,6 @@ func (s *ImportBehaviourType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Ref: #/components/schemas/ImportDto
-type ImportDto struct {
-	ImportId               OptInt32         `json:"importId"`
-	RowVersion             []byte           `json:"rowVersion"`
-	TaskId                 OptString        `json:"taskId"`
-	ImportTaskId           OptInt32         `json:"importTaskId"`
-	Status                 OptString        `json:"status"`
-	Description            OptNilString     `json:"description"`
-	ProcessedDocumentCount OptNilInt32      `json:"processedDocumentCount"`
-	TotalDocumentCount     OptNilInt32      `json:"totalDocumentCount"`
-	ImportDate             OptNilDateTime   `json:"importDate"`
-	ImportFileBlob         OptNilByte       `json:"importFileBlob"`
-	IsSuccessful           OptBool          `json:"isSuccessful"`
-	CreatedBy              OptString        `json:"createdBy"`
-	CreatedOn              OptDateTime      `json:"createdOn"`
-	ModifiedBy             OptNilString     `json:"modifiedBy"`
-	ModifiedOn             OptNilDateTime   `json:"modifiedOn"`
-	ImportTask             OptImportTaskDto `json:"importTask"`
-}
-
-// GetImportId returns the value of ImportId.
-func (s *ImportDto) GetImportId() OptInt32 {
-	return s.ImportId
-}
-
-// GetRowVersion returns the value of RowVersion.
-func (s *ImportDto) GetRowVersion() []byte {
-	return s.RowVersion
-}
-
-// GetTaskId returns the value of TaskId.
-func (s *ImportDto) GetTaskId() OptString {
-	return s.TaskId
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *ImportDto) GetImportTaskId() OptInt32 {
-	return s.ImportTaskId
-}
-
-// GetStatus returns the value of Status.
-func (s *ImportDto) GetStatus() OptString {
-	return s.Status
-}
-
-// GetDescription returns the value of Description.
-func (s *ImportDto) GetDescription() OptNilString {
-	return s.Description
-}
-
-// GetProcessedDocumentCount returns the value of ProcessedDocumentCount.
-func (s *ImportDto) GetProcessedDocumentCount() OptNilInt32 {
-	return s.ProcessedDocumentCount
-}
-
-// GetTotalDocumentCount returns the value of TotalDocumentCount.
-func (s *ImportDto) GetTotalDocumentCount() OptNilInt32 {
-	return s.TotalDocumentCount
-}
-
-// GetImportDate returns the value of ImportDate.
-func (s *ImportDto) GetImportDate() OptNilDateTime {
-	return s.ImportDate
-}
-
-// GetImportFileBlob returns the value of ImportFileBlob.
-func (s *ImportDto) GetImportFileBlob() OptNilByte {
-	return s.ImportFileBlob
-}
-
-// GetIsSuccessful returns the value of IsSuccessful.
-func (s *ImportDto) GetIsSuccessful() OptBool {
-	return s.IsSuccessful
-}
-
-// GetCreatedBy returns the value of CreatedBy.
-func (s *ImportDto) GetCreatedBy() OptString {
-	return s.CreatedBy
-}
-
-// GetCreatedOn returns the value of CreatedOn.
-func (s *ImportDto) GetCreatedOn() OptDateTime {
-	return s.CreatedOn
-}
-
-// GetModifiedBy returns the value of ModifiedBy.
-func (s *ImportDto) GetModifiedBy() OptNilString {
-	return s.ModifiedBy
-}
-
-// GetModifiedOn returns the value of ModifiedOn.
-func (s *ImportDto) GetModifiedOn() OptNilDateTime {
-	return s.ModifiedOn
-}
-
-// GetImportTask returns the value of ImportTask.
-func (s *ImportDto) GetImportTask() OptImportTaskDto {
-	return s.ImportTask
-}
-
-// SetImportId sets the value of ImportId.
-func (s *ImportDto) SetImportId(val OptInt32) {
-	s.ImportId = val
-}
-
-// SetRowVersion sets the value of RowVersion.
-func (s *ImportDto) SetRowVersion(val []byte) {
-	s.RowVersion = val
-}
-
-// SetTaskId sets the value of TaskId.
-func (s *ImportDto) SetTaskId(val OptString) {
-	s.TaskId = val
-}
-
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *ImportDto) SetImportTaskId(val OptInt32) {
-	s.ImportTaskId = val
-}
-
-// SetStatus sets the value of Status.
-func (s *ImportDto) SetStatus(val OptString) {
-	s.Status = val
-}
-
-// SetDescription sets the value of Description.
-func (s *ImportDto) SetDescription(val OptNilString) {
-	s.Description = val
-}
-
-// SetProcessedDocumentCount sets the value of ProcessedDocumentCount.
-func (s *ImportDto) SetProcessedDocumentCount(val OptNilInt32) {
-	s.ProcessedDocumentCount = val
-}
-
-// SetTotalDocumentCount sets the value of TotalDocumentCount.
-func (s *ImportDto) SetTotalDocumentCount(val OptNilInt32) {
-	s.TotalDocumentCount = val
-}
-
-// SetImportDate sets the value of ImportDate.
-func (s *ImportDto) SetImportDate(val OptNilDateTime) {
-	s.ImportDate = val
-}
-
-// SetImportFileBlob sets the value of ImportFileBlob.
-func (s *ImportDto) SetImportFileBlob(val OptNilByte) {
-	s.ImportFileBlob = val
-}
-
-// SetIsSuccessful sets the value of IsSuccessful.
-func (s *ImportDto) SetIsSuccessful(val OptBool) {
-	s.IsSuccessful = val
-}
-
-// SetCreatedBy sets the value of CreatedBy.
-func (s *ImportDto) SetCreatedBy(val OptString) {
-	s.CreatedBy = val
-}
-
-// SetCreatedOn sets the value of CreatedOn.
-func (s *ImportDto) SetCreatedOn(val OptDateTime) {
-	s.CreatedOn = val
-}
-
-// SetModifiedBy sets the value of ModifiedBy.
-func (s *ImportDto) SetModifiedBy(val OptNilString) {
-	s.ModifiedBy = val
-}
-
-// SetModifiedOn sets the value of ModifiedOn.
-func (s *ImportDto) SetModifiedOn(val OptNilDateTime) {
-	s.ModifiedOn = val
-}
-
-// SetImportTask sets the value of ImportTask.
-func (s *ImportDto) SetImportTask(val OptImportTaskDto) {
-	s.ImportTask = val
-}
-
 // Enum values:
 // - `Erfolgreich`: The import was successfull
 // - `Fehler`: The import failed and has errors.
@@ -1445,27 +494,21 @@ func (s *ImportResult) UnmarshalText(data []byte) error {
 	}
 }
 
+// Response containing the status of an import run.
 // Ref: #/components/schemas/ImportRunStatusResponse
 type ImportRunStatusResponse struct {
-	ImportTaskId    OptInt32     `json:"importTaskId"`
-	ImportRunId     OptString    `json:"importRunId"`
-	Status          OptString    `json:"status"`
-	ProgressPercent OptNilInt32  `json:"progressPercent"`
-	Error           OptNilString `json:"error"`
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *ImportRunStatusResponse) GetImportTaskId() OptInt32 {
-	return s.ImportTaskId
-}
-
-// GetImportRunId returns the value of ImportRunId.
-func (s *ImportRunStatusResponse) GetImportRunId() OptString {
-	return s.ImportRunId
+	Status ImportStatus `json:"status"`
+	// The progress of the import run in percent (0-100), if available.
+	ProgressPercent OptNilInt32     `json:"progressPercent"`
+	ImportResult    OptImportResult `json:"importResult"`
+	// How many records were processed during the import.
+	ProcessedDocumentCount OptNilInt32 `json:"processedDocumentCount"`
+	// The total number of records to be processed during the import.
+	TotalDocumentCount OptNilInt32 `json:"totalDocumentCount"`
 }
 
 // GetStatus returns the value of Status.
-func (s *ImportRunStatusResponse) GetStatus() OptString {
+func (s *ImportRunStatusResponse) GetStatus() ImportStatus {
 	return s.Status
 }
 
@@ -1474,23 +517,23 @@ func (s *ImportRunStatusResponse) GetProgressPercent() OptNilInt32 {
 	return s.ProgressPercent
 }
 
-// GetError returns the value of Error.
-func (s *ImportRunStatusResponse) GetError() OptNilString {
-	return s.Error
+// GetImportResult returns the value of ImportResult.
+func (s *ImportRunStatusResponse) GetImportResult() OptImportResult {
+	return s.ImportResult
 }
 
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *ImportRunStatusResponse) SetImportTaskId(val OptInt32) {
-	s.ImportTaskId = val
+// GetProcessedDocumentCount returns the value of ProcessedDocumentCount.
+func (s *ImportRunStatusResponse) GetProcessedDocumentCount() OptNilInt32 {
+	return s.ProcessedDocumentCount
 }
 
-// SetImportRunId sets the value of ImportRunId.
-func (s *ImportRunStatusResponse) SetImportRunId(val OptString) {
-	s.ImportRunId = val
+// GetTotalDocumentCount returns the value of TotalDocumentCount.
+func (s *ImportRunStatusResponse) GetTotalDocumentCount() OptNilInt32 {
+	return s.TotalDocumentCount
 }
 
 // SetStatus sets the value of Status.
-func (s *ImportRunStatusResponse) SetStatus(val OptString) {
+func (s *ImportRunStatusResponse) SetStatus(val ImportStatus) {
 	s.Status = val
 }
 
@@ -1499,227 +542,131 @@ func (s *ImportRunStatusResponse) SetProgressPercent(val OptNilInt32) {
 	s.ProgressPercent = val
 }
 
-// SetError sets the value of Error.
-func (s *ImportRunStatusResponse) SetError(val OptNilString) {
-	s.Error = val
-}
-
-func (*ImportRunStatusResponse) aPIImportTasksIDImportRunsRunIdStatusGetRes() {}
-
-// Ref: #/components/schemas/ImportTaskDto
-type ImportTaskDto struct {
-	ImportTaskId              OptInt32            `json:"importTaskId"`
-	RowVersion                []byte              `json:"rowVersion"`
-	TaskType                  OptString           `json:"taskType"`
-	Name                      OptNilString        `json:"name"`
-	NoAutomaticImport         OptBool             `json:"noAutomaticImport"`
-	RequiresContainers        OptBool             `json:"requiresContainers"`
-	Status                    OptString           `json:"status"`
-	AnalysisErrorMessage      OptNilString        `json:"analysisErrorMessage"`
-	AnalysisResult            OptNilString        `json:"analysisResult"`
-	AnalysisProgressInPercent OptNilInt32         `json:"analysisProgressInPercent"`
-	ImportResult              OptNilString        `json:"importResult"`
-	CreatedBy                 OptString           `json:"createdBy"`
-	CreatedOn                 OptDateTime         `json:"createdOn"`
-	ModifiedBy                OptNilString        `json:"modifiedBy"`
-	ModifiedOn                OptNilDateTime      `json:"modifiedOn"`
-	AnalysisRecords           []AnalysisRecordDto `json:"analysisRecords"`
-	DefaultValues             []DefaultValueDto   `json:"defaultValues"`
-	Documents                 []DocumentDto       `json:"documents"`
-	Imports                   []ImportDto         `json:"imports"`
-}
-
-// GetImportTaskId returns the value of ImportTaskId.
-func (s *ImportTaskDto) GetImportTaskId() OptInt32 {
-	return s.ImportTaskId
-}
-
-// GetRowVersion returns the value of RowVersion.
-func (s *ImportTaskDto) GetRowVersion() []byte {
-	return s.RowVersion
-}
-
-// GetTaskType returns the value of TaskType.
-func (s *ImportTaskDto) GetTaskType() OptString {
-	return s.TaskType
-}
-
-// GetName returns the value of Name.
-func (s *ImportTaskDto) GetName() OptNilString {
-	return s.Name
-}
-
-// GetNoAutomaticImport returns the value of NoAutomaticImport.
-func (s *ImportTaskDto) GetNoAutomaticImport() OptBool {
-	return s.NoAutomaticImport
-}
-
-// GetRequiresContainers returns the value of RequiresContainers.
-func (s *ImportTaskDto) GetRequiresContainers() OptBool {
-	return s.RequiresContainers
-}
-
-// GetStatus returns the value of Status.
-func (s *ImportTaskDto) GetStatus() OptString {
-	return s.Status
-}
-
-// GetAnalysisErrorMessage returns the value of AnalysisErrorMessage.
-func (s *ImportTaskDto) GetAnalysisErrorMessage() OptNilString {
-	return s.AnalysisErrorMessage
-}
-
-// GetAnalysisResult returns the value of AnalysisResult.
-func (s *ImportTaskDto) GetAnalysisResult() OptNilString {
-	return s.AnalysisResult
-}
-
-// GetAnalysisProgressInPercent returns the value of AnalysisProgressInPercent.
-func (s *ImportTaskDto) GetAnalysisProgressInPercent() OptNilInt32 {
-	return s.AnalysisProgressInPercent
-}
-
-// GetImportResult returns the value of ImportResult.
-func (s *ImportTaskDto) GetImportResult() OptNilString {
-	return s.ImportResult
-}
-
-// GetCreatedBy returns the value of CreatedBy.
-func (s *ImportTaskDto) GetCreatedBy() OptString {
-	return s.CreatedBy
-}
-
-// GetCreatedOn returns the value of CreatedOn.
-func (s *ImportTaskDto) GetCreatedOn() OptDateTime {
-	return s.CreatedOn
-}
-
-// GetModifiedBy returns the value of ModifiedBy.
-func (s *ImportTaskDto) GetModifiedBy() OptNilString {
-	return s.ModifiedBy
-}
-
-// GetModifiedOn returns the value of ModifiedOn.
-func (s *ImportTaskDto) GetModifiedOn() OptNilDateTime {
-	return s.ModifiedOn
-}
-
-// GetAnalysisRecords returns the value of AnalysisRecords.
-func (s *ImportTaskDto) GetAnalysisRecords() []AnalysisRecordDto {
-	return s.AnalysisRecords
-}
-
-// GetDefaultValues returns the value of DefaultValues.
-func (s *ImportTaskDto) GetDefaultValues() []DefaultValueDto {
-	return s.DefaultValues
-}
-
-// GetDocuments returns the value of Documents.
-func (s *ImportTaskDto) GetDocuments() []DocumentDto {
-	return s.Documents
-}
-
-// GetImports returns the value of Imports.
-func (s *ImportTaskDto) GetImports() []ImportDto {
-	return s.Imports
-}
-
-// SetImportTaskId sets the value of ImportTaskId.
-func (s *ImportTaskDto) SetImportTaskId(val OptInt32) {
-	s.ImportTaskId = val
-}
-
-// SetRowVersion sets the value of RowVersion.
-func (s *ImportTaskDto) SetRowVersion(val []byte) {
-	s.RowVersion = val
-}
-
-// SetTaskType sets the value of TaskType.
-func (s *ImportTaskDto) SetTaskType(val OptString) {
-	s.TaskType = val
-}
-
-// SetName sets the value of Name.
-func (s *ImportTaskDto) SetName(val OptNilString) {
-	s.Name = val
-}
-
-// SetNoAutomaticImport sets the value of NoAutomaticImport.
-func (s *ImportTaskDto) SetNoAutomaticImport(val OptBool) {
-	s.NoAutomaticImport = val
-}
-
-// SetRequiresContainers sets the value of RequiresContainers.
-func (s *ImportTaskDto) SetRequiresContainers(val OptBool) {
-	s.RequiresContainers = val
-}
-
-// SetStatus sets the value of Status.
-func (s *ImportTaskDto) SetStatus(val OptString) {
-	s.Status = val
-}
-
-// SetAnalysisErrorMessage sets the value of AnalysisErrorMessage.
-func (s *ImportTaskDto) SetAnalysisErrorMessage(val OptNilString) {
-	s.AnalysisErrorMessage = val
-}
-
-// SetAnalysisResult sets the value of AnalysisResult.
-func (s *ImportTaskDto) SetAnalysisResult(val OptNilString) {
-	s.AnalysisResult = val
-}
-
-// SetAnalysisProgressInPercent sets the value of AnalysisProgressInPercent.
-func (s *ImportTaskDto) SetAnalysisProgressInPercent(val OptNilInt32) {
-	s.AnalysisProgressInPercent = val
-}
-
 // SetImportResult sets the value of ImportResult.
-func (s *ImportTaskDto) SetImportResult(val OptNilString) {
+func (s *ImportRunStatusResponse) SetImportResult(val OptImportResult) {
 	s.ImportResult = val
 }
 
-// SetCreatedBy sets the value of CreatedBy.
-func (s *ImportTaskDto) SetCreatedBy(val OptString) {
-	s.CreatedBy = val
+// SetProcessedDocumentCount sets the value of ProcessedDocumentCount.
+func (s *ImportRunStatusResponse) SetProcessedDocumentCount(val OptNilInt32) {
+	s.ProcessedDocumentCount = val
 }
 
-// SetCreatedOn sets the value of CreatedOn.
-func (s *ImportTaskDto) SetCreatedOn(val OptDateTime) {
-	s.CreatedOn = val
+// SetTotalDocumentCount sets the value of TotalDocumentCount.
+func (s *ImportRunStatusResponse) SetTotalDocumentCount(val OptNilInt32) {
+	s.TotalDocumentCount = val
 }
 
-// SetModifiedBy sets the value of ModifiedBy.
-func (s *ImportTaskDto) SetModifiedBy(val OptNilString) {
-	s.ModifiedBy = val
+func (*ImportRunStatusResponse) aPIImporttasksIDImportrunsRunIdStatusGetRes() {}
+
+// Enum values:
+// - `RequestStart`
+// - `RequestCancel`
+// - `Started`
+// - `Failed`
+// - `Canceled`
+// - `Completed`
+// - `UndoStarted`
+// - `UndoCompleted`
+// - `Created`
+// - `Preparing`.
+// Ref: #/components/schemas/ImportStatus
+type ImportStatus string
+
+const (
+	ImportStatusRequestStart  ImportStatus = "RequestStart"
+	ImportStatusRequestCancel ImportStatus = "RequestCancel"
+	ImportStatusStarted       ImportStatus = "Started"
+	ImportStatusFailed        ImportStatus = "Failed"
+	ImportStatusCanceled      ImportStatus = "Canceled"
+	ImportStatusCompleted     ImportStatus = "Completed"
+	ImportStatusUndoStarted   ImportStatus = "UndoStarted"
+	ImportStatusUndoCompleted ImportStatus = "UndoCompleted"
+	ImportStatusCreated       ImportStatus = "Created"
+	ImportStatusPreparing     ImportStatus = "Preparing"
+)
+
+// AllValues returns all ImportStatus values.
+func (ImportStatus) AllValues() []ImportStatus {
+	return []ImportStatus{
+		ImportStatusRequestStart,
+		ImportStatusRequestCancel,
+		ImportStatusStarted,
+		ImportStatusFailed,
+		ImportStatusCanceled,
+		ImportStatusCompleted,
+		ImportStatusUndoStarted,
+		ImportStatusUndoCompleted,
+		ImportStatusCreated,
+		ImportStatusPreparing,
+	}
 }
 
-// SetModifiedOn sets the value of ModifiedOn.
-func (s *ImportTaskDto) SetModifiedOn(val OptNilDateTime) {
-	s.ModifiedOn = val
+// MarshalText implements encoding.TextMarshaler.
+func (s ImportStatus) MarshalText() ([]byte, error) {
+	switch s {
+	case ImportStatusRequestStart:
+		return []byte(s), nil
+	case ImportStatusRequestCancel:
+		return []byte(s), nil
+	case ImportStatusStarted:
+		return []byte(s), nil
+	case ImportStatusFailed:
+		return []byte(s), nil
+	case ImportStatusCanceled:
+		return []byte(s), nil
+	case ImportStatusCompleted:
+		return []byte(s), nil
+	case ImportStatusUndoStarted:
+		return []byte(s), nil
+	case ImportStatusUndoCompleted:
+		return []byte(s), nil
+	case ImportStatusCreated:
+		return []byte(s), nil
+	case ImportStatusPreparing:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
 }
 
-// SetAnalysisRecords sets the value of AnalysisRecords.
-func (s *ImportTaskDto) SetAnalysisRecords(val []AnalysisRecordDto) {
-	s.AnalysisRecords = val
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ImportStatus) UnmarshalText(data []byte) error {
+	switch ImportStatus(data) {
+	case ImportStatusRequestStart:
+		*s = ImportStatusRequestStart
+		return nil
+	case ImportStatusRequestCancel:
+		*s = ImportStatusRequestCancel
+		return nil
+	case ImportStatusStarted:
+		*s = ImportStatusStarted
+		return nil
+	case ImportStatusFailed:
+		*s = ImportStatusFailed
+		return nil
+	case ImportStatusCanceled:
+		*s = ImportStatusCanceled
+		return nil
+	case ImportStatusCompleted:
+		*s = ImportStatusCompleted
+		return nil
+	case ImportStatusUndoStarted:
+		*s = ImportStatusUndoStarted
+		return nil
+	case ImportStatusUndoCompleted:
+		*s = ImportStatusUndoCompleted
+		return nil
+	case ImportStatusCreated:
+		*s = ImportStatusCreated
+		return nil
+	case ImportStatusPreparing:
+		*s = ImportStatusPreparing
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
-
-// SetDefaultValues sets the value of DefaultValues.
-func (s *ImportTaskDto) SetDefaultValues(val []DefaultValueDto) {
-	s.DefaultValues = val
-}
-
-// SetDocuments sets the value of Documents.
-func (s *ImportTaskDto) SetDocuments(val []DocumentDto) {
-	s.Documents = val
-}
-
-// SetImports sets the value of Imports.
-func (s *ImportTaskDto) SetImports(val []ImportDto) {
-	s.Imports = val
-}
-
-func (*ImportTaskDto) aPIImportTasksIDPatchRes() {}
 
 // Enum values:
 // - `Neu`: The initial status of an import task
@@ -1798,19 +745,16 @@ func (s *ImportTaskStatus) UnmarshalText(data []byte) error {
 	}
 }
 
+// Response containing the status of an import task (analysis phase).
 // Ref: #/components/schemas/ImportTaskStatusResponse
 type ImportTaskStatusResponse struct {
 	Status         ImportTaskStatus  `json:"status"`
 	AnalysisResult OptAnalysisResult `json:"analysisResult"`
 	// During the analysis, this indicates the progress in percent.
-	AnalysisProgressInPercent OptNilInt32     `json:"analysisProgressInPercent"`
-	ImportResult              OptImportResult `json:"importResult"`
-	// During the import, this indicates the progress in percent.
-	ImportProgressInPercent OptNilInt32 `json:"importProgressInPercent"`
-	// How many records were processed by the import.
-	ProcessedDocumentCount OptNilInt32 `json:"processedDocumentCount"`
-	// The total number of records that should have been processed by the import.
-	TotalDocumentCount OptNilInt32 `json:"totalDocumentCount"`
+	AnalysisProgressInPercent OptNilInt32 `json:"analysisProgressInPercent"`
+	// If there was an error during the analysis, this contains the error message.
+	AnalysisErrorMessage OptNilString    `json:"analysisErrorMessage"`
+	ImportResult         OptImportResult `json:"importResult"`
 }
 
 // GetStatus returns the value of Status.
@@ -1828,24 +772,14 @@ func (s *ImportTaskStatusResponse) GetAnalysisProgressInPercent() OptNilInt32 {
 	return s.AnalysisProgressInPercent
 }
 
+// GetAnalysisErrorMessage returns the value of AnalysisErrorMessage.
+func (s *ImportTaskStatusResponse) GetAnalysisErrorMessage() OptNilString {
+	return s.AnalysisErrorMessage
+}
+
 // GetImportResult returns the value of ImportResult.
 func (s *ImportTaskStatusResponse) GetImportResult() OptImportResult {
 	return s.ImportResult
-}
-
-// GetImportProgressInPercent returns the value of ImportProgressInPercent.
-func (s *ImportTaskStatusResponse) GetImportProgressInPercent() OptNilInt32 {
-	return s.ImportProgressInPercent
-}
-
-// GetProcessedDocumentCount returns the value of ProcessedDocumentCount.
-func (s *ImportTaskStatusResponse) GetProcessedDocumentCount() OptNilInt32 {
-	return s.ProcessedDocumentCount
-}
-
-// GetTotalDocumentCount returns the value of TotalDocumentCount.
-func (s *ImportTaskStatusResponse) GetTotalDocumentCount() OptNilInt32 {
-	return s.TotalDocumentCount
 }
 
 // SetStatus sets the value of Status.
@@ -1863,58 +797,50 @@ func (s *ImportTaskStatusResponse) SetAnalysisProgressInPercent(val OptNilInt32)
 	s.AnalysisProgressInPercent = val
 }
 
+// SetAnalysisErrorMessage sets the value of AnalysisErrorMessage.
+func (s *ImportTaskStatusResponse) SetAnalysisErrorMessage(val OptNilString) {
+	s.AnalysisErrorMessage = val
+}
+
 // SetImportResult sets the value of ImportResult.
 func (s *ImportTaskStatusResponse) SetImportResult(val OptImportResult) {
 	s.ImportResult = val
 }
 
-// SetImportProgressInPercent sets the value of ImportProgressInPercent.
-func (s *ImportTaskStatusResponse) SetImportProgressInPercent(val OptNilInt32) {
-	s.ImportProgressInPercent = val
-}
+func (*ImportTaskStatusResponse) aPIImporttasksIDStatusGetRes() {}
 
-// SetProcessedDocumentCount sets the value of ProcessedDocumentCount.
-func (s *ImportTaskStatusResponse) SetProcessedDocumentCount(val OptNilInt32) {
-	s.ProcessedDocumentCount = val
-}
-
-// SetTotalDocumentCount sets the value of TotalDocumentCount.
-func (s *ImportTaskStatusResponse) SetTotalDocumentCount(val OptNilInt32) {
-	s.TotalDocumentCount = val
-}
-
-// NewOptAPIImportTasksIDImportRunsPostReq returns new OptAPIImportTasksIDImportRunsPostReq with value set to v.
-func NewOptAPIImportTasksIDImportRunsPostReq(v APIImportTasksIDImportRunsPostReq) OptAPIImportTasksIDImportRunsPostReq {
-	return OptAPIImportTasksIDImportRunsPostReq{
+// NewOptAPIImporttasksIDImportrunsPostReq returns new OptAPIImporttasksIDImportrunsPostReq with value set to v.
+func NewOptAPIImporttasksIDImportrunsPostReq(v APIImporttasksIDImportrunsPostReq) OptAPIImporttasksIDImportrunsPostReq {
+	return OptAPIImporttasksIDImportrunsPostReq{
 		Value: v,
 		Set:   true,
 	}
 }
 
-// OptAPIImportTasksIDImportRunsPostReq is optional APIImportTasksIDImportRunsPostReq.
-type OptAPIImportTasksIDImportRunsPostReq struct {
-	Value APIImportTasksIDImportRunsPostReq
+// OptAPIImporttasksIDImportrunsPostReq is optional APIImporttasksIDImportrunsPostReq.
+type OptAPIImporttasksIDImportrunsPostReq struct {
+	Value APIImporttasksIDImportrunsPostReq
 	Set   bool
 }
 
-// IsSet returns true if OptAPIImportTasksIDImportRunsPostReq was set.
-func (o OptAPIImportTasksIDImportRunsPostReq) IsSet() bool { return o.Set }
+// IsSet returns true if OptAPIImporttasksIDImportrunsPostReq was set.
+func (o OptAPIImporttasksIDImportrunsPostReq) IsSet() bool { return o.Set }
 
 // Reset unsets value.
-func (o *OptAPIImportTasksIDImportRunsPostReq) Reset() {
-	var v APIImportTasksIDImportRunsPostReq
+func (o *OptAPIImporttasksIDImportrunsPostReq) Reset() {
+	var v APIImporttasksIDImportrunsPostReq
 	o.Value = v
 	o.Set = false
 }
 
 // SetTo sets value to v.
-func (o *OptAPIImportTasksIDImportRunsPostReq) SetTo(v APIImportTasksIDImportRunsPostReq) {
+func (o *OptAPIImporttasksIDImportrunsPostReq) SetTo(v APIImporttasksIDImportrunsPostReq) {
 	o.Set = true
 	o.Value = v
 }
 
 // Get returns value and boolean that denotes whether value was set.
-func (o OptAPIImportTasksIDImportRunsPostReq) Get() (v APIImportTasksIDImportRunsPostReq, ok bool) {
+func (o OptAPIImporttasksIDImportrunsPostReq) Get() (v APIImporttasksIDImportrunsPostReq, ok bool) {
 	if !o.Set {
 		return v, false
 	}
@@ -1922,45 +848,45 @@ func (o OptAPIImportTasksIDImportRunsPostReq) Get() (v APIImportTasksIDImportRun
 }
 
 // Or returns value if set, or given parameter if does not.
-func (o OptAPIImportTasksIDImportRunsPostReq) Or(d APIImportTasksIDImportRunsPostReq) APIImportTasksIDImportRunsPostReq {
+func (o OptAPIImporttasksIDImportrunsPostReq) Or(d APIImporttasksIDImportrunsPostReq) APIImporttasksIDImportrunsPostReq {
 	if v, ok := o.Get(); ok {
 		return v
 	}
 	return d
 }
 
-// NewOptAPIImportTasksPostReq returns new OptAPIImportTasksPostReq with value set to v.
-func NewOptAPIImportTasksPostReq(v APIImportTasksPostReq) OptAPIImportTasksPostReq {
-	return OptAPIImportTasksPostReq{
+// NewOptAPIImporttasksPostReq returns new OptAPIImporttasksPostReq with value set to v.
+func NewOptAPIImporttasksPostReq(v APIImporttasksPostReq) OptAPIImporttasksPostReq {
+	return OptAPIImporttasksPostReq{
 		Value: v,
 		Set:   true,
 	}
 }
 
-// OptAPIImportTasksPostReq is optional APIImportTasksPostReq.
-type OptAPIImportTasksPostReq struct {
-	Value APIImportTasksPostReq
+// OptAPIImporttasksPostReq is optional APIImporttasksPostReq.
+type OptAPIImporttasksPostReq struct {
+	Value APIImporttasksPostReq
 	Set   bool
 }
 
-// IsSet returns true if OptAPIImportTasksPostReq was set.
-func (o OptAPIImportTasksPostReq) IsSet() bool { return o.Set }
+// IsSet returns true if OptAPIImporttasksPostReq was set.
+func (o OptAPIImporttasksPostReq) IsSet() bool { return o.Set }
 
 // Reset unsets value.
-func (o *OptAPIImportTasksPostReq) Reset() {
-	var v APIImportTasksPostReq
+func (o *OptAPIImporttasksPostReq) Reset() {
+	var v APIImporttasksPostReq
 	o.Value = v
 	o.Set = false
 }
 
 // SetTo sets value to v.
-func (o *OptAPIImportTasksPostReq) SetTo(v APIImportTasksPostReq) {
+func (o *OptAPIImporttasksPostReq) SetTo(v APIImporttasksPostReq) {
 	o.Set = true
 	o.Value = v
 }
 
 // Get returns value and boolean that denotes whether value was set.
-func (o OptAPIImportTasksPostReq) Get() (v APIImportTasksPostReq, ok bool) {
+func (o OptAPIImporttasksPostReq) Get() (v APIImporttasksPostReq, ok bool) {
 	if !o.Set {
 		return v, false
 	}
@@ -1968,7 +894,7 @@ func (o OptAPIImportTasksPostReq) Get() (v APIImportTasksPostReq, ok bool) {
 }
 
 // Or returns value if set, or given parameter if does not.
-func (o OptAPIImportTasksPostReq) Or(d APIImportTasksPostReq) APIImportTasksPostReq {
+func (o OptAPIImporttasksPostReq) Or(d APIImporttasksPostReq) APIImporttasksPostReq {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -2015,98 +941,6 @@ func (o OptAnalysisResult) Get() (v AnalysisResult, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptAnalysisResult) Or(d AnalysisResult) AnalysisResult {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptBool returns new OptBool with value set to v.
-func NewOptBool(v bool) OptBool {
-	return OptBool{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptBool is optional bool.
-type OptBool struct {
-	Value bool
-	Set   bool
-}
-
-// IsSet returns true if OptBool was set.
-func (o OptBool) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptBool) Reset() {
-	var v bool
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptBool) SetTo(v bool) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptBool) Get() (v bool, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptBool) Or(d bool) bool {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptDateTime returns new OptDateTime with value set to v.
-func NewOptDateTime(v time.Time) OptDateTime {
-	return OptDateTime{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptDateTime is optional time.Time.
-type OptDateTime struct {
-	Value time.Time
-	Set   bool
-}
-
-// IsSet returns true if OptDateTime was set.
-func (o OptDateTime) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptDateTime) Reset() {
-	var v time.Time
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptDateTime) SetTo(v time.Time) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptDateTime) Get() (v time.Time, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptDateTime) Or(d time.Time) time.Time {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -2245,333 +1079,6 @@ func (o OptImportResult) Get() (v ImportResult, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptImportResult) Or(d ImportResult) ImportResult {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptImportTaskDto returns new OptImportTaskDto with value set to v.
-func NewOptImportTaskDto(v ImportTaskDto) OptImportTaskDto {
-	return OptImportTaskDto{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptImportTaskDto is optional ImportTaskDto.
-type OptImportTaskDto struct {
-	Value ImportTaskDto
-	Set   bool
-}
-
-// IsSet returns true if OptImportTaskDto was set.
-func (o OptImportTaskDto) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptImportTaskDto) Reset() {
-	var v ImportTaskDto
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptImportTaskDto) SetTo(v ImportTaskDto) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptImportTaskDto) Get() (v ImportTaskDto, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptImportTaskDto) Or(d ImportTaskDto) ImportTaskDto {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptInt32 returns new OptInt32 with value set to v.
-func NewOptInt32(v int32) OptInt32 {
-	return OptInt32{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptInt32 is optional int32.
-type OptInt32 struct {
-	Value int32
-	Set   bool
-}
-
-// IsSet returns true if OptInt32 was set.
-func (o OptInt32) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptInt32) Reset() {
-	var v int32
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptInt32) SetTo(v int32) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptInt32) Get() (v int32, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptInt32) Or(d int32) int32 {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptInt64 returns new OptInt64 with value set to v.
-func NewOptInt64(v int64) OptInt64 {
-	return OptInt64{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptInt64 is optional int64.
-type OptInt64 struct {
-	Value int64
-	Set   bool
-}
-
-// IsSet returns true if OptInt64 was set.
-func (o OptInt64) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptInt64) Reset() {
-	var v int64
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptInt64) SetTo(v int64) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptInt64) Get() (v int64, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptInt64) Or(d int64) int64 {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptNilBool returns new OptNilBool with value set to v.
-func NewOptNilBool(v bool) OptNilBool {
-	return OptNilBool{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptNilBool is optional nullable bool.
-type OptNilBool struct {
-	Value bool
-	Set   bool
-	Null  bool
-}
-
-// IsSet returns true if OptNilBool was set.
-func (o OptNilBool) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptNilBool) Reset() {
-	var v bool
-	o.Value = v
-	o.Set = false
-	o.Null = false
-}
-
-// SetTo sets value to v.
-func (o *OptNilBool) SetTo(v bool) {
-	o.Set = true
-	o.Null = false
-	o.Value = v
-}
-
-// IsNull returns true if value is Null.
-func (o OptNilBool) IsNull() bool { return o.Null }
-
-// SetToNull sets value to null.
-func (o *OptNilBool) SetToNull() {
-	o.Set = true
-	o.Null = true
-	var v bool
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptNilBool) Get() (v bool, ok bool) {
-	if o.Null {
-		return v, false
-	}
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptNilBool) Or(d bool) bool {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptNilByte returns new OptNilByte with value set to v.
-func NewOptNilByte(v []byte) OptNilByte {
-	return OptNilByte{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptNilByte is optional nullable []byte.
-type OptNilByte struct {
-	Value []byte
-	Set   bool
-	Null  bool
-}
-
-// IsSet returns true if OptNilByte was set.
-func (o OptNilByte) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptNilByte) Reset() {
-	var v []byte
-	o.Value = v
-	o.Set = false
-	o.Null = false
-}
-
-// SetTo sets value to v.
-func (o *OptNilByte) SetTo(v []byte) {
-	o.Set = true
-	o.Null = false
-	o.Value = v
-}
-
-// IsNull returns true if value is Null.
-func (o OptNilByte) IsNull() bool { return o.Null }
-
-// SetToNull sets value to null.
-func (o *OptNilByte) SetToNull() {
-	o.Set = true
-	o.Null = true
-	var v []byte
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptNilByte) Get() (v []byte, ok bool) {
-	if o.Null {
-		return v, false
-	}
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptNilByte) Or(d []byte) []byte {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptNilDateTime returns new OptNilDateTime with value set to v.
-func NewOptNilDateTime(v time.Time) OptNilDateTime {
-	return OptNilDateTime{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptNilDateTime is optional nullable time.Time.
-type OptNilDateTime struct {
-	Value time.Time
-	Set   bool
-	Null  bool
-}
-
-// IsSet returns true if OptNilDateTime was set.
-func (o OptNilDateTime) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptNilDateTime) Reset() {
-	var v time.Time
-	o.Value = v
-	o.Set = false
-	o.Null = false
-}
-
-// SetTo sets value to v.
-func (o *OptNilDateTime) SetTo(v time.Time) {
-	o.Set = true
-	o.Null = false
-	o.Value = v
-}
-
-// IsNull returns true if value is Null.
-func (o OptNilDateTime) IsNull() bool { return o.Null }
-
-// SetToNull sets value to null.
-func (o *OptNilDateTime) SetToNull() {
-	o.Set = true
-	o.Null = true
-	var v time.Time
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptNilDateTime) Get() (v time.Time, ok bool) {
-	if o.Null {
-		return v, false
-	}
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptNilDateTime) Or(d time.Time) time.Time {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -2767,144 +1274,6 @@ func (o OptNilString) Or(d string) string {
 	return d
 }
 
-// NewOptString returns new OptString with value set to v.
-func NewOptString(v string) OptString {
-	return OptString{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptString is optional string.
-type OptString struct {
-	Value string
-	Set   bool
-}
-
-// IsSet returns true if OptString was set.
-func (o OptString) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptString) Reset() {
-	var v string
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptString) SetTo(v string) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptString) Get() (v string, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptString) Or(d string) string {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptUUID returns new OptUUID with value set to v.
-func NewOptUUID(v uuid.UUID) OptUUID {
-	return OptUUID{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptUUID is optional uuid.UUID.
-type OptUUID struct {
-	Value uuid.UUID
-	Set   bool
-}
-
-// IsSet returns true if OptUUID was set.
-func (o OptUUID) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptUUID) Reset() {
-	var v uuid.UUID
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptUUID) SetTo(v uuid.UUID) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptUUID) Get() (v uuid.UUID, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptUUID) Or(d uuid.UUID) uuid.UUID {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptValidationProblemDetailsErrors returns new OptValidationProblemDetailsErrors with value set to v.
-func NewOptValidationProblemDetailsErrors(v ValidationProblemDetailsErrors) OptValidationProblemDetailsErrors {
-	return OptValidationProblemDetailsErrors{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptValidationProblemDetailsErrors is optional ValidationProblemDetailsErrors.
-type OptValidationProblemDetailsErrors struct {
-	Value ValidationProblemDetailsErrors
-	Set   bool
-}
-
-// IsSet returns true if OptValidationProblemDetailsErrors was set.
-func (o OptValidationProblemDetailsErrors) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptValidationProblemDetailsErrors) Reset() {
-	var v ValidationProblemDetailsErrors
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptValidationProblemDetailsErrors) SetTo(v ValidationProblemDetailsErrors) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptValidationProblemDetailsErrors) Get() (v ValidationProblemDetailsErrors, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptValidationProblemDetailsErrors) Or(d ValidationProblemDetailsErrors) ValidationProblemDetailsErrors {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // Ref: #/components/schemas/ProblemDetails
 type ProblemDetails struct {
 	Type            OptNilString `json:"type"`
@@ -2974,8 +1343,6 @@ func (s *ProblemDetails) SetInstance(val OptNilString) {
 func (s *ProblemDetails) SetAdditionalProps(val ProblemDetailsAdditional) {
 	s.AdditionalProps = val
 }
-
-func (*ProblemDetails) aPIImportTasksPostRes() {}
 
 type ProblemDetailsAdditional map[string]jx.Raw
 
@@ -3072,109 +1439,4 @@ func (s *Smart) SetToken(val string) {
 // SetRoles sets the value of Roles.
 func (s *Smart) SetRoles(val []string) {
 	s.Roles = val
-}
-
-// Ref: #/components/schemas/ValidationProblemDetails
-type ValidationProblemDetails struct {
-	Type            OptNilString                      `json:"type"`
-	Title           OptNilString                      `json:"title"`
-	Status          OptNilInt32                       `json:"status"`
-	Detail          OptNilString                      `json:"detail"`
-	Instance        OptNilString                      `json:"instance"`
-	Errors          OptValidationProblemDetailsErrors `json:"errors"`
-	AdditionalProps ValidationProblemDetailsAdditional
-}
-
-// GetType returns the value of Type.
-func (s *ValidationProblemDetails) GetType() OptNilString {
-	return s.Type
-}
-
-// GetTitle returns the value of Title.
-func (s *ValidationProblemDetails) GetTitle() OptNilString {
-	return s.Title
-}
-
-// GetStatus returns the value of Status.
-func (s *ValidationProblemDetails) GetStatus() OptNilInt32 {
-	return s.Status
-}
-
-// GetDetail returns the value of Detail.
-func (s *ValidationProblemDetails) GetDetail() OptNilString {
-	return s.Detail
-}
-
-// GetInstance returns the value of Instance.
-func (s *ValidationProblemDetails) GetInstance() OptNilString {
-	return s.Instance
-}
-
-// GetErrors returns the value of Errors.
-func (s *ValidationProblemDetails) GetErrors() OptValidationProblemDetailsErrors {
-	return s.Errors
-}
-
-// GetAdditionalProps returns the value of AdditionalProps.
-func (s *ValidationProblemDetails) GetAdditionalProps() ValidationProblemDetailsAdditional {
-	return s.AdditionalProps
-}
-
-// SetType sets the value of Type.
-func (s *ValidationProblemDetails) SetType(val OptNilString) {
-	s.Type = val
-}
-
-// SetTitle sets the value of Title.
-func (s *ValidationProblemDetails) SetTitle(val OptNilString) {
-	s.Title = val
-}
-
-// SetStatus sets the value of Status.
-func (s *ValidationProblemDetails) SetStatus(val OptNilInt32) {
-	s.Status = val
-}
-
-// SetDetail sets the value of Detail.
-func (s *ValidationProblemDetails) SetDetail(val OptNilString) {
-	s.Detail = val
-}
-
-// SetInstance sets the value of Instance.
-func (s *ValidationProblemDetails) SetInstance(val OptNilString) {
-	s.Instance = val
-}
-
-// SetErrors sets the value of Errors.
-func (s *ValidationProblemDetails) SetErrors(val OptValidationProblemDetailsErrors) {
-	s.Errors = val
-}
-
-// SetAdditionalProps sets the value of AdditionalProps.
-func (s *ValidationProblemDetails) SetAdditionalProps(val ValidationProblemDetailsAdditional) {
-	s.AdditionalProps = val
-}
-
-func (*ValidationProblemDetails) aPIImportTasksIDImportRunsPostRes() {}
-
-type ValidationProblemDetailsAdditional map[string]jx.Raw
-
-func (s *ValidationProblemDetailsAdditional) init() ValidationProblemDetailsAdditional {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
-type ValidationProblemDetailsErrors map[string][]string
-
-func (s *ValidationProblemDetailsErrors) init() ValidationProblemDetailsErrors {
-	m := *s
-	if m == nil {
-		m = map[string][]string{}
-		*s = m
-	}
-	return m
 }

--- a/internal/apis/gen/oas_security_gen.go
+++ b/internal/apis/gen/oas_security_gen.go
@@ -19,11 +19,11 @@ type SecuritySource interface {
 // operationRolesSmart is a private map storing roles per operation.
 var operationRolesSmart = map[string][]string{
 	APIHealthzGetOperation:                            []string{},
-	APIImportTasksIDImportRunsPostOperation:           []string{},
-	APIImportTasksIDImportRunsRunIdStatusGetOperation: []string{},
-	APIImportTasksIDPatchOperation:                    []string{},
-	APIImportTasksIDStatusGetOperation:                []string{},
-	APIImportTasksPostOperation:                       []string{},
+	APIImporttasksIDCancelPostOperation:               []string{},
+	APIImporttasksIDImportrunsPostOperation:           []string{},
+	APIImporttasksIDImportrunsRunIdStatusGetOperation: []string{},
+	APIImporttasksIDStatusGetOperation:                []string{},
+	APIImporttasksPostOperation:                       []string{},
 }
 
 // GetRolesForSmart returns the required roles for the given operation.

--- a/internal/apis/gen/oas_validators_gen.go
+++ b/internal/apis/gen/oas_validators_gen.go
@@ -25,7 +25,7 @@ func (s *APIHealthzGetServiceUnavailable) Validate() error {
 	return nil
 }
 
-func (s *APIImportTasksIDImportRunsPostReq) Validate() error {
+func (s *APIImporttasksIDImportrunsPostReq) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
 	}
@@ -55,7 +55,7 @@ func (s *APIImportTasksIDImportRunsPostReq) Validate() error {
 	return nil
 }
 
-func (s *APIImportTasksPostReq) Validate() error {
+func (s *APIImporttasksPostReq) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
 	}
@@ -91,52 +91,6 @@ func (s AnalysisResult) Validate() error {
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
-}
-
-func (s *CancelImportTaskRequest) Validate() error {
-	if s == nil {
-		return validate.ErrNilPointer
-	}
-
-	var failures []validate.FieldError
-	if err := func() error {
-		if err := s.Status.Validate(); err != nil {
-			return err
-		}
-		return nil
-	}(); err != nil {
-		failures = append(failures, validate.FieldError{
-			Name:  "status",
-			Error: err,
-		})
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-	return nil
-}
-
-func (s *CancelImportTaskRequestWithContentType) Validate() error {
-	if s == nil {
-		return validate.ErrNilPointer
-	}
-
-	var failures []validate.FieldError
-	if err := func() error {
-		if err := s.Content.Validate(); err != nil {
-			return err
-		}
-		return nil
-	}(); err != nil {
-		failures = append(failures, validate.FieldError{
-			Name:  "Content",
-			Error: err,
-		})
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-	return nil
 }
 
 func (s *HealthCheckResult) Validate() error {
@@ -238,6 +192,74 @@ func (s ImportResult) Validate() error {
 	}
 }
 
+func (s *ImportRunStatusResponse) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Status.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "status",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.ImportResult.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "importResult",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ImportStatus) Validate() error {
+	switch s {
+	case "RequestStart":
+		return nil
+	case "RequestCancel":
+		return nil
+	case "Started":
+		return nil
+	case "Failed":
+		return nil
+	case "Canceled":
+		return nil
+	case "Completed":
+		return nil
+	case "UndoStarted":
+		return nil
+	case "UndoCompleted":
+		return nil
+	case "Created":
+		return nil
+	case "Preparing":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
 func (s ImportTaskStatus) Validate() error {
 	switch s {
 	case "Neu":
@@ -329,56 +351,4 @@ func (s SipType) Validate() error {
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
-}
-
-func (s *ValidationProblemDetails) Validate() error {
-	if s == nil {
-		return validate.ErrNilPointer
-	}
-
-	var failures []validate.FieldError
-	if err := func() error {
-		if value, ok := s.Errors.Get(); ok {
-			if err := func() error {
-				if err := value.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return err
-			}
-		}
-		return nil
-	}(); err != nil {
-		failures = append(failures, validate.FieldError{
-			Name:  "errors",
-			Error: err,
-		})
-	}
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-	return nil
-}
-
-func (s ValidationProblemDetailsErrors) Validate() error {
-	var failures []validate.FieldError
-	for key, elem := range s {
-		if err := func() error {
-			if elem == nil {
-				return errors.New("nil is invalid value")
-			}
-			return nil
-		}(); err != nil {
-			failures = append(failures, validate.FieldError{
-				Name:  key,
-				Error: err,
-			})
-		}
-	}
-
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-	return nil
 }

--- a/internal/apis/poll_import_task_status_activity.go
+++ b/internal/apis/poll_import_task_status_activity.go
@@ -54,30 +54,51 @@ func (a *PollImportTaskStatusActivity) Execute(
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-ticker.C:
-			status, err := a.client.APIImportTasksIDStatusGet(ctx, gen.APIImportTasksIDStatusGetParams{
+			res, err := a.client.APIImporttasksIDStatusGet(ctx, gen.APIImporttasksIDStatusGetParams{
 				ID: params.TaskID,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("poll APIS import task status: %w", err)
 			}
 
-			done, err := analysisComplete(status)
-			if err != nil {
-				return nil, err
-			}
-			if !done {
-				continue
-			}
+			switch status := res.(type) {
+			case *gen.ImportTaskStatusResponse:
+				done, err := analysisComplete(status)
+				if err != nil {
+					return nil, err
+				}
+				if !done {
+					continue
+				}
 
-			analysisResult, ok := status.AnalysisResult.Get()
-			if !ok {
+				analysisResult, ok := status.AnalysisResult.Get()
+				if !ok {
+					return nil, temporal.NewNonRetryableError(fmt.Errorf(
+						"poll APIS import task status: missing analysis result for completed task %q",
+						params.TaskID,
+					))
+				}
+
+				return &PollImportTaskStatusResult{AnalysisResult: analysisResult}, nil
+			case *gen.APIImporttasksIDStatusGetUnauthorized:
+				return nil, temporal.NewNonRetryableError(
+					fmt.Errorf("poll APIS import task status: unauthorized"),
+				)
+			case *gen.APIImporttasksIDStatusGetNotFound:
 				return nil, temporal.NewNonRetryableError(fmt.Errorf(
-					"poll APIS import task status: missing analysis result for completed task %q",
-					params.TaskID,
+					"poll APIS import task status: task not found: %s",
+					problemDetail(status.Detail),
 				))
+			case *gen.APIImporttasksIDStatusGetInternalServerError:
+				return nil, fmt.Errorf(
+					"poll APIS import task status: server error: %s",
+					problemDetail(status.Detail),
+				)
+			default:
+				return nil, temporal.NewNonRetryableError(
+					fmt.Errorf("poll APIS import task status: unexpected response"),
+				)
 			}
-
-			return &PollImportTaskStatusResult{AnalysisResult: analysisResult}, nil
 		}
 	}
 }

--- a/internal/apis/poll_import_task_status_activity_test.go
+++ b/internal/apis/poll_import_task_status_activity_test.go
@@ -29,23 +29,23 @@ func TestPollImportTaskStatusActivity(t *testing.T) {
 			name:   "polls until analysis is complete",
 			params: apis.PollImportTaskStatusParams{TaskID: "task-000001"},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksIDStatusGet(
+				m.APIImporttasksIDStatusGet(
 					gomock.Any(),
-					apisgen.APIImportTasksIDStatusGetParams{ID: "task-000001"},
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000001"},
 				).Return(
 					&apisgen.ImportTaskStatusResponse{Status: apisgen.ImportTaskStatusNeu},
 					nil,
 				)
-				m.APIImportTasksIDStatusGet(
+				m.APIImporttasksIDStatusGet(
 					gomock.Any(),
-					apisgen.APIImportTasksIDStatusGetParams{ID: "task-000001"},
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000001"},
 				).Return(
 					&apisgen.ImportTaskStatusResponse{Status: apisgen.ImportTaskStatusInAnalyse},
 					nil,
 				)
-				m.APIImportTasksIDStatusGet(
+				m.APIImporttasksIDStatusGet(
 					gomock.Any(),
-					apisgen.APIImportTasksIDStatusGetParams{ID: "task-000001"},
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000001"},
 				).Return(
 					&apisgen.ImportTaskStatusResponse{
 						Status:         apisgen.ImportTaskStatusAnalysiert,
@@ -60,9 +60,9 @@ func TestPollImportTaskStatusActivity(t *testing.T) {
 			name:   "returns conflict analysis result",
 			params: apis.PollImportTaskStatusParams{TaskID: "task-000002"},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksIDStatusGet(
+				m.APIImporttasksIDStatusGet(
 					gomock.Any(),
-					apisgen.APIImportTasksIDStatusGetParams{ID: "task-000002"},
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000002"},
 				).Return(
 					&apisgen.ImportTaskStatusResponse{
 						Status:         apisgen.ImportTaskStatusAnalysiert,
@@ -77,9 +77,9 @@ func TestPollImportTaskStatusActivity(t *testing.T) {
 			name:   "returns analysis error result",
 			params: apis.PollImportTaskStatusParams{TaskID: "task-000003"},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksIDStatusGet(
+				m.APIImporttasksIDStatusGet(
 					gomock.Any(),
-					apisgen.APIImportTasksIDStatusGetParams{ID: "task-000003"},
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000003"},
 				).Return(
 					&apisgen.ImportTaskStatusResponse{
 						Status:         apisgen.ImportTaskStatusAnalysiert,
@@ -94,20 +94,68 @@ func TestPollImportTaskStatusActivity(t *testing.T) {
 			name:   "returns polling error",
 			params: apis.PollImportTaskStatusParams{TaskID: "task-000004"},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksIDStatusGet(
+				m.APIImporttasksIDStatusGet(
 					gomock.Any(),
-					apisgen.APIImportTasksIDStatusGetParams{ID: "task-000004"},
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000004"},
 				).Return(nil, errors.New("status boom"))
 			},
 			wantErr: "status boom",
 		},
 		{
-			name:   "returns error on unexpected analysis status",
+			name:   "returns unauthorized error response",
 			params: apis.PollImportTaskStatusParams{TaskID: "task-000005"},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksIDStatusGet(
+				m.APIImporttasksIDStatusGet(
 					gomock.Any(),
-					apisgen.APIImportTasksIDStatusGetParams{ID: "task-000005"},
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000005"},
+				).Return(
+					&apisgen.APIImporttasksIDStatusGetUnauthorized{
+						Detail: apisgen.NewOptNilString("unauthorized"),
+					},
+					nil,
+				)
+			},
+			wantErr: "poll APIS import task status: unauthorized",
+		},
+		{
+			name:   "returns not found error response",
+			params: apis.PollImportTaskStatusParams{TaskID: "task-000006"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000006"},
+				).Return(
+					&apisgen.APIImporttasksIDStatusGetNotFound{
+						Detail: apisgen.NewOptNilString("import task does not exist"),
+					},
+					nil,
+				)
+			},
+			wantErr: "poll APIS import task status: task not found: import task does not exist",
+		},
+		{
+			name:   "returns internal server error response",
+			params: apis.PollImportTaskStatusParams{TaskID: "task-000007"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000007"},
+				).Return(
+					&apisgen.APIImporttasksIDStatusGetInternalServerError{
+						Detail: apisgen.NewOptNilString("status backend failed"),
+					},
+					nil,
+				)
+			},
+			wantErr: "poll APIS import task status: server error: status backend failed",
+		},
+		{
+			name:   "returns error on unexpected analysis status",
+			params: apis.PollImportTaskStatusParams{TaskID: "task-000008"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000008"},
 				).Return(
 					&apisgen.ImportTaskStatusResponse{Status: apisgen.ImportTaskStatusImportiert},
 					nil,
@@ -117,11 +165,11 @@ func TestPollImportTaskStatusActivity(t *testing.T) {
 		},
 		{
 			name:   "returns error when analysis result is missing",
-			params: apis.PollImportTaskStatusParams{TaskID: "task-000006"},
+			params: apis.PollImportTaskStatusParams{TaskID: "task-000009"},
 			expect: func(m *fake_apis.MockClientMockRecorder) {
-				m.APIImportTasksIDStatusGet(
+				m.APIImporttasksIDStatusGet(
 					gomock.Any(),
-					apisgen.APIImportTasksIDStatusGetParams{ID: "task-000006"},
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000009"},
 				).Return(
 					&apisgen.ImportTaskStatusResponse{Status: apisgen.ImportTaskStatusAnalysiert},
 					nil,

--- a/internal/apis/problem_details.go
+++ b/internal/apis/problem_details.go
@@ -1,0 +1,11 @@
+package apis
+
+import "github.com/artefactual-sdps/preprocessing-sfa/internal/apis/gen"
+
+func problemDetail(detail gen.OptNilString) string {
+	if value, ok := detail.Get(); ok && value != "" {
+		return value
+	}
+
+	return "no additional details"
+}


### PR DESCRIPTION
Add latest apis/openapi3.json in two steps, the first commit adds the spec reorganized to better match the existing structure and the second one updates it as it was provided. Regenerate server and client stubs from the new spec and update mock server implementation and the workflow activities using the generated client.

Refs #173.