### PR TITLE
Add APIS import run delivery to poststorage

### DIFF
--- a/cmd/worker/workercmd/cmd.go
+++ b/cmd/worker/workercmd/cmd.go
@@ -134,7 +134,7 @@ func (m *Main) Run(ctx context.Context) error {
 	}
 
 	m.registerPreprocessingWorkflow(psvc, apisClient, veraPDFValidator)
-	m.registerPoststorageWorkflow(ssClient.Packages())
+	m.registerPoststorageWorkflow(ssClient.Packages(), apisClient)
 
 	if err := w.Start(); err != nil {
 		m.logger.Error(err, "Worker failed to start.")
@@ -267,9 +267,9 @@ func (m *Main) registerPreprocessingWorkflow(
 	)
 }
 
-func (m *Main) registerPoststorageWorkflow(packages *ssclient.PackagesService) {
+func (m *Main) registerPoststorageWorkflow(packages *ssclient.PackagesService, apisClient apis.Client) {
 	m.temporalWorker.RegisterWorkflowWithOptions(
-		workflows.NewPoststorage(m.cfg.Poststorage).Execute,
+		workflows.NewPoststorage(m.cfg.Poststorage, m.cfg.APIS.Enabled).Execute,
 		temporalsdk_workflow.RegisterOptions{Name: m.cfg.Poststorage.WorkflowName},
 	)
 
@@ -284,5 +284,13 @@ func (m *Main) registerPoststorageWorkflow(packages *ssclient.PackagesService) {
 	m.temporalWorker.RegisterActivityWithOptions(
 		removepaths.New().Execute,
 		temporalsdk_activity.RegisterOptions{Name: removepaths.Name},
+	)
+	m.temporalWorker.RegisterActivityWithOptions(
+		apis.NewCreateImportRunActivity(apisClient).Execute,
+		temporalsdk_activity.RegisterOptions{Name: apis.CreateImportRunActivityName},
+	)
+	m.temporalWorker.RegisterActivityWithOptions(
+		apis.NewPollImportRunStatusActivity(apisClient, m.cfg.APIS.PollInterval).Execute,
+		temporalsdk_activity.RegisterOptions{Name: apis.PollImportRunStatusActivityName},
 	)
 }

--- a/internal/apis/create_import_run_activity.go
+++ b/internal/apis/create_import_run_activity.go
@@ -1,0 +1,93 @@
+package apis
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	ogenhttp "github.com/ogen-go/ogen/http"
+	"go.artefactual.dev/tools/temporal"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis/gen"
+)
+
+const CreateImportRunActivityName = "create-apis-import-run"
+
+type (
+	CreateImportRunActivity struct {
+		client Client
+	}
+
+	CreateImportRunParams struct {
+		TaskID          string
+		METSPath        string
+		ImportBehaviour gen.ImportBehaviourType
+		Username        string
+	}
+
+	CreateImportRunResult struct {
+		RunID string
+	}
+)
+
+func NewCreateImportRunActivity(client Client) *CreateImportRunActivity {
+	return &CreateImportRunActivity{client: client}
+}
+
+func (a *CreateImportRunActivity) Execute(
+	ctx context.Context,
+	params *CreateImportRunParams,
+) (*CreateImportRunResult, error) {
+	mets, err := os.Open(params.METSPath)
+	if err != nil {
+		return nil, temporal.NewNonRetryableError(fmt.Errorf("open METS.xml: %v", err))
+	}
+	defer mets.Close()
+
+	req := gen.APIImporttasksIDImportrunsPostReq{
+		File: ogenhttp.MultipartFile{
+			Name: filepath.Base(params.METSPath),
+			File: mets,
+		},
+		ImportBehaviour: gen.NewOptImportBehaviourType(params.ImportBehaviour),
+		Username:        params.Username,
+	}
+	res, err := a.client.APIImporttasksIDImportrunsPost(
+		ctx,
+		gen.NewOptAPIImporttasksIDImportrunsPostReq(req),
+		gen.APIImporttasksIDImportrunsPostParams{ID: params.TaskID},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create APIS import run: %v", err)
+	}
+
+	switch t := res.(type) {
+	case *gen.CreateImportRunResponse:
+		if t.ImportRunId == "" {
+			return nil, temporal.NewNonRetryableError(fmt.Errorf(
+				"create APIS import run: missing run ID in created response",
+			))
+		}
+		return &CreateImportRunResult{RunID: t.ImportRunId}, nil
+	case *gen.APIImporttasksIDImportrunsPostBadRequest:
+		return nil, temporal.NewNonRetryableError(fmt.Errorf(
+			"create APIS import run: bad request: %s",
+			problemDetail(t.Detail),
+		))
+	case *gen.APIImporttasksIDImportrunsPostUnauthorized:
+		return nil, temporal.NewNonRetryableError(fmt.Errorf("create APIS import run: unauthorized"))
+	case *gen.APIImporttasksIDImportrunsPostNotFound:
+		return nil, temporal.NewNonRetryableError(fmt.Errorf(
+			"create APIS import run: task not found: %s",
+			problemDetail(t.Detail),
+		))
+	case *gen.APIImporttasksIDImportrunsPostUnsupportedMediaType:
+		return nil, temporal.NewNonRetryableError(fmt.Errorf(
+			"create APIS import run: unsupported media type: %s",
+			problemDetail(t.Detail),
+		))
+	default:
+		return nil, fmt.Errorf("create APIS import run: unexpected response")
+	}
+}

--- a/internal/apis/create_import_run_activity_test.go
+++ b/internal/apis/create_import_run_activity_test.go
@@ -1,0 +1,200 @@
+package apis_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis"
+	fake_apis "github.com/artefactual-sdps/preprocessing-sfa/internal/apis/fake"
+	apisgen "github.com/artefactual-sdps/preprocessing-sfa/internal/apis/gen"
+)
+
+func TestCreateImportRunActivity(t *testing.T) {
+	t.Parallel()
+
+	metsPath := fs.NewDir(t, "", fs.WithFile("METS.uuid.xml", "mets-body")).Join("METS.uuid.xml")
+
+	tests := []struct {
+		name    string
+		params  apis.CreateImportRunParams
+		expect  func(*testing.T, *fake_apis.MockClientMockRecorder)
+		want    apis.CreateImportRunResult
+		wantErr string
+	}{
+		{
+			name: "creates import run",
+			params: apis.CreateImportRunParams{
+				TaskID:          "task-000001",
+				METSPath:        metsPath,
+				ImportBehaviour: apisgen.ImportBehaviourTypeOverwriteAndAppend,
+				Username:        "archivist@example.com",
+			},
+			expect: func(t *testing.T, m *fake_apis.MockClientMockRecorder) {
+				t.Helper()
+				m.APIImporttasksIDImportrunsPost(
+					gomock.Any(),
+					gomock.Any(),
+					apisgen.APIImporttasksIDImportrunsPostParams{ID: "task-000001"},
+				).DoAndReturn(
+					func(
+						_ context.Context,
+						req apisgen.OptAPIImporttasksIDImportrunsPostReq,
+						_ apisgen.APIImporttasksIDImportrunsPostParams,
+					) (apisgen.APIImporttasksIDImportrunsPostRes, error) {
+						payload, ok := req.Get()
+						assert.Assert(t, ok)
+						assert.Equal(t, payload.Username, "archivist@example.com")
+						assert.Equal(t, payload.File.Name, filepath.Base(metsPath))
+						assert.DeepEqual(
+							t,
+							payload.ImportBehaviour,
+							apisgen.NewOptImportBehaviourType(apisgen.ImportBehaviourTypeOverwriteAndAppend),
+						)
+
+						body, err := io.ReadAll(payload.File.File)
+						assert.NilError(t, err)
+						assert.Equal(t, string(body), "mets-body")
+
+						return &apisgen.CreateImportRunResponse{ImportRunId: "run-000001"}, nil
+					},
+				)
+			},
+			want: apis.CreateImportRunResult{RunID: "run-000001"},
+		},
+		{
+			name: "returns bad request error",
+			params: apis.CreateImportRunParams{
+				TaskID:   "task-000003",
+				METSPath: metsPath,
+			},
+			expect: func(t *testing.T, m *fake_apis.MockClientMockRecorder) {
+				t.Helper()
+				m.APIImporttasksIDImportrunsPost(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&apisgen.APIImporttasksIDImportrunsPostBadRequest{
+						Detail: apisgen.NewOptNilString("cannot create import run"),
+					},
+					nil,
+				)
+			},
+			wantErr: "create APIS import run: bad request: cannot create import run",
+		},
+		{
+			name: "returns not found error",
+			params: apis.CreateImportRunParams{
+				TaskID:   "task-000004",
+				METSPath: metsPath,
+			},
+			expect: func(t *testing.T, m *fake_apis.MockClientMockRecorder) {
+				t.Helper()
+				m.APIImporttasksIDImportrunsPost(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&apisgen.APIImporttasksIDImportrunsPostNotFound{
+						Detail: apisgen.NewOptNilString("import task does not exist"),
+					},
+					nil,
+				)
+			},
+			wantErr: "create APIS import run: task not found: import task does not exist",
+		},
+		{
+			name: "returns unauthorized error",
+			params: apis.CreateImportRunParams{
+				TaskID:   "task-000005",
+				METSPath: metsPath,
+			},
+			expect: func(t *testing.T, m *fake_apis.MockClientMockRecorder) {
+				t.Helper()
+				m.APIImporttasksIDImportrunsPost(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&apisgen.APIImporttasksIDImportrunsPostUnauthorized{
+						Detail: apisgen.NewOptNilString("unauthorized"),
+					},
+					nil,
+				)
+			},
+			wantErr: "create APIS import run: unauthorized",
+		},
+		{
+			name: "returns unsupported media type error",
+			params: apis.CreateImportRunParams{
+				TaskID:   "task-000006",
+				METSPath: metsPath,
+			},
+			expect: func(t *testing.T, m *fake_apis.MockClientMockRecorder) {
+				t.Helper()
+				m.APIImporttasksIDImportrunsPost(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&apisgen.APIImporttasksIDImportrunsPostUnsupportedMediaType{
+						Detail: apisgen.NewOptNilString("not xml"),
+					},
+					nil,
+				)
+			},
+			wantErr: "create APIS import run: unsupported media type: not xml",
+		},
+		{
+			name: "returns client error",
+			params: apis.CreateImportRunParams{
+				TaskID:   "task-000007",
+				METSPath: metsPath,
+			},
+			expect: func(t *testing.T, m *fake_apis.MockClientMockRecorder) {
+				t.Helper()
+				m.APIImporttasksIDImportrunsPost(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("error from client"))
+			},
+			wantErr: "create APIS import run: error from client",
+		},
+		{
+			name: "returns missing run ID error",
+			params: apis.CreateImportRunParams{
+				TaskID:   "task-000008",
+				METSPath: metsPath,
+			},
+			expect: func(t *testing.T, m *fake_apis.MockClientMockRecorder) {
+				t.Helper()
+				m.APIImporttasksIDImportrunsPost(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&apisgen.CreateImportRunResponse{},
+					nil,
+				)
+			},
+			wantErr: "missing run ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			client := fake_apis.NewMockClient(ctrl)
+			if tt.expect != nil {
+				tt.expect(t, client.EXPECT())
+			}
+
+			suite := temporalsdk_testsuite.WorkflowTestSuite{}
+			env := suite.NewTestActivityEnvironment()
+			env.RegisterActivityWithOptions(
+				apis.NewCreateImportRunActivity(client).Execute,
+				temporalsdk_activity.RegisterOptions{Name: apis.CreateImportRunActivityName},
+			)
+
+			future, err := env.ExecuteActivity(apis.CreateImportRunActivityName, &tt.params)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+
+			var result apis.CreateImportRunResult
+			assert.NilError(t, future.Get(&result))
+			assert.DeepEqual(t, result, tt.want)
+		})
+	}
+}

