### PR TITLE
Add APIS decision signaling to preprocessing

### DIFF
--- a/internal/workflow/preprocessing.go
+++ b/internal/workflow/preprocessing.go
@@ -60,10 +60,18 @@ type (
 		SIPName string
 	}
 
+	// PreprocessingWorkflowResult is returned to Enduro processing workflow and
+	// also serves as this workflow's local state.
 	PreprocessingWorkflowResult struct {
 		Outcome           Outcome
 		RelativePath      string
 		PreservationTasks []*eventlog.Event
+
+		// These APIS fields are kept as local state for now. They are excluded
+		// from Temporal serialization until we decide how they should be shared
+		// with the AIS poststorage workflow.
+		APISTaskID   string `json:"-"`
+		APISDecision string `json:"-"`
 	}
 )
 
@@ -592,10 +600,8 @@ func (w *PreprocessingWorkflow) Execute(
 	}
 
 	// Create APIS import task.
-	// TODO: Share task ID and user decision with ais poststorage workflow.
 	if w.apisEnabled {
-		_ = w.createAPISImportTask(ctx, result, sip)
-		if result.Outcome == OutcomeSystemError {
+		if ok := w.createAPISImportTask(ctx, result, sip); !ok {
 			return result, nil
 		}
 	}
@@ -700,11 +706,15 @@ func withFilesysActOpts(ctx temporalsdk_workflow.Context) temporalsdk_workflow.C
 	})
 }
 
+// createAPISImportTask submits metadata to APIS, stores the resulting task ID
+// and decision, and handles the analysis outcome for the current workflow execution.
+// It returns false when processing should stop after recording the failure in
+// the workflow result/state.
 func (w *PreprocessingWorkflow) createAPISImportTask(
 	ctx temporalsdk_workflow.Context,
 	result *PreprocessingWorkflowResult,
 	sip sip.SIP,
-) string {
+) bool {
 	ev := result.newEvent(ctx, "Submit metadata to APIS")
 	var createAPISImportTask apis.CreateImportTaskResult
 	err := temporalsdk_workflow.ExecuteActivity(
@@ -730,10 +740,10 @@ func (w *PreprocessingWorkflow) createAPISImportTask(
 			"failed to submit metadata to APIS.",
 			"An error occurred while creating the APIS import task. Please try again, or ask a system administrator to investigate.",
 		)
-		return ""
+		return false
 	}
-	taskID := createAPISImportTask.TaskID
-	ev.Succeed(ctx, fmt.Sprintf("Submitted metadata to APIS with import task ID %q", taskID))
+	result.APISTaskID = createAPISImportTask.TaskID
+	ev.Succeed(ctx, fmt.Sprintf("Submitted metadata to APIS with import task ID %q", result.APISTaskID))
 
 	ev = result.newEvent(ctx, "Wait for APIS analysis")
 	var pollAPISImportTaskStatus apis.PollImportTaskStatusResult
@@ -748,7 +758,7 @@ func (w *PreprocessingWorkflow) createAPISImportTask(
 			},
 		}),
 		apis.PollImportTaskStatusActivityName,
