### PR TITLE
Revert "Remove AIP path lookup from poststorage"

### DIFF
--- a/cmd/worker/workercmd/cmd.go
+++ b/cmd/worker/workercmd/cmd.go
@@ -274,6 +274,10 @@ func (m *Main) registerPoststorageWorkflow(packages *ssclient.PackagesService) {
 	)
 
 	m.temporalWorker.RegisterActivityWithOptions(
+		amss.NewGetAIPPathActivity(packages).Execute,
+		temporalsdk_activity.RegisterOptions{Name: amss.GetAIPPathActivityName},
+	)
+	m.temporalWorker.RegisterActivityWithOptions(
 		amss.NewFetchActivity(packages).Execute,
 		temporalsdk_activity.RegisterOptions{Name: amss.FetchActivityName},
 	)

--- a/internal/amss/get_aip_path.go
+++ b/internal/amss/get_aip_path.go
@@ -1,0 +1,47 @@
+package amss
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.artefactual.dev/ssclient"
+)
+
+const GetAIPPathActivityName = "get-aip-path"
+
+type (
+	GetAIPPathActivity struct {
+		packages *ssclient.PackagesService
+	}
+	GetAIPPathActivityParams struct {
+		AIPUUID uuid.UUID
+	}
+	GetAIPPathActivityResult struct {
+		Path string
+	}
+)
+
+func NewGetAIPPathActivity(packages *ssclient.PackagesService) *GetAIPPathActivity {
+	return &GetAIPPathActivity{packages: packages}
+}
+
+func (a *GetAIPPathActivity) Execute(
+	ctx context.Context,
+	params *GetAIPPathActivityParams,
+) (*GetAIPPathActivityResult, error) {
+	pkg, err := a.packages.Get(ctx, params.AIPUUID)
+	if err != nil {
+		return nil, fmt.Errorf("GetAIPPath: get package: %w", err)
+	}
+	if pkg == nil {
+		return nil, fmt.Errorf("GetAIPPath: package not found")
+	}
+
+	path := pkg.GetCurrentPath()
+	if path == nil {
+		return nil, fmt.Errorf("GetAIPPath: current_path not found in response")
+	}
+
+	return &GetAIPPathActivityResult{Path: *path}, nil
+}

--- a/internal/amss/get_aip_path_test.go
+++ b/internal/amss/get_aip_path_test.go
@@ -1,0 +1,74 @@
+package amss_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/preprocessing-sfa/internal/amss"
+)
+
+func TestGetAIPPathActivity(t *testing.T) {
+	t.Parallel()
+
+	aipUUID := uuid.MustParse("9390594f-84c2-457d-bd6a-618f21f7c954")
+	aipUUIDString := aipUUID.String()
+
+	for _, tt := range []struct {
+		name     string
+		params   *amss.GetAIPPathActivityParams
+		response string
+		want     *amss.GetAIPPathActivityResult
+		wantErr  string
+	}{
+		{
+			name:     "success",
+			params:   &amss.GetAIPPathActivityParams{AIPUUID: aipUUID},
+			response: fmt.Sprintf(`{"uuid":%q,"current_path":"test/path/METS.xml"}`, aipUUIDString),
+			want:     &amss.GetAIPPathActivityResult{Path: "test/path/METS.xml"},
+		},
+		{
+			name:     "missing current path",
+			params:   &amss.GetAIPPathActivityParams{AIPUUID: aipUUID},
+			response: fmt.Sprintf(`{"uuid":%q}`, aipUUIDString),
+			wantErr:  "GetAIPPath: current_path not found in response",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			packages := newPackagesService(t, func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, r.Method, http.MethodGet)
+				assert.Equal(t, r.URL.Path, fmt.Sprintf("/api/v2/file/%s/", aipUUIDString))
+				assert.Equal(t, r.Header.Get("Authorization"), "ApiKey test:test")
+
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tt.response)
+			})
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			env.RegisterActivityWithOptions(
+				amss.NewGetAIPPathActivity(packages).Execute,
+				temporalsdk_activity.RegisterOptions{Name: amss.GetAIPPathActivityName},
+			)
+
+			future, err := env.ExecuteActivity(amss.GetAIPPathActivityName, tt.params)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+
+			var got amss.GetAIPPathActivityResult
+			err = future.Get(&got)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, &got, tt.want)
+		})
+	}
+}

--- a/internal/workflows/poststorage.go
+++ b/internal/workflows/poststorage.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/artefactual-sdps/enduro/pkg/childwf"
@@ -53,6 +54,29 @@ func (w *Poststorage) Execute(
 		)
 	}
 
