### PR TITLE
Carry APIS metadata to AIS poststorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Bring up the Enduro environment by following the [Enduro development manual].
 
 ### Set up
 
-The specific requirements for `preprocessing-sfa` are:
+The specific requirements for this project are:
 
 - clone this repository as a sibling of the Enduro repository
 - configure `CHILD_WORKFLOW_PATHS=../preprocessing-sfa`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/artefactual-sdps/preprocessing-sfa
 
-go 1.26.2
+go 1.26.3
 
 require (
 	ariga.io/sqlcomment v0.1.0

--- a/internal/ais/workflow.go
+++ b/internal/ais/workflow.go
@@ -18,6 +18,7 @@ import (
 	"gocloud.dev/blob"
 
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/amss"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis"
 )
 
 type Workflow struct {
@@ -34,6 +35,18 @@ func (w *Workflow) Execute(
 ) (r *childwf.PostStorageResult, e error) {
 	logger := temporalsdk_workflow.GetLogger(ctx)
 	logger.Debug("AIS workflow running!", "params", params)
+
+	if data, ok := params.CustomMetadata[apis.CustomMetadataKey]; ok {
+		var metadata apis.CustomMetadata
+		if err := metadata.Unmarshal(data); err != nil {
+			return nil, err
+		}
+		logger.Info(
+			"Received APIS custom metadata.",
+			"importTaskID", metadata.ImportTaskID,
+			"decision", metadata.Decision,
+		)
+	}
 
 	defer func() {
 		logger.Debug("AIS workflow finished!", "result", r, "error", e)

--- a/internal/ais/workflow_test.go
+++ b/internal/ais/workflow_test.go
@@ -1,6 +1,7 @@
 package ais_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	temporalsdk_worker "go.temporal.io/sdk/worker"
 
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/ais"
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis"
 )
 
 type TestSuite struct {
@@ -48,7 +50,14 @@ func (s *TestSuite) TestWorkflowSuccess() {
 
 	s.env.ExecuteWorkflow(
 		s.workflow.Execute,
-		&childwf.PostStorageParams{AIPUUID: aipUUID},
+		&childwf.PostStorageParams{
+			AIPUUID: aipUUID,
+			CustomMetadata: childwf.CustomMetadata{
+				apis.CustomMetadataKey: json.RawMessage(
+					`{"importTaskId":"task-000001","decision":"Continue and append"}`,
+				),
+			},
+		},
 	)
 
 	s.True(s.env.IsWorkflowCompleted())

--- a/internal/apis/custom_metadata.go
+++ b/internal/apis/custom_metadata.go
@@ -1,0 +1,40 @@
+package apis
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const CustomMetadataKey = "apis"
+
+type CustomMetadata struct {
+	ImportTaskID string `json:"importTaskId"`
+	Decision     string `json:"decision"`
+}
+
+func (m CustomMetadata) Marshal() ([]byte, error) {
+	if m.ImportTaskID == "" {
+		return nil, fmt.Errorf("APIS custom metadata requires import task ID")
+	}
+
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("marshal APIS custom metadata: %w", err)
+	}
+
+	return data, nil
+}
+
+func (m *CustomMetadata) Unmarshal(data []byte) error {
+	if m == nil {
+		return fmt.Errorf("APIS custom metadata destination is nil")
+	}
+	if err := json.Unmarshal(data, m); err != nil {
+		return fmt.Errorf("unmarshal APIS custom metadata: %w", err)
+	}
+	if m.ImportTaskID == "" {
+		return fmt.Errorf("APIS custom metadata requires import task ID")
+	}
+
+	return nil
+}

--- a/internal/apis/custom_metadata_test.go
+++ b/internal/apis/custom_metadata_test.go
@@ -1,0 +1,63 @@
+package apis_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis"
+)
+
+func TestCustomMetadataMarshal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("marshals APIS metadata", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := apis.CustomMetadata{
+			ImportTaskID: "task-000001",
+			Decision:     "Continue and append",
+		}.Marshal()
+		assert.NilError(t, err)
+		assert.Equal(t, string(data), `{"importTaskId":"task-000001","decision":"Continue and append"}`)
+	})
+
+	t.Run("rejects missing task ID", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := apis.CustomMetadata{}.Marshal()
+		assert.ErrorContains(t, err, "requires import task ID")
+	})
+}
+
+func TestCustomMetadataUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unmarshals APIS metadata", func(t *testing.T) {
+		t.Parallel()
+
+		var metadata apis.CustomMetadata
+		err := metadata.Unmarshal([]byte(`{"importTaskId":"task-000001","decision":"Continue and append"}`))
+		assert.NilError(t, err)
+		assert.DeepEqual(t, metadata, apis.CustomMetadata{
+			ImportTaskID: "task-000001",
+			Decision:     "Continue and append",
+		})
+	})
+
+	t.Run("rejects missing task ID", func(t *testing.T) {
+		t.Parallel()
+
+		var metadata apis.CustomMetadata
+		err := metadata.Unmarshal([]byte(`{"decision":"Continue and append"}`))
+		assert.ErrorContains(t, err, "requires import task ID")
+	})
+
+	t.Run("rejects nil destination", func(t *testing.T) {
+		t.Parallel()
+
+		var metadata *apis.CustomMetadata
+		err := metadata.Unmarshal([]byte(`{"importTaskId":"task-000001","decision":"Continue and append"}`))
+		assert.ErrorContains(t, err, "destination is nil")
+	})
+}