-		&apis.PollImportTaskStatusParams{TaskID: taskID},
+		&apis.PollImportTaskStatusParams{TaskID: result.APISTaskID},
 	).Get(ctx, &pollAPISImportTaskStatus)
 	if err != nil {
 		result.systemError(
@@ -758,7 +768,7 @@ func (w *PreprocessingWorkflow) createAPISImportTask(
 			"failed to get an APIS analysis result.",
 			"An error occurred while checking the APIS import task status. Please try again, or ask a system administrator to investigate.",
 		)
-		return ""
+		return false
 	}
 
 	switch pollAPISImportTaskStatus.AnalysisResult {
@@ -767,43 +777,129 @@ func (w *PreprocessingWorkflow) createAPISImportTask(
 			ctx,
 			fmt.Sprintf(
 				"APIS analysis completed for import task ID %q with result %q",
-				taskID,
+				result.APISTaskID,
 				pollAPISImportTaskStatus.AnalysisResult,
 			),
 		)
-		return taskID
+		return true
 	case apisgen.AnalysisResultKonflikte:
-		// TODO: Signal parent and wait for user decision.
-		result.systemError(
-			ctx,
-			fmt.Errorf("APIS analysis reported metadata conflicts for task %q", taskID),
-			ev,
-			"submission to APIS requires human review.",
-			"APIS detected metadata conflicts and preprocessing cannot continue automatically. Review the APIS task before resuming or canceling the ingest.",
-		)
-		return ""
+		return w.waitForAPISDecision(ctx, result, ev)
 	case apisgen.AnalysisResultFehler:
 		result.systemError(
 			ctx,
-			fmt.Errorf("APIS analysis failed for task %q", taskID),
+			fmt.Errorf("APIS analysis failed for task %q", result.APISTaskID),
 			ev,
 			"submission to APIS has failed.",
 			"APIS reported an analysis error while processing the submitted metadata. Please try again, or ask a system administrator to investigate.",
 		)
-		return ""
+		return false
 	default:
 		result.systemError(
 			ctx,
 			fmt.Errorf(
 				"unexpected APIS analysis result %q for task %q",
 				pollAPISImportTaskStatus.AnalysisResult,
-				taskID,
+				result.APISTaskID,
 			),
 			ev,
 			"submission to APIS has failed.",
 			"APIS returned an unexpected analysis result. Please ask a system administrator to investigate.",
 		)
-		return ""
+		return false
+	}
+}
+
+// waitForAPISDecision asks the parent workflow for a decision and applies the
+// selected outcome to the current APIS conflict event. It returns false when
+// the workflow should stop after recording the failure in the workflow
+// result/state.
+func (w *PreprocessingWorkflow) waitForAPISDecision(
+	ctx temporalsdk_workflow.Context,
+	result *PreprocessingWorkflowResult,
+	ev *eventWrapper,
+) bool {
+	info := temporalsdk_workflow.GetInfo(ctx)
+	if info.ParentWorkflowExecution == nil {
+		result.systemError(
+			ctx,
+			fmt.Errorf(
+				"missing parent workflow execution while waiting for a decision on APIS import task %q",
+				result.APISTaskID,
+			),
+			ev,
+			"submission to APIS has failed.",
+			"An error occurred requesting a human decision on how to continue processing. Please try again, or ask a system administrator to investigate.",
+		)
+		return false
+	}
+
+	err := temporalsdk_workflow.SignalExternalWorkflow(
+		ctx,
+		info.ParentWorkflowExecution.ID,
+		info.ParentWorkflowExecution.RunID,
+		DecisionRequestSignal,
+		DecisionRequest{
+			Message: fmt.Sprintf(
+				"APIS detected metadata conflicts for import task ID %q. Review the APIS task and choose how ingest should continue.",
+				result.APISTaskID,
+			),
+			Options: []string{
+				DecisionOptionCancelIngest,
+				DecisionOptionContinueOverwrite,
+				DecisionOptionContinueAppend,
+			},
+		},
+	).Get(ctx, nil)
+	if err != nil {
+		result.systemError(
+			ctx,
+			fmt.Errorf("signal parent workflow for decision on APIS import task %q: %w", result.APISTaskID, err),
+			ev,
+			"submission to APIS has failed.",
+			"Could not notify the parent workflow that human review is required. Please try again, or ask a system administrator to investigate.",
+		)
+		return false
+	}
+
+	var decision DecisionResponse
+	temporalsdk_workflow.GetSignalChannel(ctx, DecisionResponseSignal).Receive(ctx, &decision)
+	result.APISDecision = decision.Option
+
+	switch result.APISDecision {
+	case DecisionOptionContinueOverwrite, DecisionOptionContinueAppend:
+		ev.Succeed(
+			ctx,
+			fmt.Sprintf(
+				"APIS detected metadata conflicts for import task ID %q but ingest was continued with user decision %q.",
+				result.APISTaskID,
+				result.APISDecision,
+			),
+		)
+		return true
+	case DecisionOptionCancelIngest:
+		// TODO: Add and use canceled as workflow outcome.
+		result.validationError(
+			ctx,
+			ev,
+			"ingest was canceled after APIS metadata conflict review.",
+			fmt.Sprintf(
+				"APIS detected metadata conflicts for import task ID %q and ingest was canceled by user decision.",
+				result.APISTaskID,
+			),
+		)
+		return false
+	default:
+		result.systemError(
+			ctx,
+			fmt.Errorf("unsupported decision %q for APIS import task %q", result.APISDecision, result.APISTaskID),
+			ev,
+			"submission to APIS has failed.",
+			fmt.Sprintf(
+				"Received unsupported user decision %q while resolving APIS metadata conflicts. Please ask a system administrator to investigate.",
+				result.APISDecision,
+			),
+		)
+		return false
 	}
 }
 