+	var getAIPPathResult amss.GetAIPPathActivityResult
+	err = temporalsdk_workflow.ExecuteActivity(
+		temporalsdk_workflow.WithActivityOptions(
+			ctx,
+			temporalsdk_workflow.ActivityOptions{
+				ScheduleToCloseTimeout: 10 * time.Minute,
+				RetryPolicy: &temporalsdk_temporal.RetryPolicy{
+					InitialInterval:    15 * time.Second,
+					BackoffCoefficient: 2,
+					MaximumInterval:    time.Minute,
+					MaximumAttempts:    5,
+				},
+			},
+		),
+		amss.GetAIPPathActivityName,
+		&amss.GetAIPPathActivityParams{
+			AIPUUID: aipUUID,
+		},
+	).Get(ctx, &getAIPPathResult)
+	if err != nil {
+		return nil, err
+	}
+
 	// Activities running within a session.
 	{
 		var sessErr error
@@ -70,7 +94,7 @@ func (w *Poststorage) Execute(
 				return nil, fmt.Errorf("error creating session: %v", err)
 			}
 
-			sessErr = w.SessionHandler(sessCtx, aipUUID)
+			sessErr = w.SessionHandler(sessCtx, aipUUID, getAIPPathResult.Path)
 
 			// We want to retry the session if it has been canceled as a result
 			// of losing the worker but not otherwise. This scenario seems to be
@@ -106,7 +130,7 @@ func (w *Poststorage) Execute(
 	return &childwf.PostStorageResult{}, nil
 }
 
-func (w *Poststorage) SessionHandler(ctx temporalsdk_workflow.Context, aipUUID uuid.UUID) (e error) {
+func (w *Poststorage) SessionHandler(ctx temporalsdk_workflow.Context, aipUUID uuid.UUID, aipPath string) (e error) {
 	removePaths := []string{}
 
 	defer func() {
@@ -123,8 +147,11 @@ func (w *Poststorage) SessionHandler(ctx temporalsdk_workflow.Context, aipUUID u
 		temporalsdk_workflow.CompleteSession(ctx)
 	}()
 
+	// In case the AIP is compressed, remove its UUID and the possible
+	// extension from the directory/file name, and append the UUID back.
 	aipUUIDString := aipUUID.String()
-	localDir := filepath.Join(w.cfg.WorkingDir, aipUUIDString)
+	aipDirName := strings.Split(filepath.Base(aipPath), aipUUIDString)[0] + aipUUIDString
+	localDir := filepath.Join(w.cfg.WorkingDir, fmt.Sprintf("search-md_%s", aipDirName))
 	metsName := fmt.Sprintf("METS.%s.xml", aipUUIDString)
 	metsPath := filepath.Join(localDir, metsName)
 
@@ -136,7 +163,7 @@ func (w *Poststorage) SessionHandler(ctx temporalsdk_workflow.Context, aipUUID u
 		amss.FetchActivityName,
 		&amss.FetchActivityParams{
 			AIPUUID:      aipUUID,
-			RelativePath: fmt.Sprintf("%s/data/%s", aipUUIDString, metsName),
+			RelativePath: fmt.Sprintf("%s/data/%s", aipDirName, metsName),
 			Destination:  metsPath,
 		},
 	).Get(ctx, &fetchMETSResult)

--- a/internal/workflows/poststorage_test.go
+++ b/internal/workflows/poststorage_test.go
@@ -37,6 +37,10 @@ func (s *TestSuite) setup(cfg *config.PoststorageConfig) {
 	cfg.WorkingDir = s.testDir
 
 	s.env.RegisterActivityWithOptions(
+		amss.NewGetAIPPathActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: amss.GetAIPPathActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
 		amss.NewFetchActivity(nil).Execute,
 		temporalsdk_activity.RegisterOptions{Name: amss.FetchActivityName},
 	)
@@ -97,7 +101,20 @@ func (s *TestSuite) TestWorkflowErrorsWhenAIPUUIDIsInvalid() {
 
 func (s *TestSuite) mockActivitiesSuccess(aipUUID uuid.UUID) {
 	aipUUIDString := aipUUID.String()
-	localDir := filepath.Join(s.testDir, aipUUIDString)
+	aipName := "test-" + aipUUIDString
+	searchMDName := fmt.Sprintf("search-md_%s", aipName)
+	localDir := filepath.Join(s.testDir, searchMDName)
+
+	// Mock activities.
+	s.env.OnActivity(
+		amss.GetAIPPathActivityName,
+		mock.AnythingOfType("*context.timerCtx"),
+		&amss.GetAIPPathActivityParams{AIPUUID: aipUUID},
+	).Return(
+		&amss.GetAIPPathActivityResult{
+			Path: "9390/594f/84c2/457d/bd6a/618f/21f7/c954/test-9390594f-84c2-457d-bd6a-618f21f7c954.zip",
+		}, nil,
+	)
 
 	// Mock session activities.
 	sessionCtx := mock.AnythingOfType("*context.timerCtx")
@@ -108,7 +125,7 @@ func (s *TestSuite) mockActivitiesSuccess(aipUUID uuid.UUID) {
 		sessionCtx,
 		&amss.FetchActivityParams{
 			AIPUUID:      aipUUID,
-			RelativePath: fmt.Sprintf("%s/data/%s", aipUUIDString, metsName),
+			RelativePath: fmt.Sprintf("%s/data/%s", aipName, metsName),
 			Destination:  metsPath,
 		},
 	).Return(


### PR DESCRIPTION
This reverts commit a7acc7a5fa358dbb68295c3e3dc69febaf8a95ec.

Refs #174.

Sorry for the back and forward @djjuhasz, I thought this was only needed to create the bundle name, but it's actually needed to fetch the METS.