--- a/internal/apis/custom_metadata.go
+++ b/internal/apis/custom_metadata.go
@@ -3,9 +3,16 @@ package apis
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis/gen"
 )
 
-const CustomMetadataKey = "apis"
+const (
+	CustomMetadataKey               = "apis"
+	DecisionOptionCancelIngest      = "Cancel ingest"
+	DecisionOptionContinueOverwrite = "Continue and overwrite"
+	DecisionOptionContinueAppend    = "Continue and append"
+)
 
 type CustomMetadata struct {
 	ImportTaskID string `json:"importTaskId"`
@@ -37,4 +44,17 @@ func (m *CustomMetadata) Unmarshal(data []byte) error {
 	}
 
 	return nil
+}
+
+func (m CustomMetadata) ImportBehaviour() (gen.ImportBehaviourType, error) {
+	switch m.Decision {
+	case "", DecisionOptionContinueAppend:
+		return gen.ImportBehaviourTypeAppendOnly, nil
+	case DecisionOptionContinueOverwrite:
+		return gen.ImportBehaviourTypeOverwriteAndAppend, nil
+	case DecisionOptionCancelIngest:
+		return "", fmt.Errorf("APIS import task %q was canceled during preprocessing", m.ImportTaskID)
+	default:
+		return "", fmt.Errorf("unsupported APIS decision %q for import task %q", m.Decision, m.ImportTaskID)
+	}
 }

--- a/internal/apis/custom_metadata_test.go
+++ b/internal/apis/custom_metadata_test.go
@@ -6,6 +6,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis"
+	apisgen "github.com/artefactual-sdps/preprocessing-sfa/internal/apis/gen"
 )
 
 func TestCustomMetadataMarshal(t *testing.T) {
@@ -60,4 +61,68 @@ func TestCustomMetadataUnmarshal(t *testing.T) {
 		err := metadata.Unmarshal([]byte(`{"importTaskId":"task-000001","decision":"Continue and append"}`))
 		assert.ErrorContains(t, err, "destination is nil")
 	})