--- a/internal/workflow/preprocessing_test.go
+++ b/internal/workflow/preprocessing_test.go
@@ -20,10 +20,12 @@ import (
 	temporalsdk_activity "go.temporal.io/sdk/activity"
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
 	temporalsdk_worker "go.temporal.io/sdk/worker"
+	temporalsdk_workflow "go.temporal.io/sdk/workflow"
 	"gotest.tools/v3/fs"
 
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/activities"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis"
+	apisgen "github.com/artefactual-sdps/preprocessing-sfa/internal/apis/gen"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/config"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/enums"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/eventlog"
@@ -35,7 +37,8 @@ import (
 )
 
 const (
-	sipName = "SIP_20240606_dept.zip"
+	sipName    = "SIP_20240606_dept.zip"
+	apisTaskID = "task-000001"
 
 	// The relPath reflects an actual SFA ZIP path passed from Enduro to
 	// preprocessing-sfa — it seems that ingest prepends "SIP_" to the original
@@ -123,6 +126,133 @@ const (
 var (
 	testTime = time.Date(2024, 6, 6, 15, 8, 39, 0, time.UTC)
 	sipUUID  = uuid.MustParse("8fdfaea1-06ed-4cf6-8bdf-d15d80420f35")
+
+	preAPISEvents = []*eventlog.Event{
+		{
+			Name:        "Calculate SIP checksum",
+			Message:     "SIP checksum calculated using SHA-256",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Check for duplicate SIP",
+			Message:     "SIP is not a duplicate",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Extract SIP",
+			Message:     "SIP extracted",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Validate Bag",
+			Message:     "Bag successfully validated",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Unbag SIP",
+			Message:     "SIP unbagged",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Identify SIP structure",
+			Message:     "SIP structure identified: DigitizedAIP",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Validate SIP structure",
+			Message:     "SIP structure matches validation criteria",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Validate SIP name",
+			Message:     "SIP name matches expected naming convention for the identified structure type",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Verify SIP manifest",
+			Message:     "SIP contents match manifest",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Verify SIP checksums",
+			Message:     "SIP checksums match file contents",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Validate SIP file formats",
+			Message:     "No invalid files found",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name: "Validate SIP metadata",
+			Message: `Metadata validation successful on the following file(s):
+
+- UpdatedAreldaMetadata.xml`,
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Validate logical metadata",
+			Message:     "Logical metadata validation successful",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+	}
+
+	postAPISEvents = []*eventlog.Event{
+		{
+			Name:        "Create premis.xml",
+			Message:     "Created a premis.xml file and stored it in the metadata directory",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Restructure SIP",
+			Message:     "SIP has been restructured for preservation processing",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Create identifier.json",
+			Message:     "Created an identifier.json file and stored it in the metadata directory",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		{
+			Name:        "Bag SIP",
+			Message:     "SIP has been bagged",
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+	}
 )
 
 type PreprocessingTestSuite struct {
@@ -235,6 +365,7 @@ func (s *PreprocessingTestSuite) SetupTest(cfg *config.Configuration) {
 	)
 
 	s.workflow = workflow.NewPreprocessingWorkflow(nil, s.testDir, cfg.CheckDuplicates, cfg.APIS.Enabled)
+	s.env.RegisterWorkflow(s.workflow.Execute)
 }
 
 func (s *PreprocessingTestSuite) digitizedAIP(path string) sip.SIP {
@@ -323,23 +454,12 @@ Tag-File-Character-Encoding: UTF-8
 	}
 }
 
-func (s *PreprocessingTestSuite) TestSuccess() {
-	s.SetupTest(&config.Configuration{
-		CheckDuplicates: true,
-		APIS:            apis.Config{Enabled: true},
-	})
-	s.writeBagitTxt(s.sipPath)
-
+func (s *PreprocessingTestSuite) preAPISActivities(ar apisgen.AnalysisResult) (sip.SIP, string, string) {
 	extractPath := filepath.Join(filepath.Dir(s.sipPath), fsutil.BaseNoExt(filepath.Base(sipName)))
 	expectedSIP := s.digitizedAIP(extractPath)
-	expectedPIP := pips.NewFromSIP(expectedSIP)
-
-	// Mock activities.
 	ctx := mock.AnythingOfType("*context.valueCtx")
 	sessionCtx := mock.AnythingOfType("*context.timerCtx")
-	premisFilePath := filepath.Join(expectedSIP.Path, "metadata", "premis.xml")
 	checksum := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	apisTaskID := "task-000001"
 
 	s.env.OnActivity(
 		activities.ChecksumSIPName,
@@ -359,7 +479,6 @@ func (s *PreprocessingTestSuite) TestSuccess() {
 	).Return(
 		&localact.CheckDuplicateResult{}, nil,
 	)
-
 	s.env.OnActivity(
 		archiveextract.Name,
 		sessionCtx,
@@ -433,7 +552,6 @@ func (s *PreprocessingTestSuite) TestSuccess() {
 	).Return(
 		&xmlvalidate.Result{}, nil,
 	)
-
 	s.env.OnActivity(
 		activities.ValidatePREMISName,
 		sessionCtx,
@@ -456,10 +574,17 @@ func (s *PreprocessingTestSuite) TestSuccess() {
 		sessionCtx,
 		&apis.PollImportTaskStatusParams{TaskID: apisTaskID},
 	).Return(
-		&apis.PollImportTaskStatusResult{AnalysisResult: "AlleNeu"}, nil,
+		&apis.PollImportTaskStatusResult{AnalysisResult: ar}, nil,
 	)
 
-	// PREMIS activities.
+	return expectedSIP, extractPath, apisTaskID
+}
+
+func (s *PreprocessingTestSuite) postAPISActivities(expectedSIP sip.SIP) {
+	sessionCtx := mock.AnythingOfType("*context.timerCtx")
+	premisFilePath := filepath.Join(expectedSIP.Path, "metadata", "premis.xml")
+	expectedPIP := pips.NewFromSIP(expectedSIP)
+
 	s.env.OnActivity(
 		activities.AddPREMISObjectsName,
 		sessionCtx,
@@ -540,8 +665,6 @@ func (s *PreprocessingTestSuite) TestSuccess() {
 	).Return(
 		&activities.AddPREMISAgentResult{}, nil,
 	)
-
-	// Transform SIP.
 	s.env.OnActivity(
 		activities.TransformSIPName,
 		sessionCtx,
@@ -549,7 +672,6 @@ func (s *PreprocessingTestSuite) TestSuccess() {
 	).Return(
 		&activities.TransformSIPResult{PIP: expectedPIP}, nil,
 	)
-
 	s.env.OnActivity(
 		activities.WriteIdentifierFileName,
 		sessionCtx,
@@ -559,14 +681,104 @@ func (s *PreprocessingTestSuite) TestSuccess() {
 			Path: filepath.Join(s.sipPath, "metadata", "identifiers.json"),
 		}, nil,
 	)
-
 	s.env.OnActivity(
 		bagcreate.Name,
 		sessionCtx,
-		&bagcreate.Params{SourcePath: extractPath},
+		&bagcreate.Params{SourcePath: expectedSIP.Path},
 	).Return(
 		&bagcreate.Result{}, nil,
 	)
+}
+
+func apisEvents(
+	taskID string,
+	waitMessage string,
+	waitOutcome enums.EventOutcome,
+	includePostAPIS bool,
+) []*eventlog.Event {
+	events := append([]*eventlog.Event{}, preAPISEvents...)
+	events = append(events,
+		&eventlog.Event{
+			Name:        "Submit metadata to APIS",
+			Message:     fmt.Sprintf(`Submitted metadata to APIS with import task ID %q`, taskID),
+			Outcome:     enums.EventOutcomeSuccess,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+		&eventlog.Event{
+			Name:        "Wait for APIS analysis",
+			Message:     waitMessage,
+			Outcome:     waitOutcome,
+			StartedAt:   testTime,
+			CompletedAt: testTime,
+		},
+	)
+	if includePostAPIS {
+		events = append(events, postAPISEvents...)
+	}
+
+	return events
+}
+
+func (s *PreprocessingTestSuite) executeAsChildWithHumanReview(
+	params *workflow.PreprocessingWorkflowParams,
+	decision workflow.DecisionResponse,
+) *workflow.PreprocessingWorkflowResult {
+	parentWorkflow := func(
+		ctx temporalsdk_workflow.Context,
+		childParams *workflow.PreprocessingWorkflowParams,
+	) (*workflow.PreprocessingWorkflowResult, error) {
+		childFuture := temporalsdk_workflow.ExecuteChildWorkflow(ctx, s.workflow.Execute, childParams)
+
+		var request workflow.DecisionRequest
+		temporalsdk_workflow.GetSignalChannel(ctx, workflow.DecisionRequestSignal).Receive(ctx, &request)
+		s.Equal(
+			workflow.DecisionRequest{
+				Message: fmt.Sprintf(
+					"APIS detected metadata conflicts for import task ID %q. Review the APIS task and choose how ingest should continue.",
+					apisTaskID,
+				),
+				Options: []string{
+					workflow.DecisionOptionCancelIngest,
+					workflow.DecisionOptionContinueOverwrite,
+					workflow.DecisionOptionContinueAppend,
+				},
+			},
+			request,
+		)
+
+		err := childFuture.SignalChildWorkflow(ctx, workflow.DecisionResponseSignal, decision).Get(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var childResult workflow.PreprocessingWorkflowResult
+		if err := childFuture.Get(ctx, &childResult); err != nil {
+			return nil, err
+		}
+
+		return &childResult, nil
+	}
+
+	s.env.ExecuteWorkflow(parentWorkflow, params)
+	s.True(s.env.IsWorkflowCompleted())
+
+	var result workflow.PreprocessingWorkflowResult
+	err := s.env.GetWorkflowResult(&result)
+	s.NoError(err)
+
+	return &result
+}
+
+func (s *PreprocessingTestSuite) TestSuccess() {
+	s.SetupTest(&config.Configuration{
+		CheckDuplicates: true,
+		APIS:            apis.Config{Enabled: true},
+	})
+	s.writeBagitTxt(s.sipPath)
+
+	expectedSIP, extractPath, apisTaskID := s.preAPISActivities(apisgen.AnalysisResultAlleNeu)
+	s.postAPISActivities(expectedSIP)
 
 	s.env.ExecuteWorkflow(
 		s.workflow.Execute,
@@ -589,143 +801,16 @@ func (s *PreprocessingTestSuite) TestSuccess() {
 		&workflow.PreprocessingWorkflowResult{
 			Outcome:      workflow.OutcomeSuccess,
 			RelativePath: relPath,
-			PreservationTasks: []*eventlog.Event{
-				{
-					Name:        "Calculate SIP checksum",
-					Message:     "SIP checksum calculated using SHA-256",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Check for duplicate SIP",
-					Message:     "SIP is not a duplicate",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Extract SIP",
-					Message:     "SIP extracted",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Validate Bag",
-					Message:     "Bag successfully validated",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Unbag SIP",
-					Message:     "SIP unbagged",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Identify SIP structure",
-					Message:     "SIP structure identified: DigitizedAIP",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Validate SIP structure",
-					Message:     "SIP structure matches validation criteria",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Validate SIP name",
-					Message:     "SIP name matches expected naming convention for the identified structure type",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Verify SIP manifest",
-					Message:     "SIP contents match manifest",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Verify SIP checksums",
-					Message:     "SIP checksums match file contents",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Validate SIP file formats",
-					Message:     "No invalid files found",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name: "Validate SIP metadata",
-					Message: `Metadata validation successful on the following file(s):
-
-- UpdatedAreldaMetadata.xml`,
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Validate logical metadata",
-					Message:     "Logical metadata validation successful",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Submit metadata to APIS",
-					Message:     `Submitted metadata to APIS with import task ID "task-000001"`,
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Wait for APIS analysis",
-					Message:     `APIS analysis completed for import task ID "task-000001" with result "AlleNeu"`,
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Create premis.xml",
-					Message:     "Created a premis.xml file and stored it in the metadata directory",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Restructure SIP",
-					Message:     "SIP has been restructured for preservation processing",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Create identifier.json",
-					Message:     "Created an identifier.json file and stored it in the metadata directory",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-				{
-					Name:        "Bag SIP",
-					Message:     "SIP has been bagged",
-					Outcome:     enums.EventOutcomeSuccess,
-					StartedAt:   testTime,
-					CompletedAt: testTime,
-				},
-			},
+			PreservationTasks: apisEvents(
+				apisTaskID,
+				fmt.Sprintf(
+					`APIS analysis completed for import task ID %q with result %q`,
+					apisTaskID,
+					apisgen.AnalysisResultAlleNeu,
+				),
+				enums.EventOutcomeSuccess,
+				true,
+			),
 		},
 		&result,
 	)
@@ -1095,8 +1180,8 @@ func (s *PreprocessingTestSuite) TestExtractionError() {
 		sessionCtx,
 		&activities.IdentifySIPParams{Path: extractPath},
 	).Return(
-		activities.IdentifySIPResult{},
 		nil,
+		fmt.Errorf("IdentifySIP: NewSIP: stat : no such file or directory"),
 	)
 
 	// Execute workflow.
@@ -1145,5 +1230,174 @@ Enduro could not identify the package type. Please ensure that your SIP matches 
 			},
 		},
 		&result,
+	)
+}
+
+func (s *PreprocessingTestSuite) TestHumanReviewContinueAndOverwrite() {
+	s.SetupTest(&config.Configuration{
+		CheckDuplicates: true,
+		APIS:            apis.Config{Enabled: true},
+	})
+	s.writeBagitTxt(s.sipPath)
+
+	expectedSIP, extractPath, apisTaskID := s.preAPISActivities(apisgen.AnalysisResultKonflikte)
+	s.postAPISActivities(expectedSIP)
+
+	result := s.executeAsChildWithHumanReview(
+		&workflow.PreprocessingWorkflowParams{
+			RelativePath: relPath,
+			SIPID:        sipUUID,
+			SIPName:      sipName,
+		},
+		workflow.DecisionResponse{
+			Option: workflow.DecisionOptionContinueOverwrite,
+		},
+	)
+
+	updatedRelPath, err := filepath.Rel(s.testDir, extractPath)
+	s.NoError(err)
+
+	s.Equal(
+		&workflow.PreprocessingWorkflowResult{
+			Outcome:      workflow.OutcomeSuccess,
+			RelativePath: updatedRelPath,
+			PreservationTasks: apisEvents(
+				apisTaskID,
+				fmt.Sprintf(
+					"APIS detected metadata conflicts for import task ID %q but ingest was continued with user decision %q.",
+					apisTaskID,
+					workflow.DecisionOptionContinueOverwrite,
+				),
+				enums.EventOutcomeSuccess,
+				true,
+			),
+		},
+		result,
+	)
+}
+
+func (s *PreprocessingTestSuite) TestHumanReviewContinueAndAppend() {
+	s.SetupTest(&config.Configuration{
+		CheckDuplicates: true,
+		APIS:            apis.Config{Enabled: true},
+	})
+	s.writeBagitTxt(s.sipPath)
+
+	expectedSIP, extractPath, apisTaskID := s.preAPISActivities(apisgen.AnalysisResultKonflikte)
+	s.postAPISActivities(expectedSIP)
+
+	result := s.executeAsChildWithHumanReview(
+		&workflow.PreprocessingWorkflowParams{
+			RelativePath: relPath,
+			SIPID:        sipUUID,
+			SIPName:      sipName,
+		},
+		workflow.DecisionResponse{
+			Option: workflow.DecisionOptionContinueAppend,
+		},
+	)
+
+	updatedRelPath, err := filepath.Rel(s.testDir, extractPath)
+	s.NoError(err)
+
+	s.Equal(
+		&workflow.PreprocessingWorkflowResult{
+			Outcome:      workflow.OutcomeSuccess,
+			RelativePath: updatedRelPath,
+			PreservationTasks: apisEvents(
+				apisTaskID,
+				fmt.Sprintf(
+					"APIS detected metadata conflicts for import task ID %q but ingest was continued with user decision %q.",
+					apisTaskID,
+					workflow.DecisionOptionContinueAppend,
+				),
+				enums.EventOutcomeSuccess,
+				true,
+			),
+		},
+		result,
+	)
+}
+
+func (s *PreprocessingTestSuite) TestHumanReviewCancelIngest() {
+	s.SetupTest(&config.Configuration{
+		CheckDuplicates: true,
+		APIS:            apis.Config{Enabled: true},
+	})
+	s.writeBagitTxt(s.sipPath)
+
+	_, extractPath, apisTaskID := s.preAPISActivities(apisgen.AnalysisResultKonflikte)
+
+	result := s.executeAsChildWithHumanReview(
+		&workflow.PreprocessingWorkflowParams{
+			RelativePath: relPath,
+			SIPID:        sipUUID,
+			SIPName:      sipName,
+		},
+		workflow.DecisionResponse{
+			Option: workflow.DecisionOptionCancelIngest,
+		},
+	)
+
+	updatedRelPath, err := filepath.Rel(s.testDir, extractPath)
+	s.NoError(err)
+
+	s.Equal(
+		&workflow.PreprocessingWorkflowResult{
+			Outcome:      workflow.OutcomeContentError,
+			RelativePath: updatedRelPath,
+			PreservationTasks: apisEvents(
+				apisTaskID,
+				fmt.Sprintf(
+					`Content error: ingest was canceled after APIS metadata conflict review.
+
+APIS detected metadata conflicts for import task ID %q and ingest was canceled by user decision.`,
+					apisTaskID,
+				),
+				enums.EventOutcomeValidationFailure,
+				false,
+			),
+		},
+		result,
+	)
+}
+
+func (s *PreprocessingTestSuite) TestHumanReviewInvalidOption() {
+	s.SetupTest(&config.Configuration{
+		CheckDuplicates: true,
+		APIS:            apis.Config{Enabled: true},
+	})
+	s.writeBagitTxt(s.sipPath)
+
+	_, extractPath, apisTaskID := s.preAPISActivities(apisgen.AnalysisResultKonflikte)
+
+	result := s.executeAsChildWithHumanReview(
+		&workflow.PreprocessingWorkflowParams{
+			RelativePath: relPath,
+			SIPID:        sipUUID,
+			SIPName:      sipName,
+		},
+		workflow.DecisionResponse{
+			Option: "Unexpected option",
+		},
+	)
+
+	updatedRelPath, err := filepath.Rel(s.testDir, extractPath)
+	s.NoError(err)
+
+	s.Equal(
+		&workflow.PreprocessingWorkflowResult{
+			Outcome:      workflow.OutcomeSystemError,
+			RelativePath: updatedRelPath,
+			PreservationTasks: apisEvents(
+				apisTaskID,
+				`System error: submission to APIS has failed.
+
+Received unsupported user decision "Unexpected option" while resolving APIS metadata conflicts. Please ask a system administrator to investigate.`,
+				enums.EventOutcomeSystemFailure,
+				false,
+			),
+		},
+		result,
 	)
 }

--- a/internal/workflow/signals.go
+++ b/internal/workflow/signals.go
@@ -1,0 +1,19 @@
+package workflow
+
+const (
+	DecisionRequestSignal  = "decision-request-signal"
+	DecisionResponseSignal = "decision-response-signal"
+
+	DecisionOptionCancelIngest      = "Cancel ingest"
+	DecisionOptionContinueOverwrite = "Continue and overwrite"
+	DecisionOptionContinueAppend    = "Continue and append"
+)
+
+type DecisionRequest struct {
+	Message string
+	Options []string
+}
+
+type DecisionResponse struct {
+	Option string
+}


### PR DESCRIPTION
Signal the parent workflow when APIS reports metadata conflicts and wait for a decision before continuing preprocessing. Keep the APIS task ID and decision as local state, excluding them from the Temporal result.

Refs #173. See https://github.com/artefactual-sdps/enduro/issues/1536 and https://github.com/artefactual-sdps/enduro/pull/1608.