--- a/internal/workflow/preprocessing.go
+++ b/internal/workflow/preprocessing.go
@@ -521,7 +521,6 @@ func (w *PreprocessingWorkflow) Execute(
 
 	// Create APIS import task.
 	if w.apisEnabled {
-		// TODO: Add APIS import task ID and decision to result.CustomMetadata.
 		if ok := w.createAPISImportTask(ctx, result, sip); !ok {
 			return result, nil
 		}
@@ -630,10 +629,10 @@ func withFilesysActOpts(ctx temporalsdk_workflow.Context) temporalsdk_workflow.C
 	})
 }
 
-// createAPISImportTask submits metadata to APIS, stores the resulting task ID
-// and decision, and handles the analysis outcome for the current workflow execution.
-// It returns false when processing should stop after recording the failure in
-// the workflow result/state.
+// createAPISImportTask submits metadata to APIS, waits for analysis, and records
+// the resulting custom metadata for the AIS poststorage workflow. It returns
+// false when processing should stop after recording the failure in the workflow
+// result.
 func (w *PreprocessingWorkflow) createAPISImportTask(
 	ctx temporalsdk_workflow.Context,
 	result *childwf.PreprocessingResult,
@@ -668,10 +667,11 @@ func (w *PreprocessingWorkflow) createAPISImportTask(
 		)
 		return false
 	}
+	metadata := apis.CustomMetadata{ImportTaskID: createAPISImportTask.TaskID}
 	task.Succeed(
 		temporalsdk_workflow.Now(ctx),
 		"Submitted metadata to APIS with import task ID %q",
-		createAPISImportTask.TaskID,
+		metadata.ImportTaskID,
 	)
 
 	task = result.NewTask(temporalsdk_workflow.Now(ctx), "Wait for APIS analysis")
@@ -687,7 +687,7 @@ func (w *PreprocessingWorkflow) createAPISImportTask(
 			},
 		}),
 		apis.PollImportTaskStatusActivityName,