+}
+
+func TestCustomMetadataImportBehaviour(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		metadata apis.CustomMetadata
+		want     apisgen.ImportBehaviourType
+		wantErr  string
+	}{
+		{
+			name:     "empty decision maps to append only",
+			metadata: apis.CustomMetadata{ImportTaskID: "task-000001"},
+			want:     apisgen.ImportBehaviourTypeAppendOnly,
+		},
+		{
+			name: "append decision maps to append only",
+			metadata: apis.CustomMetadata{
+				ImportTaskID: "task-000002",
+				Decision:     apis.DecisionOptionContinueAppend,
+			},
+			want: apisgen.ImportBehaviourTypeAppendOnly,
+		},
+		{
+			name: "overwrite decision maps to overwrite and append",
+			metadata: apis.CustomMetadata{
+				ImportTaskID: "task-000003",
+				Decision:     apis.DecisionOptionContinueOverwrite,
+			},
+			want: apisgen.ImportBehaviourTypeOverwriteAndAppend,
+		},
+		{
+			name: "cancel decision returns error",
+			metadata: apis.CustomMetadata{
+				ImportTaskID: "task-000004",
+				Decision:     apis.DecisionOptionCancelIngest,
+			},
+			wantErr: "was canceled during preprocessing",
+		},
+		{
+			name: "unsupported decision returns error",
+			metadata: apis.CustomMetadata{
+				ImportTaskID: "task-000005",
+				Decision:     "Something else",
+			},
+			wantErr: `unsupported APIS decision "Something else"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.metadata.ImportBehaviour()
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
 }

--- a/internal/apis/poll_import_run_status_activity.go
+++ b/internal/apis/poll_import_run_status_activity.go
@@ -1,0 +1,118 @@
+package apis
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.artefactual.dev/tools/temporal"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis/gen"
+)
+
+const PollImportRunStatusActivityName = "poll-apis-import-run-status"
+
+type (
+	PollImportRunStatusActivity struct {
+		client       Client
+		pollInterval time.Duration
+	}
+
+	PollImportRunStatusParams struct {
+		TaskID string
+	}
+
+	PollImportRunStatusResult struct {
+		ImportResult gen.ImportResult
+	}
+)
+
+func NewPollImportRunStatusActivity(client Client, pollInterval time.Duration) *PollImportRunStatusActivity {
+	if pollInterval <= 0 {
+		pollInterval = DefaultPollInterval
+	}
+	return &PollImportRunStatusActivity{
+		client:       client,
+		pollInterval: pollInterval,
+	}
+}
+
+func (a *PollImportRunStatusActivity) Execute(
+	ctx context.Context,
+	params *PollImportRunStatusParams,
+) (*PollImportRunStatusResult, error) {
+	h := temporal.StartAutoHeartbeat(ctx)
+	defer h.Stop()
+
+	ticker := time.NewTicker(a.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			res, err := a.client.APIImporttasksIDStatusGet(ctx, gen.APIImporttasksIDStatusGetParams{
+				ID: params.TaskID,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("poll APIS import run status: %w", err)
+			}
+
+			switch status := res.(type) {
+			case *gen.ImportTaskStatusResponse:
+				done, err := importComplete(status)
+				if err != nil {
+					return nil, err
+				}
+				if !done {
+					continue
+				}
+
+				importResult, ok := status.ImportResult.Get()
+				if !ok {
+					return nil, temporal.NewNonRetryableError(fmt.Errorf(
+						"poll APIS import run status: missing import result for completed task %q",
+						params.TaskID,
+					))
+				}
+
+				return &PollImportRunStatusResult{ImportResult: importResult}, nil
+			case *gen.APIImporttasksIDStatusGetUnauthorized:
+				return nil, temporal.NewNonRetryableError(
+					fmt.Errorf("poll APIS import run status: unauthorized"),
+				)
+			case *gen.APIImporttasksIDStatusGetNotFound:
+				return nil, temporal.NewNonRetryableError(fmt.Errorf(
+					"poll APIS import run status: task not found: %s",
+					problemDetail(status.Detail),
+				))
+			case *gen.APIImporttasksIDStatusGetInternalServerError:
+				return nil, fmt.Errorf(
+					"poll APIS import run status: server error: %s",
+					problemDetail(status.Detail),
+				)
+			default:
+				return nil, fmt.Errorf("poll APIS import run status: unexpected response")
+			}
+		}
+	}
+}
+
+func importComplete(status *gen.ImportTaskStatusResponse) (bool, error) {
+	switch status.Status {
+	case gen.ImportTaskStatusWirdImportiert:
+		return false, nil
+	case gen.ImportTaskStatusImportiert:
+		return true, nil
+	case gen.ImportTaskStatusNeu, gen.ImportTaskStatusInAnalyse, gen.ImportTaskStatusAnalysiert,
+		gen.ImportTaskStatusAbgebrochen:
+		return false, temporal.NewNonRetryableError(fmt.Errorf(
+			"unexpected APIS import task status during import: %s", status.Status,
+		))
+	default:
+		return false, temporal.NewNonRetryableError(fmt.Errorf(
+			"unknown APIS import task status during import: %s", status.Status,
+		))
+	}
+}

--- a/internal/apis/poll_import_run_status_activity_test.go
+++ b/internal/apis/poll_import_run_status_activity_test.go
@@ -1,0 +1,187 @@
+package apis_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis"
+	fake_apis "github.com/artefactual-sdps/preprocessing-sfa/internal/apis/fake"
+	apisgen "github.com/artefactual-sdps/preprocessing-sfa/internal/apis/gen"
+)
+
+func TestPollImportRunStatusActivity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		params  apis.PollImportRunStatusParams
+		expect  func(*fake_apis.MockClientMockRecorder)
+		want    apis.PollImportRunStatusResult
+		wantErr string
+	}{
+		{
+			name:   "polls until import is complete",
+			params: apis.PollImportRunStatusParams{TaskID: "task-000001"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000001"},
+				).Return(
+					&apisgen.ImportTaskStatusResponse{Status: apisgen.ImportTaskStatusWirdImportiert},
+					nil,
+				)
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000001"},
+				).Return(
+					&apisgen.ImportTaskStatusResponse{
+						Status:       apisgen.ImportTaskStatusImportiert,
+						ImportResult: apisgen.NewOptNilImportResult(apisgen.ImportResultErfolgreich),
+					},
+					nil,
+				)
+			},
+			want: apis.PollImportRunStatusResult{ImportResult: apisgen.ImportResultErfolgreich},
+		},
+		{
+			name:   "returns import error result",
+			params: apis.PollImportRunStatusParams{TaskID: "task-000002"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000002"},
+				).Return(
+					&apisgen.ImportTaskStatusResponse{
+						Status:       apisgen.ImportTaskStatusImportiert,
+						ImportResult: apisgen.NewOptNilImportResult(apisgen.ImportResultFehler),
+					},
+					nil,
+				)
+			},
+			want: apis.PollImportRunStatusResult{ImportResult: apisgen.ImportResultFehler},
+		},
+		{
+			name:   "returns polling error",
+			params: apis.PollImportRunStatusParams{TaskID: "task-000003"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000003"},
+				).Return(nil, errors.New("status boom"))
+			},
+			wantErr: "status boom",
+		},
+		{
+			name:   "returns unauthorized error response",
+			params: apis.PollImportRunStatusParams{TaskID: "task-000004"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000004"},
+				).Return(
+					&apisgen.APIImporttasksIDStatusGetUnauthorized{
+						Detail: apisgen.NewOptNilString("unauthorized"),
+					},
+					nil,
+				)
+			},
+			wantErr: "poll APIS import run status: unauthorized",
+		},
+		{
+			name:   "returns not found error response",
+			params: apis.PollImportRunStatusParams{TaskID: "task-000005"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000005"},
+				).Return(
+					&apisgen.APIImporttasksIDStatusGetNotFound{
+						Detail: apisgen.NewOptNilString("import task does not exist"),
+					},
+					nil,
+				)
+			},
+			wantErr: "poll APIS import run status: task not found: import task does not exist",
+		},
+		{
+			name:   "returns internal server error response",
+			params: apis.PollImportRunStatusParams{TaskID: "task-000006"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000006"},
+				).Return(
+					&apisgen.APIImporttasksIDStatusGetInternalServerError{
+						Detail: apisgen.NewOptNilString("status backend failed"),
+					},
+					nil,
+				)
+			},
+			wantErr: "poll APIS import run status: server error: status backend failed",
+		},
+		{
+			name:   "returns error on unexpected status",
+			params: apis.PollImportRunStatusParams{TaskID: "task-000007"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000007"},
+				).Return(
+					&apisgen.ImportTaskStatusResponse{Status: apisgen.ImportTaskStatusAnalysiert},
+					nil,
+				)
+			},
+			wantErr: "unexpected APIS import task status during import: Analysiert",
+		},
+		{
+			name:   "returns error when import result is missing",
+			params: apis.PollImportRunStatusParams{TaskID: "task-000008"},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksIDStatusGet(
+					gomock.Any(),
+					apisgen.APIImporttasksIDStatusGetParams{ID: "task-000008"},
+				).Return(
+					&apisgen.ImportTaskStatusResponse{Status: apisgen.ImportTaskStatusImportiert},
+					nil,
+				)
+			},
+			wantErr: "missing import result",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			client := fake_apis.NewMockClient(ctrl)
+			if tt.expect != nil {
+				tt.expect(client.EXPECT())
+			}
+
+			suite := temporalsdk_testsuite.WorkflowTestSuite{}
+			env := suite.NewTestActivityEnvironment()
+			env.RegisterActivityWithOptions(
+				apis.NewPollImportRunStatusActivity(client, time.Millisecond).Execute,
+				temporalsdk_activity.RegisterOptions{Name: apis.PollImportRunStatusActivityName},
+			)
+
+			future, err := env.ExecuteActivity(apis.PollImportRunStatusActivityName, &tt.params)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+
+			var result apis.PollImportRunStatusResult
+			assert.NilError(t, future.Get(&result))
+			assert.DeepEqual(t, result, tt.want)
+		})
+	}
+}

--- a/internal/workflows/policies.go
+++ b/internal/workflows/policies.go
@@ -51,3 +51,26 @@ func withFilesystemActivityOpts(ctx temporalsdk_workflow.Context) temporalsdk_wo
 		},
 	})
 }
+
+func withAPISActivityOpts(ctx temporalsdk_workflow.Context) temporalsdk_workflow.Context {
+	return temporalsdk_workflow.WithActivityOptions(ctx, temporalsdk_workflow.ActivityOptions{
+		StartToCloseTimeout: time.Hour,
+		RetryPolicy: &temporalsdk_temporal.RetryPolicy{
+			InitialInterval:    time.Second * 5,
+			BackoffCoefficient: 2,
+			MaximumAttempts:    3,
+		},
+	})
+}
+
+func withAPISPollActivityOpts(ctx temporalsdk_workflow.Context) temporalsdk_workflow.Context {
+	return temporalsdk_workflow.WithActivityOptions(ctx, temporalsdk_workflow.ActivityOptions{
+		StartToCloseTimeout: time.Hour * 24,
+		HeartbeatTimeout:    time.Minute,
+		RetryPolicy: &temporalsdk_temporal.RetryPolicy{
+			InitialInterval:    time.Second * 5,
+			BackoffCoefficient: 2,
+			MaximumAttempts:    3,
+		},
+	})
+}

--- a/internal/workflows/poststorage.go
+++ b/internal/workflows/poststorage.go
@@ -15,21 +15,27 @@ import (
 
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/amss"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis"
+	apisgen "github.com/artefactual-sdps/preprocessing-sfa/internal/apis/gen"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/config"
 )
 
 type Poststorage struct {
-	cfg config.PoststorageConfig
+	cfg         config.PoststorageConfig
+	apisEnabled bool
 }
 
-func NewPoststorage(cfg config.PoststorageConfig) *Poststorage {
-	return &Poststorage{cfg: cfg}
+func NewPoststorage(cfg config.PoststorageConfig, apisEnabled bool) *Poststorage {
+	return &Poststorage{
+		cfg:         cfg,
+		apisEnabled: apisEnabled,
+	}
 }
 
 func (w *Poststorage) Execute(
 	ctx temporalsdk_workflow.Context,
 	params *childwf.PostStorageParams,
 ) (r *childwf.PostStorageResult, e error) {
+	r = &childwf.PostStorageResult{}
 	logger := temporalsdk_workflow.GetLogger(ctx)
 	logger.Debug("Poststorage workflow running!", "params", params)
 
@@ -37,42 +43,16 @@ func (w *Poststorage) Execute(
 		logger.Debug("Poststorage workflow finished!", "result", r, "error", e)
 	}()
 
+	if !w.apisEnabled {
+		return r, nil
+	}
+
 	aipUUID, err := uuid.Parse(params.AIPUUID)
 	if err != nil {
 		return nil, fmt.Errorf("parse AIP UUID: %v", err)
 	}
 
-	if data, ok := params.CustomMetadata[apis.CustomMetadataKey]; ok {
-		var metadata apis.CustomMetadata
-		if err := metadata.Unmarshal(data); err != nil {
-			return nil, err
-		}
-		logger.Info(
-			"Received APIS custom metadata.",
-			"importTaskID", metadata.ImportTaskID,
-			"decision", metadata.Decision,
-		)
-	}
-
-	var getAIPPathResult amss.GetAIPPathActivityResult
-	err = temporalsdk_workflow.ExecuteActivity(
-		temporalsdk_workflow.WithActivityOptions(
-			ctx,
-			temporalsdk_workflow.ActivityOptions{
-				ScheduleToCloseTimeout: 10 * time.Minute,
-				RetryPolicy: &temporalsdk_temporal.RetryPolicy{
-					InitialInterval:    15 * time.Second,
-					BackoffCoefficient: 2,
-					MaximumInterval:    time.Minute,
-					MaximumAttempts:    5,
-				},
-			},
-		),
-		amss.GetAIPPathActivityName,
-		&amss.GetAIPPathActivityParams{
-			AIPUUID: aipUUID,
-		},
-	).Get(ctx, &getAIPPathResult)
+	apisMetadata, err := getApisMetadata(params.CustomMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +74,7 @@ func (w *Poststorage) Execute(
 				return nil, fmt.Errorf("error creating session: %v", err)
 			}
 
-			sessErr = w.SessionHandler(sessCtx, aipUUID, getAIPPathResult.Path)
+			sessErr = w.SessionHandler(sessCtx, r, aipUUID, apisMetadata)
 
 			// We want to retry the session if it has been canceled as a result
 			// of losing the worker but not otherwise. This scenario seems to be
@@ -127,10 +107,16 @@ func (w *Poststorage) Execute(
 		}
 	}
 
-	return &childwf.PostStorageResult{}, nil
+	return r, nil
 }
 
-func (w *Poststorage) SessionHandler(ctx temporalsdk_workflow.Context, aipUUID uuid.UUID, aipPath string) (e error) {
+func (w *Poststorage) SessionHandler(
+	ctx temporalsdk_workflow.Context,
+	result *childwf.PostStorageResult,
+	aipUUID uuid.UUID,
+	apisMetadata apis.CustomMetadata,
+) (e error) {
+	logger := temporalsdk_workflow.GetLogger(ctx)
 	removePaths := []string{}
 
 	defer func() {
@@ -147,14 +133,44 @@ func (w *Poststorage) SessionHandler(ctx temporalsdk_workflow.Context, aipUUID u
 		temporalsdk_workflow.CompleteSession(ctx)
 	}()
 
+	task := result.NewTask(temporalsdk_workflow.Now(ctx), "Download AIP METS")
+	var getAIPPathResult amss.GetAIPPathActivityResult
+	e = temporalsdk_workflow.ExecuteActivity(
+		temporalsdk_workflow.WithActivityOptions(
+			ctx,
+			temporalsdk_workflow.ActivityOptions{
+				ScheduleToCloseTimeout: 15 * time.Minute,
+				RetryPolicy: &temporalsdk_temporal.RetryPolicy{
+					InitialInterval:    15 * time.Second,
+					BackoffCoefficient: 2,
+					MaximumInterval:    time.Minute,
+					MaximumAttempts:    5,
+				},
+			},
+		),
+		amss.GetAIPPathActivityName,
+		&amss.GetAIPPathActivityParams{
+			AIPUUID: aipUUID,
+		},
+	).Get(ctx, &getAIPPathResult)
+	if e != nil {
+		logger.Error("System error", "message", e.Error())
+		result.SystemError(
+			temporalsdk_workflow.Now(ctx),
+			task,
+			"AIP METS download has failed.",
+			"The AIP is stored, but the poststorage workflow failed to get the AIP path. Please try again, or ask a system administrator to investigate.",
+		)
+		return nil
+	}
+
 	// In case the AIP is compressed, remove its UUID and the possible
 	// extension from the directory/file name, and append the UUID back.
 	aipUUIDString := aipUUID.String()
-	aipDirName := strings.Split(filepath.Base(aipPath), aipUUIDString)[0] + aipUUIDString
-	localDir := filepath.Join(w.cfg.WorkingDir, fmt.Sprintf("search-md_%s", aipDirName))
+	aipDirName := strings.Split(filepath.Base(getAIPPathResult.Path), aipUUIDString)[0] + aipUUIDString
+	localDir := filepath.Join(w.cfg.WorkingDir, aipUUIDString)
 	metsName := fmt.Sprintf("METS.%s.xml", aipUUIDString)
 	metsPath := filepath.Join(localDir, metsName)
-
 	removePaths = append(removePaths, localDir)
 
 	var fetchMETSResult amss.FetchActivityResult
@@ -168,8 +184,122 @@ func (w *Poststorage) SessionHandler(ctx temporalsdk_workflow.Context, aipUUID u
 		},
 	).Get(ctx, &fetchMETSResult)
 	if e != nil {
-		return e
+		logger.Error("System error", "message", e.Error())
+		result.SystemError(
+			temporalsdk_workflow.Now(ctx),
+			task,
+			"AIP METS download has failed.",
+			"The AIP is stored, but the poststorage workflow failed while downloading the AIP METS file. Please try again, or ask a system administrator to investigate.",
+		)
+		return nil
+	}
+	task.Succeed(temporalsdk_workflow.Now(ctx), "AIP METS downloaded")
+
+	task = result.NewTask(temporalsdk_workflow.Now(ctx), "Submit AIP METS to APIS")
+	importBehaviour, err := apisMetadata.ImportBehaviour()
+	if err != nil {
+		logger.Error("System error", "message", err.Error())
+		result.SystemError(
+			temporalsdk_workflow.Now(ctx),
+			task,
+			"AIP METS submission to APIS has failed.",
+			"The AIP is stored, but the post-storage workflow failed while preparing to deliver the AIP METS file to APIS for AIS import. Please try again, or ask a system administrator to investigate.",
+		)
+		return nil
 	}
 
-	return nil
+	var createImportRun apis.CreateImportRunResult
+	err = temporalsdk_workflow.ExecuteActivity(
+		withAPISActivityOpts(ctx),
+		apis.CreateImportRunActivityName,
+		&apis.CreateImportRunParams{
+			TaskID:          apisMetadata.ImportTaskID,
+			METSPath:        metsPath,
+			ImportBehaviour: importBehaviour,
+			Username:        "sfa-enduro", // TODO: Use real username.
+		},
+	).Get(ctx, &createImportRun)
+	if err != nil {
+		logger.Error("System error", "message", err.Error())
+		result.SystemError(
+			temporalsdk_workflow.Now(ctx),
+			task,
+			"AIP METS submission to APIS has failed.",
+			"The AIP is stored, but the post-storage workflow failed while delivering the AIP METS file to APIS for AIS import. Please try again, or ask a system administrator to investigate.",
+		)
+		return nil
+	}
+	task.Succeed(
+		temporalsdk_workflow.Now(ctx),
+		"Submitted AIP METS to APIS with import task ID %q and import run ID %q",
+		apisMetadata.ImportTaskID,
+		createImportRun.RunID,
+	)
+
+	task = result.NewTask(temporalsdk_workflow.Now(ctx), "Wait for APIS import")
+	var pollImportRunStatus apis.PollImportRunStatusResult
+	err = temporalsdk_workflow.ExecuteActivity(
+		withAPISPollActivityOpts(ctx),
+		apis.PollImportRunStatusActivityName,
+		&apis.PollImportRunStatusParams{TaskID: apisMetadata.ImportTaskID},
+	).Get(ctx, &pollImportRunStatus)
+	if err != nil {
+		logger.Error("System error", "message", err.Error())
+		result.SystemError(
+			temporalsdk_workflow.Now(ctx),
+			task,
+			"APIS import status check has failed.",
+			"The AIP is stored, but the post-storage workflow failed while checking whether APIS imported the AIP METS file for AIS. Please try again, or ask a system administrator to investigate.",
+		)
+		return nil
+	}
+
+	switch pollImportRunStatus.ImportResult {
+	case apisgen.ImportResultErfolgreich:
+		task.Succeed(
+			temporalsdk_workflow.Now(ctx),
+			"APIS import completed for import task ID %q with result %q",
+			apisMetadata.ImportTaskID,
+			pollImportRunStatus.ImportResult,
+		)
+		return nil
+	case apisgen.ImportResultFehler:
+		logger.Error(
+			"System error",
+			"message",
+			fmt.Sprintf("APIS import failed for task %q", apisMetadata.ImportTaskID),
+		)
+		result.SystemError(
+			temporalsdk_workflow.Now(ctx),
+			task,
+			"APIS import has failed.",
+			"The AIP is stored, but APIS reported an error while importing the AIP METS file into AIS. Please try again, or ask a system administrator to investigate.",
+		)
+		return nil
+	default:
+		logger.Error("System error", "message", fmt.Errorf(
+			"unexpected APIS import result %q for task %q",
+			pollImportRunStatus.ImportResult,
+			apisMetadata.ImportTaskID,
+		))
+		result.SystemError(
+			temporalsdk_workflow.Now(ctx),
+			task,
+			"APIS import has failed.",
+			"The AIP is stored, but APIS returned an unexpected import result while processing the AIP METS file. Please ask a system administrator to investigate.",
+		)
+		return nil
+	}
+}
+
+func getApisMetadata(data childwf.CustomMetadata) (apis.CustomMetadata, error) {
+	customMetadata, ok := data[apis.CustomMetadataKey]
+	if !ok {
+		return apis.CustomMetadata{}, fmt.Errorf("APIS custom metadata is required when APIS integration is enabled")
+	}
+	var apisMetadata apis.CustomMetadata
+	if err := apisMetadata.Unmarshal(customMetadata); err != nil {
+		return apis.CustomMetadata{}, err
+	}
+	return apisMetadata, nil
 }

--- a/internal/workflows/poststorage_test.go
+++ b/internal/workflows/poststorage_test.go
@@ -2,9 +2,12 @@ package workflows_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/artefactual-sdps/enduro/pkg/childwf"
 	"github.com/artefactual-sdps/temporal-activities/removepaths"
@@ -17,6 +20,7 @@ import (
 
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/amss"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/apis"
+	apisgen "github.com/artefactual-sdps/preprocessing-sfa/internal/apis/gen"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/config"
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/workflows"
 )
@@ -27,14 +31,47 @@ type TestSuite struct {
 
 	env      *temporalsdk_testsuite.TestWorkflowEnvironment
 	workflow *workflows.Poststorage
-	testDir  string
 }
 
-func (s *TestSuite) setup(cfg *config.PoststorageConfig) {
+const (
+	poststorageAIPUUIDString = "9390594f-84c2-457d-bd6a-618f21f7c954"
+	poststorageAIPName       = "test-" + poststorageAIPUUIDString
+	poststorageAIPPath       = "9390/594f/84c2/457d/bd6a/618f/21f7/c954/" + poststorageAIPName + ".zip"
+	poststorageImportTaskID  = "task-000001"
+	poststorageImportRunID   = "run-000001"
+	poststorageMETSName      = "METS." + poststorageAIPUUIDString + ".xml"
+	poststorageMETSRelPath   = poststorageAIPName + "/data/" + poststorageMETSName
+	poststorageWorkflowUser  = "sfa-enduro"
+)
+
+var (
+	poststorageAIPUUID    = uuid.MustParse(poststorageAIPUUIDString)
+	poststorageWorkingDir = filepath.Join(os.TempDir(), "sfa-enduro-poststorage-test")
+	poststorageMETSPath   = filepath.Join(poststorageWorkingDir, poststorageAIPUUIDString, poststorageMETSName)
+	poststorageSessionCtx = mock.AnythingOfType("*context.timerCtx")
+	poststorageTestTime   = time.Date(2024, 6, 6, 15, 8, 39, 0, time.UTC)
+
+	poststorageAppendMetadata = childwf.CustomMetadata{
+		apis.CustomMetadataKey: json.RawMessage(fmt.Sprintf(
+			`{"importTaskId":%q,"decision":%q}`,
+			poststorageImportTaskID,
+			apis.DecisionOptionContinueAppend,
+		)),
+	}
+	poststorageOverwriteMetadata = childwf.CustomMetadata{
+		apis.CustomMetadataKey: json.RawMessage(fmt.Sprintf(
+			`{"importTaskId":%q,"decision":%q}`,
+			poststorageImportTaskID,
+			apis.DecisionOptionContinueOverwrite,
+		)),
+	}
+)
+
+func (s *TestSuite) setup(cfg *config.PoststorageConfig, apisEnabled bool) {
 	s.env = s.NewTestWorkflowEnvironment()
+	s.env.SetStartTime(poststorageTestTime)
 	s.env.SetWorkerOptions(temporalsdk_worker.Options{EnableSessionWorker: true})
-	s.testDir = s.T().TempDir()
-	cfg.WorkingDir = s.testDir
+	cfg.WorkingDir = poststorageWorkingDir
 
 	s.env.RegisterActivityWithOptions(
 		amss.NewGetAIPPathActivity(nil).Execute,
@@ -48,44 +85,53 @@ func (s *TestSuite) setup(cfg *config.PoststorageConfig) {
 		removepaths.New().Execute,
 		temporalsdk_activity.RegisterOptions{Name: removepaths.Name},
 	)
+	s.env.RegisterActivityWithOptions(
+		apis.NewCreateImportRunActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: apis.CreateImportRunActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		apis.NewPollImportRunStatusActivity(nil, 0).Execute,
+		temporalsdk_activity.RegisterOptions{Name: apis.PollImportRunStatusActivityName},
+	)
 
-	s.workflow = workflows.NewPoststorage(*cfg)
+	s.workflow = workflows.NewPoststorage(*cfg, apisEnabled)
 }
 
-func TestWorkflow(t *testing.T) {
+func TestPoststorage(t *testing.T) {
 	suite.Run(t, new(TestSuite))
 }
 
-func (s *TestSuite) TestWorkflowSuccess() {
-	aipUUID := uuid.MustParse("9390594f-84c2-457d-bd6a-618f21f7c954")
-
-	s.setup(&config.PoststorageConfig{})
-	s.mockActivitiesSuccess(aipUUID)
-
-	s.env.ExecuteWorkflow(
-		s.workflow.Execute,
-		&childwf.PostStorageParams{
-			AIPUUID: aipUUID.String(),
-			CustomMetadata: childwf.CustomMetadata{
-				apis.CustomMetadataKey: json.RawMessage(
-					`{"importTaskId":"task-000001","decision":"Continue and append"}`,
-				),
-			},
-		},
-	)
+func (s *TestSuite) assertWorkflow(expected *childwf.PostStorageResult, errorContains string) {
+	s.T().Helper()
 
 	s.True(s.env.IsWorkflowCompleted())
 	s.env.AssertExpectations(s.T())
 
-	var result childwf.PostStorageResult
-	err := s.env.GetWorkflowResult(&result)
-	s.NoError(err)
+	if errorContains != "" {
+		s.ErrorContains(s.env.GetWorkflowError(), errorContains)
+		return
+	}
 
-	s.Equal(result, childwf.PostStorageResult{})
+	var result childwf.PostStorageResult
+	s.NoError(s.env.GetWorkflowResult(&result))
+	s.Equal(expected, &result)
 }
 
-func (s *TestSuite) TestWorkflowErrorsWhenAIPUUIDIsInvalid() {
-	s.setup(&config.PoststorageConfig{})
+func (s *TestSuite) TestAPISDisabled() {
+	s.setup(&config.PoststorageConfig{}, false)
+
+	s.env.ExecuteWorkflow(
+		s.workflow.Execute,
+		&childwf.PostStorageParams{
+			AIPUUID: poststorageAIPUUIDString,
+		},
+	)
+
+	s.assertWorkflow(&childwf.PostStorageResult{}, "")
+}
+
+func (s *TestSuite) TestInvalidAIPUUID() {
+	s.setup(&config.PoststorageConfig{}, true)
 
 	s.env.ExecuteWorkflow(
 		s.workflow.Execute,
@@ -94,39 +140,227 @@ func (s *TestSuite) TestWorkflowErrorsWhenAIPUUIDIsInvalid() {
 		},
 	)
 
-	s.True(s.env.IsWorkflowCompleted())
-	s.ErrorContains(s.env.GetWorkflowError(), "parse AIP UUID")
-	s.env.AssertExpectations(s.T())
+	s.assertWorkflow(nil, "parse AIP UUID")
 }
 
-func (s *TestSuite) mockActivitiesSuccess(aipUUID uuid.UUID) {
-	aipUUIDString := aipUUID.String()
-	aipName := "test-" + aipUUIDString
-	searchMDName := fmt.Sprintf("search-md_%s", aipName)
-	localDir := filepath.Join(s.testDir, searchMDName)
+func (s *TestSuite) TestAPISMetadataMissing() {
+	s.setup(&config.PoststorageConfig{}, true)
 
-	// Mock activities.
-	s.env.OnActivity(
-		amss.GetAIPPathActivityName,
-		mock.AnythingOfType("*context.timerCtx"),
-		&amss.GetAIPPathActivityParams{AIPUUID: aipUUID},
-	).Return(
-		&amss.GetAIPPathActivityResult{
-			Path: "9390/594f/84c2/457d/bd6a/618f/21f7/c954/test-9390594f-84c2-457d-bd6a-618f21f7c954.zip",
-		}, nil,
+	s.env.ExecuteWorkflow(
+		s.workflow.Execute,
+		&childwf.PostStorageParams{
+			AIPUUID: poststorageAIPUUIDString,
+		},
 	)
 
-	// Mock session activities.
-	sessionCtx := mock.AnythingOfType("*context.timerCtx")
-	metsName := fmt.Sprintf("METS.%s.xml", aipUUIDString)
-	metsPath := filepath.Join(localDir, metsName)
+	s.assertWorkflow(nil, "APIS custom metadata is required when APIS integration is enabled")
+}
+
+func (s *TestSuite) TestSuccess() {
+	s.setup(&config.PoststorageConfig{}, true)
+	s.mockActivitiesSuccess()
+	s.env.OnActivity(
+		apis.CreateImportRunActivityName,
+		poststorageSessionCtx,
+		&apis.CreateImportRunParams{
+			TaskID:          poststorageImportTaskID,
+			METSPath:        poststorageMETSPath,
+			ImportBehaviour: apisgen.ImportBehaviourTypeOverwriteAndAppend,
+			Username:        poststorageWorkflowUser,
+		},
+	).Return(
+		&apis.CreateImportRunResult{RunID: poststorageImportRunID}, nil,
+	)
+	s.env.OnActivity(
+		apis.PollImportRunStatusActivityName,
+		poststorageSessionCtx,
+		&apis.PollImportRunStatusParams{TaskID: poststorageImportTaskID},
+	).Return(
+		&apis.PollImportRunStatusResult{ImportResult: apisgen.ImportResultErfolgreich}, nil,
+	)
+
+	s.env.ExecuteWorkflow(
+		s.workflow.Execute,
+		&childwf.PostStorageParams{
+			AIPUUID:        poststorageAIPUUIDString,
+			CustomMetadata: poststorageOverwriteMetadata,
+		},
+	)
+
+	s.assertWorkflow(
+		&childwf.PostStorageResult{
+			Outcome: childwf.OutcomeSuccess,
+			Tasks: []*childwf.Task{
+				{
+					Name:        "Download AIP METS",
+					Message:     "AIP METS downloaded",
+					Outcome:     childwf.TaskOutcomeSuccess,
+					StartedAt:   poststorageTestTime,
+					CompletedAt: poststorageTestTime,
+				},
+				{
+					Name: "Submit AIP METS to APIS",
+					Message: fmt.Sprintf(
+						`Submitted AIP METS to APIS with import task ID %q and import run ID %q`,
+						poststorageImportTaskID,
+						poststorageImportRunID,
+					),
+					Outcome:     childwf.TaskOutcomeSuccess,
+					StartedAt:   poststorageTestTime,
+					CompletedAt: poststorageTestTime,
+				},
+				{
+					Name: "Wait for APIS import",
+					Message: fmt.Sprintf(
+						`APIS import completed for import task ID %q with result %q`,
+						poststorageImportTaskID,
+						apisgen.ImportResultErfolgreich,
+					),
+					Outcome:     childwf.TaskOutcomeSuccess,
+					StartedAt:   poststorageTestTime,
+					CompletedAt: poststorageTestTime,
+				},
+			},
+		},
+		"",
+	)
+}
+
+func (s *TestSuite) TestDownloadFailure() {
+	s.setup(&config.PoststorageConfig{}, true)
+	s.env.OnActivity(
+		amss.GetAIPPathActivityName,
+		poststorageSessionCtx,
+		&amss.GetAIPPathActivityParams{AIPUUID: poststorageAIPUUID},
+	).Return(
+		&amss.GetAIPPathActivityResult{
+			Path: poststorageAIPPath,
+		}, nil,
+	)
 	s.env.OnActivity(
 		amss.FetchActivityName,
-		sessionCtx,
+		poststorageSessionCtx,
 		&amss.FetchActivityParams{
-			AIPUUID:      aipUUID,
-			RelativePath: fmt.Sprintf("%s/data/%s", aipName, metsName),
-			Destination:  metsPath,
+			AIPUUID:      poststorageAIPUUID,
+			RelativePath: poststorageMETSRelPath,
+			Destination:  poststorageMETSPath,
+		},
+	).Return(
+		nil, errors.New("download failed"),
+	)
+
+	s.env.ExecuteWorkflow(
+		s.workflow.Execute,
+		&childwf.PostStorageParams{
+			AIPUUID:        poststorageAIPUUIDString,
+			CustomMetadata: poststorageAppendMetadata,
+		},
+	)
+
+	s.assertWorkflow(
+		&childwf.PostStorageResult{
+			Outcome: childwf.OutcomeSystemError,
+			Tasks: []*childwf.Task{
+				{
+					Name: "Download AIP METS",
+					Message: `System error: AIP METS download has failed.
+
+The AIP is stored, but the poststorage workflow failed while downloading the AIP METS file. Please try again, or ask a system administrator to investigate.`,
+					Outcome:     childwf.TaskOutcomeSystemFailure,
+					StartedAt:   poststorageTestTime,
+					CompletedAt: poststorageTestTime.Add(4 * time.Second),
+				},
+			},
+		},
+		"",
+	)
+}
+
+func (s *TestSuite) TestAPISImportFailure() {
+	s.setup(&config.PoststorageConfig{}, true)
+	s.mockActivitiesSuccess()
+	s.env.OnActivity(
+		apis.CreateImportRunActivityName,
+		poststorageSessionCtx,
+		&apis.CreateImportRunParams{
+			TaskID:          poststorageImportTaskID,
+			METSPath:        poststorageMETSPath,
+			ImportBehaviour: apisgen.ImportBehaviourTypeAppendOnly,
+			Username:        poststorageWorkflowUser,
+		},
+	).Return(
+		&apis.CreateImportRunResult{RunID: poststorageImportRunID}, nil,
+	)
+	s.env.OnActivity(
+		apis.PollImportRunStatusActivityName,
+		poststorageSessionCtx,
+		&apis.PollImportRunStatusParams{TaskID: poststorageImportTaskID},
+	).Return(
+		&apis.PollImportRunStatusResult{ImportResult: apisgen.ImportResultFehler}, nil,
+	)
+
+	s.env.ExecuteWorkflow(
+		s.workflow.Execute,
+		&childwf.PostStorageParams{
+			AIPUUID:        poststorageAIPUUIDString,
+			CustomMetadata: poststorageAppendMetadata,
+		},
+	)
+
+	s.assertWorkflow(
+		&childwf.PostStorageResult{
+			Outcome: childwf.OutcomeSystemError,
+			Tasks: []*childwf.Task{
+				{
+					Name:        "Download AIP METS",
+					Message:     "AIP METS downloaded",
+					Outcome:     childwf.TaskOutcomeSuccess,
+					StartedAt:   poststorageTestTime,
+					CompletedAt: poststorageTestTime,
+				},
+				{
+					Name: "Submit AIP METS to APIS",
+					Message: fmt.Sprintf(
+						`Submitted AIP METS to APIS with import task ID %q and import run ID %q`,
+						poststorageImportTaskID,
+						poststorageImportRunID,
+					),
+					Outcome:     childwf.TaskOutcomeSuccess,
+					StartedAt:   poststorageTestTime,
+					CompletedAt: poststorageTestTime,
+				},
+				{
+					Name: "Wait for APIS import",
+					Message: `System error: APIS import has failed.
+
+The AIP is stored, but APIS reported an error while importing the AIP METS file into AIS. Please try again, or ask a system administrator to investigate.`,
+					Outcome:     childwf.TaskOutcomeSystemFailure,
+					StartedAt:   poststorageTestTime,
+					CompletedAt: poststorageTestTime,
+				},
+			},
+		},
+		"",
+	)
+}
+
+func (s *TestSuite) mockActivitiesSuccess() {
+	s.env.OnActivity(
+		amss.GetAIPPathActivityName,
+		poststorageSessionCtx,
+		&amss.GetAIPPathActivityParams{AIPUUID: poststorageAIPUUID},
+	).Return(
+		&amss.GetAIPPathActivityResult{
+			Path: poststorageAIPPath,
+		}, nil,
+	)
+	s.env.OnActivity(
+		amss.FetchActivityName,
+		poststorageSessionCtx,
+		&amss.FetchActivityParams{
+			AIPUUID:      poststorageAIPUUID,
+			RelativePath: poststorageMETSRelPath,
+			Destination:  poststorageMETSPath,
 		},
 	).Return(
 		&amss.FetchActivityResult{}, nil,

--- a/internal/workflows/preprocessing.go
+++ b/internal/workflows/preprocessing.go
@@ -28,12 +28,6 @@ import (
 	"github.com/artefactual-sdps/preprocessing-sfa/internal/sip"
 )
 
-const (
-	DecisionOptionCancelIngest      = "Cancel ingest"
-	DecisionOptionContinueOverwrite = "Continue and overwrite"
-	DecisionOptionContinueAppend    = "Continue and append"
-)
-
 type Preprocessing struct {
 	psvc        persistence.Service
 	cfg         config.PreprocessingConfig
@@ -628,7 +622,7 @@ func (w *Preprocessing) createAPISImportTask(
 		apis.CreateImportTaskActivityName,
 		&apis.CreateImportTaskParams{
 			SIP:      sip,
-			Username: "preprocessing-sfa", // TODO: Use real username.
+			Username: "sfa-enduro", // TODO: Use real username.
 		},
 	).Get(ctx, &createAPISImportTask)
 	if err != nil {
@@ -769,9 +763,9 @@ func (w *Preprocessing) waitForAPISDecision(
 				taskID,
 			),
 			Options: []string{
-				DecisionOptionCancelIngest,
-				DecisionOptionContinueOverwrite,
-				DecisionOptionContinueAppend,
+				apis.DecisionOptionCancelIngest,
+				apis.DecisionOptionContinueOverwrite,
+				apis.DecisionOptionContinueAppend,
 			},
 		},
 	).Get(ctx, nil)
@@ -792,7 +786,7 @@ func (w *Preprocessing) waitForAPISDecision(
 	temporalsdk_workflow.GetSignalChannel(ctx, childwf.DecisionResponseSignalName).Receive(ctx, &decision)
 
 	switch decision.Option {
-	case DecisionOptionContinueOverwrite, DecisionOptionContinueAppend:
+	case apis.DecisionOptionContinueOverwrite, apis.DecisionOptionContinueAppend:
 		task.Succeed(
 			temporalsdk_workflow.Now(ctx),
 			"APIS detected metadata conflicts for import task ID %q but ingest was continued with user decision %q.",
@@ -800,7 +794,7 @@ func (w *Preprocessing) waitForAPISDecision(
 			decision.Option,
 		)
 		return decision.Option, true
-	case DecisionOptionCancelIngest:
+	case apis.DecisionOptionCancelIngest:
 		// TODO: Add and use canceled as workflow outcome.
 		result.ValidationError(
 			temporalsdk_workflow.Now(ctx),

--- a/internal/workflows/preprocessing_test.go
+++ b/internal/workflows/preprocessing_test.go
@@ -564,7 +564,7 @@ func (s *PreprocessingTestSuite) preAPISActivities(ar apisgen.AnalysisResult) (s
 		sessionCtx,
 		&apis.CreateImportTaskParams{
 			SIP:      expectedSIP,
-			Username: "preprocessing-sfa",
+			Username: "sfa-enduro",
 		},
 	).Return(
 		&apis.CreateImportTaskResult{TaskID: apisTaskID}, nil,
@@ -749,9 +749,9 @@ func (s *PreprocessingTestSuite) executeAsChildWithHumanReview(
 					apisTaskID,
 				),
 				Options: []string{
-					workflows.DecisionOptionCancelIngest,
-					workflows.DecisionOptionContinueOverwrite,
-					workflows.DecisionOptionContinueAppend,
+					apis.DecisionOptionCancelIngest,
+					apis.DecisionOptionContinueOverwrite,
+					apis.DecisionOptionContinueAppend,
 				},
 			},
 			request,
@@ -1265,7 +1265,7 @@ func (s *PreprocessingTestSuite) TestHumanReviewContinueAndOverwrite() {
 			SIPName:      sipName,
 		},
 		childwf.DecisionResponse{
-			Option: workflows.DecisionOptionContinueOverwrite,
+			Option: apis.DecisionOptionContinueOverwrite,
 		},
 	)
 
@@ -1275,14 +1275,14 @@ func (s *PreprocessingTestSuite) TestHumanReviewContinueAndOverwrite() {
 	s.Equal(
 		&childwf.PreprocessingResult{
 			Outcome:        childwf.OutcomeSuccess,
-			CustomMetadata: apisCustomMetadata(apisTaskID, workflows.DecisionOptionContinueOverwrite),
+			CustomMetadata: apisCustomMetadata(apisTaskID, apis.DecisionOptionContinueOverwrite),
 			RelativePath:   updatedRelPath,
 			Tasks: apisTasks(
 				apisTaskID,
 				fmt.Sprintf(
 					"APIS detected metadata conflicts for import task ID %q but ingest was continued with user decision %q.",
 					apisTaskID,
-					workflows.DecisionOptionContinueOverwrite,
+					apis.DecisionOptionContinueOverwrite,
 				),
 				childwf.TaskOutcomeSuccess,
 				true,
@@ -1311,7 +1311,7 @@ func (s *PreprocessingTestSuite) TestHumanReviewContinueAndAppend() {
 			SIPName:      sipName,
 		},
 		childwf.DecisionResponse{
-			Option: workflows.DecisionOptionContinueAppend,
+			Option: apis.DecisionOptionContinueAppend,
 		},
 	)
 
@@ -1321,14 +1321,14 @@ func (s *PreprocessingTestSuite) TestHumanReviewContinueAndAppend() {
 	s.Equal(
 		&childwf.PreprocessingResult{
 			Outcome:        childwf.OutcomeSuccess,
-			CustomMetadata: apisCustomMetadata(apisTaskID, workflows.DecisionOptionContinueAppend),
+			CustomMetadata: apisCustomMetadata(apisTaskID, apis.DecisionOptionContinueAppend),
 			RelativePath:   updatedRelPath,
 			Tasks: apisTasks(
 				apisTaskID,
 				fmt.Sprintf(
 					"APIS detected metadata conflicts for import task ID %q but ingest was continued with user decision %q.",
 					apisTaskID,
-					workflows.DecisionOptionContinueAppend,
+					apis.DecisionOptionContinueAppend,
 				),
 				childwf.TaskOutcomeSuccess,
 				true,
@@ -1356,7 +1356,7 @@ func (s *PreprocessingTestSuite) TestHumanReviewCancelIngest() {
 			SIPName:      sipName,
 		},
 		childwf.DecisionResponse{
-			Option: workflows.DecisionOptionCancelIngest,
+			Option: apis.DecisionOptionCancelIngest,
 		},
 	)
 


### PR DESCRIPTION
Create poststorage tasks for downloading the AIP METS, submitting it to
APIS as an import run, and waiting for the APIS import result. Require
APIS custom metadata when APIS is enabled, map preprocessing decisions
to APIS import run behaviour.

Refs #174.