-		&apis.PollImportTaskStatusParams{TaskID: createAPISImportTask.TaskID},
+		&apis.PollImportTaskStatusParams{TaskID: metadata.ImportTaskID},
 	).Get(ctx, &pollAPISImportTaskStatus)
 	if err != nil {
 		logger.Error("System error", "message", err.Error())
@@ -705,17 +705,20 @@ func (w *PreprocessingWorkflow) createAPISImportTask(
 		task.Succeed(
 			temporalsdk_workflow.Now(ctx),
 			"APIS analysis completed for import task ID %q with result %q",
-			createAPISImportTask.TaskID,
+			metadata.ImportTaskID,
 			pollAPISImportTaskStatus.AnalysisResult,
 		)
-		return true
 	case apisgen.AnalysisResultKonflikte:
-		return w.waitForAPISDecision(ctx, result, task, createAPISImportTask.TaskID)
+		decision, ok := w.waitForAPISDecision(ctx, result, task, metadata.ImportTaskID)
+		metadata.Decision = decision
+		if !ok {
+			return false
+		}
 	case apisgen.AnalysisResultFehler:
 		logger.Error(
 			"System error",
 			"message",
-			fmt.Sprintf("APIS analysis failed for task %q", createAPISImportTask.TaskID),
+			fmt.Sprintf("APIS analysis failed for task %q", metadata.ImportTaskID),
 		)
 		result.SystemError(
 			temporalsdk_workflow.Now(ctx),
@@ -728,7 +731,7 @@ func (w *PreprocessingWorkflow) createAPISImportTask(
 		logger.Error("System error", "message", fmt.Errorf(
 			"unexpected APIS analysis result %q for task %q",
 			pollAPISImportTaskStatus.AnalysisResult,
-			createAPISImportTask.TaskID,
+			metadata.ImportTaskID,
 		))
 		result.SystemError(
 			temporalsdk_workflow.Now(ctx),
@@ -738,20 +741,34 @@ func (w *PreprocessingWorkflow) createAPISImportTask(
 		)
 		return false
 	}
+
+	data, err := metadata.Marshal()
+	if err != nil {
+		logger.Error("System error", "message", err.Error())
+		task = result.NewTask(temporalsdk_workflow.Now(ctx), "Record APIS metadata")
+		result.SystemError(
+			temporalsdk_workflow.Now(ctx),
+			task,
+			"APIS metadata recording has failed.",
+			"An error occurred while recording APIS metadata for later workflow steps. Please try again, or ask a system administrator to investigate.",
+		)
+		return false
+	}
+	result.CustomMetadata = childwf.CustomMetadata{apis.CustomMetadataKey: data}
+
+	return true
 }
 
-// waitForAPISDecision asks the parent workflow for a decision and applies the
-// selected outcome to the current APIS conflict event. It returns false when
-// the workflow should stop after recording the failure in the workflow
-// result/state.
+// waitForAPISDecision asks the parent workflow for a decision. It returns the
+// selected decision and false when processing should stop after recording the
+// failure in the workflow result.
 func (w *PreprocessingWorkflow) waitForAPISDecision(
 	ctx temporalsdk_workflow.Context,
 	result *childwf.PreprocessingResult,
 	task *childwf.Task,
 	taskID string,
-) bool {
+) (string, bool) {
 	logger := temporalsdk_workflow.GetLogger(ctx)
-
 	info := temporalsdk_workflow.GetInfo(ctx)
 	if info.ParentWorkflowExecution == nil {
 		logger.Error("System error", "message", fmt.Errorf(
@@ -764,7 +781,7 @@ func (w *PreprocessingWorkflow) waitForAPISDecision(
 			"submission to APIS has failed.",
 			"An error occurred requesting a human decision on how to continue processing. Please try again, or ask a system administrator to investigate.",
 		)
-		return false
+		return "", false
 	}
 
 	err := temporalsdk_workflow.SignalExternalWorkflow(
@@ -794,7 +811,7 @@ func (w *PreprocessingWorkflow) waitForAPISDecision(
 			"submission to APIS has failed.",
 			"Could not notify the parent workflow that human review is required. Please try again, or ask a system administrator to investigate.",
 		)
-		return false
+		return "", false
 	}
 
 	var decision childwf.DecisionResponse
@@ -808,7 +825,7 @@ func (w *PreprocessingWorkflow) waitForAPISDecision(
 			taskID,
 			decision.Option,
 		)
-		return true
+		return decision.Option, true
 	case DecisionOptionCancelIngest:
 		// TODO: Add and use canceled as workflow outcome.
 		result.ValidationError(
@@ -820,7 +837,7 @@ func (w *PreprocessingWorkflow) waitForAPISDecision(
 				taskID,
 			),
 		)
-		return false
+		return decision.Option, false
 	default:
 		logger.Error("System error", "message", fmt.Errorf(
 			"unsupported decision %q for APIS import task %q", decision.Option, taskID,
@@ -834,7 +851,7 @@ func (w *PreprocessingWorkflow) waitForAPISDecision(
 				decision.Option,
 			),
 		)
-		return false
+		return decision.Option, false
 	}
 }
 

--- a/internal/workflow/preprocessing_test.go
+++ b/internal/workflow/preprocessing_test.go
@@ -1,6 +1,7 @@
 package workflow_test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -719,6 +720,16 @@ func apisTasks(
 	return events
 }
 
+func apisCustomMetadata(taskID, decision string) childwf.CustomMetadata {
+	return childwf.CustomMetadata{
+		apis.CustomMetadataKey: json.RawMessage(fmt.Sprintf(
+			`{"importTaskId":%q,"decision":%q}`,
+			taskID,
+			decision,
+		)),
+	}
+}
+
 func (s *PreprocessingTestSuite) executeAsChildWithHumanReview(
 	params *childwf.PreprocessingParams,
 	decision childwf.DecisionResponse,
@@ -798,8 +809,9 @@ func (s *PreprocessingTestSuite) TestSuccess() {
 	s.NoError(err)
 	s.Equal(
 		&childwf.PreprocessingResult{
-			Outcome:      childwf.OutcomeSuccess,
-			RelativePath: relPath,
+			Outcome:        childwf.OutcomeSuccess,
+			CustomMetadata: apisCustomMetadata(apisTaskID, ""),
+			RelativePath:   relPath,
 			Tasks: apisTasks(
 				apisTaskID,
 				fmt.Sprintf(
@@ -1258,8 +1270,9 @@ func (s *PreprocessingTestSuite) TestHumanReviewContinueAndOverwrite() {
 
 	s.Equal(
 		&childwf.PreprocessingResult{
-			Outcome:      childwf.OutcomeSuccess,
-			RelativePath: updatedRelPath,
+			Outcome:        childwf.OutcomeSuccess,
+			CustomMetadata: apisCustomMetadata(apisTaskID, workflow.DecisionOptionContinueOverwrite),
+			RelativePath:   updatedRelPath,
 			Tasks: apisTasks(
 				apisTaskID,
 				fmt.Sprintf(
@@ -1301,8 +1314,9 @@ func (s *PreprocessingTestSuite) TestHumanReviewContinueAndAppend() {
 
 	s.Equal(
 		&childwf.PreprocessingResult{
-			Outcome:      childwf.OutcomeSuccess,
-			RelativePath: updatedRelPath,
+			Outcome:        childwf.OutcomeSuccess,
+			CustomMetadata: apisCustomMetadata(apisTaskID, workflow.DecisionOptionContinueAppend),
+			RelativePath:   updatedRelPath,
 			Tasks: apisTasks(
 				apisTaskID,
 				fmt.Sprintf(


### PR DESCRIPTION
Record the APIS import task ID and human review decision in preprocessing custom metadata so the AIS workflow can receive the context it needs.  Read and log that metadata in the AIS poststorage workflow without starting APIS poststorage integration yet.

Refs #174.