### PR TITLE
Update APIS mock server

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ starting, stopping, and clearing the environment, are documented in Enduro.
 This repository can also provide local overrides through its own `.tilt.env`
 file, including settings such as `TRIGGER_MODE_AUTO`.
 
+The local APIS mock uses happy path terminal results by default. Set these
+values in this repository's `.tilt.env` to exercise APIS conflict or failure
+flows:
+
+```bash
+MOCK_ANALYSIS_RESULT=AlleNeu      # AlleNeu, AlleGleich, Konflikte, Fehler
+MOCK_IMPORT_RESULT=Erfolgreich    # Erfolgreich, Fehler
+```
+
 ### Requirements for development
 
 While we run the services inside a Kubernetes cluster we recomend installing

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,17 @@ custom_build(
 docker_build(ref="apis-mock:dev", context="hack/apis-mock")
 
 # Kubernetes manifests
-k8s_yaml(kustomize("hack/kube"))
+kube_objects = decode_yaml_stream(kustomize("hack/kube"))
+for obj in kube_objects:
+  if (
+    obj.get("kind") == "Deployment" and
+    obj.get("metadata", {}).get("name") == "apis-mock"
+  ):
+    env = obj["spec"]["template"]["spec"]["containers"][0]["env"]
+    env[0]["value"] = os.environ.get("MOCK_ANALYSIS_RESULT") or env[0]["value"]
+    env[1]["value"] = os.environ.get("MOCK_IMPORT_RESULT") or env[1]["value"]
+
+k8s_yaml(encode_yaml_stream(kube_objects))
 
 # Tilt resources
 k8s_resource(

--- a/hack/apis-mock/README.md
+++ b/hack/apis-mock/README.md
@@ -72,8 +72,8 @@ The mock is intentionally small:
 - one in-memory task record per `POST /api/ImportTasks`
 - one optional import run per task
 - `GET /api/ImportTasks/{id}/status` is the only endpoint that advances state
-- the default path is the happy path, and request hints override it when a test
-  or manual run needs a conflict or failure
+- terminal analysis and import results are configured with environment
+  variables
 
 That shape keeps the implementation easy to read and easy to tweak for local
 development, while still matching the workflow semantics described in the APIS
@@ -118,8 +118,7 @@ go run ./cmd/mockapi
 Server listens on `:8080` by default.
 
 The generated security model expects a bearer token on all endpoints. The
-health endpoint is intentionally not implemented because the current
-integration work only needs the import-task endpoints.
+health endpoint returns a minimal `OK` response.
 
 ## Build binary
 
@@ -132,24 +131,44 @@ go build -o bin/mockapi ./cmd/mockapi
 ```bash
 docker build -t apis-mock:latest .
 docker run --rm -p 8080:8080 apis-mock:latest
+docker run --rm -p 8080:8080 \
+  -e MOCK_ANALYSIS_RESULT=Konflikte \
+  -e MOCK_IMPORT_RESULT=Fehler \
+  apis-mock:latest
 ```
 
 ## Mock tuning switches
 
 - `MOCK_AUTH_TOKEN=some-token` -> expected bearer token (default: `mock-token`)
 - `PORT=9090` -> change listening port
+- `MOCK_ANALYSIS_RESULT=Konflikte` -> terminal `analysisResult` assigned to
+  new import tasks (fallback if unset: `AlleNeu`; valid values: `AlleNeu`,
+  `AlleGleich`, `Konflikte`, `Fehler`)
+- `MOCK_IMPORT_RESULT=Fehler` -> terminal `importResult` assigned to import
+  runs (fallback if unset: `Erfolgreich`; valid values: `Erfolgreich`,
+  `Fehler`)
+
+The configured result values apply to every task and import run created during
+the mock server process.
+
+The result variables are also read by the Tilt-managed Kubernetes Deployment.
+Add them to the repo-local `.tilt.env` to change the mock behavior in a Tilt
+environment:
+
+```bash
+MOCK_ANALYSIS_RESULT=Konflikte
+MOCK_IMPORT_RESULT=Fehler
+```
 
 ## What Is Intentionally Simplified
 
 - all state is in memory and is lost on restart
 - task and import statuses advance in a short deterministic sequence when polled
 - auth is a single bearer-token equality check against `MOCK_AUTH_TOKEN`
-- `/api/Healthz` is intentionally not implemented
+- `/api/Healthz` returns a minimal `OK` response
 - percentages and document counts are omitted because the current integration
   only cares about statuses and terminal results
 - only the APIS behaviors currently needed by preprocessing-sfa are modeled
-- request hints are taken from uploaded filenames so individual scenarios can
-  be forced without changing config or restarting the mock
 
 ## Notes on behavior
 
@@ -172,17 +191,6 @@ docker run --rm -p 8080:8080 apis-mock:latest
 - Analysis results `Konflikte` and `Fehler` stop the flow before import,
   matching the current workflow expectations.
 - Cancelling a task after analysis keeps the completed `analysisResult` visible.
-- The mock accepts request hints in uploaded filenames to force per-request
-  outcomes without restarting.
-  The checks are simple substring matches, so use the lowercase markers
-  exactly as shown:
-  - `mock-alleneu`, `mock-allegleich`, `mock-konflikte`, `mock-fehler`. These
-  substrings must be put in the metadata.xml file name, and only apply to the
-  analysis results. The filename is passed to the `/api/ImportTasks/ POST`
-  endpoint.
-  - `mock-import-erfolgreich`, `mock-import-fehler`. These substrings must be
-  put in the METS file name, and only apply to the importRun results. The
-  filename is passed to the `/api/ImportTasks/{id}/importRuns/ POST` endpoint.
 
 ## Example Flows
 
@@ -197,15 +205,10 @@ curl \
   http://localhost:8080/api/ImportTasks
 ```
 
-Create a task that ends in a metadata conflict:
+Run with a metadata conflict result:
 
 ```bash
-curl \
-  -H 'Authorization: Bearer mock-token' \
-  -F 'file=@metadata.xml;filename=metadata-mock-konflikte.xml' \
-  -F 'sipType=BornDigitalSIP' \
-  -F 'username=archivist@example.com' \
-  http://localhost:8080/api/ImportTasks
+MOCK_ANALYSIS_RESULT=Konflikte go run ./cmd/mockapi
 ```
 
 Poll task status:
@@ -216,12 +219,8 @@ curl \
   http://localhost:8080/api/ImportTasks/task-000001/status
 ```
 
-Start an import run that will fail:
+Run with a failed import result:
 
 ```bash
-curl \
-  -H 'Authorization: Bearer mock-token' \
-  -F 'file=@METS.xml;filename=METS-mock-import-fehler.xml' \
-  -F 'importBehaviour=AppendOnly' \
-  http://localhost:8080/api/ImportTasks/task-000001/importRuns
+MOCK_IMPORT_RESULT=Fehler go run ./cmd/mockapi
 ```

--- a/hack/apis-mock/cmd/mockapi/main.go
+++ b/hack/apis-mock/cmd/mockapi/main.go
@@ -1,32 +1,63 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/artefactual-sdps/preprocessing-sfa/hack/apis-mock/internal/gen"
 	"github.com/artefactual-sdps/preprocessing-sfa/hack/apis-mock/internal/mock"
 )
 
+const (
+	envMockAnalysisResult = "MOCK_ANALYSIS_RESULT"
+	envMockImportResult   = "MOCK_IMPORT_RESULT"
+)
+
 func main() {
 	addr := ":" + envOrDefault("PORT", "8080")
 
-	handler := mock.NewHandler()
+	analysisResult, importResult, err := handlerResultsFromEnv()
+	if err != nil {
+		log.Fatalf("read mock configuration: %v", err)
+	}
+
+	handler := mock.NewHandler(analysisResult, importResult)
 	security := mock.NewSecurity(envOrDefault("MOCK_AUTH_TOKEN", "mock-token"))
 	server, err := gen.NewServer(handler, security)
 	if err != nil {
 		log.Fatalf("create server: %v", err)
 	}
 
+	log.Printf("mock API configured with analysisResult=%s importResult=%s", analysisResult, importResult)
 	log.Printf("mock API listening on %s", addr)
 	if err := http.ListenAndServe(addr, server); err != nil {
 		log.Fatalf("server stopped: %v", err)
 	}
 }
 
+func handlerResultsFromEnv() (gen.AnalysisResult, gen.ImportResult, error) {
+	analysisResult, err := mock.ParseAnalysisResult(
+		envOrDefault(envMockAnalysisResult, string(mock.DefaultAnalysisResult)),
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("%s: %w", envMockAnalysisResult, err)
+	}
+
+	importResult, err := mock.ParseImportResult(
+		envOrDefault(envMockImportResult, string(mock.DefaultImportResult)),
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("%s: %w", envMockImportResult, err)
+	}
+
+	return analysisResult, importResult, nil
+}
+
 func envOrDefault(key, fallback string) string {
-	if v, ok := os.LookupEnv(key); ok && v != "" {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
 		return v
 	}
 	return fallback

--- a/hack/apis-mock/go.mod
+++ b/hack/apis-mock/go.mod
@@ -1,12 +1,10 @@
 module github.com/artefactual-sdps/preprocessing-sfa/hack/apis-mock
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
-	github.com/google/go-cmp v0.7.0
-	github.com/google/uuid v1.6.0
 	github.com/ogen-go/ogen v1.20.0
 	go.opentelemetry.io/otel v1.41.0
 	go.opentelemetry.io/otel/metric v1.41.0
@@ -22,6 +20,8 @@ require (
 	github.com/go-faster/yaml v0.4.6 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/hack/apis-mock/internal/mock/server.go
+++ b/hack/apis-mock/internal/mock/server.go
@@ -11,6 +11,11 @@ import (
 	"github.com/artefactual-sdps/preprocessing-sfa/hack/apis-mock/internal/gen"
 )
 
+const (
+	DefaultAnalysisResult = gen.AnalysisResultAlleNeu
+	DefaultImportResult   = gen.ImportResultErfolgreich
+)
+
 // Security implements the APIS authentication scheme for the generated server.
 type Security struct {
 	token string
@@ -33,17 +38,17 @@ func (s *Security) HandleSmart(ctx context.Context, _ gen.OperationName, t gen.S
 // Handler keeps just enough state to reproduce the APIS workflow:
 // analysis, optional cancellation, and one import run.
 type Handler struct {
-	mu       sync.Mutex
-	nextTask int
-	nextRun  int
-	tasks    map[string]*taskState
+	mu             sync.Mutex
+	nextTask       int
+	nextRun        int
+	tasks          map[string]*taskState
+	analysisResult gen.AnalysisResult
+	importResult   gen.ImportResult
 }
 
 // taskState stores the minimal in-memory state for an APIS import task.
 type taskState struct {
 	id             string
-	name           string
-	createdBy      string
 	createdAt      time.Time
 	status         gen.ImportTaskStatus
 	analysisPolls  int
@@ -56,12 +61,15 @@ type taskState struct {
 }
 
 // NewHandler returns the in-memory APIS mock handler.
-func NewHandler() *Handler {
-	return &Handler{tasks: make(map[string]*taskState)}
+func NewHandler(analysisResult gen.AnalysisResult, importResult gen.ImportResult) *Handler {
+	return &Handler{
+		tasks:          make(map[string]*taskState),
+		analysisResult: analysisResult,
+		importResult:   importResult,
+	}
 }
 
-// APIHealthzGet is left unimplemented because the preprocessing
-// integration work only depends on the import-task endpoints.
+// APIHealthzGet returns the minimal health response needed for local checks.
 func (h *Handler) APIHealthzGet(_ context.Context) (gen.APIHealthzGetRes, error) {
 	return &gen.APIHealthzGetOK{Status: "OK"}, nil
 }
@@ -71,7 +79,7 @@ func (h *Handler) APIHealthzGet(_ context.Context) (gen.APIHealthzGetRes, error)
 // lifecycle until the terminal result becomes visible.
 func (h *Handler) APIImporttasksPost(
 	_ context.Context,
-	req gen.OptAPIImporttasksPostReq,
+	_ gen.OptAPIImporttasksPostReq,
 ) (gen.APIImporttasksPostRes, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -82,16 +90,8 @@ func (h *Handler) APIImporttasksPost(
 		id:             taskID,
 		createdAt:      time.Now().UTC(),
 		status:         gen.ImportTaskStatusNeu,
-		analysisResult: gen.AnalysisResultAlleNeu,
-		importResult:   gen.ImportResultErfolgreich,
-	}
-
-	if r, ok := req.Get(); ok {
-		task.name = r.File.Name
-		task.createdBy = r.Username
-		if result, ok := analysisResultFromName(r.File.Name); ok {
-			task.analysisResult = result
-		}
+		analysisResult: h.analysisResult,
+		importResult:   h.importResult,
 	}
 
 	h.tasks[taskID] = task
@@ -136,7 +136,7 @@ func (h *Handler) APIImporttasksIDCancelPost(
 // on the task status endpoint exposes the import lifecycle.
 func (h *Handler) APIImporttasksIDImportrunsPost(
 	_ context.Context,
-	req gen.OptAPIImporttasksIDImportrunsPostReq,
+	_ gen.OptAPIImporttasksIDImportrunsPostReq,
 	params gen.APIImporttasksIDImportrunsPostParams,
 ) (gen.APIImporttasksIDImportrunsPostRes, error) {
 	h.mu.Lock()
@@ -167,12 +167,7 @@ func (h *Handler) APIImporttasksIDImportrunsPost(
 	task.runID = runID
 	task.status = gen.ImportTaskStatusWirdImportiert
 	task.importPolls = 0
-	task.importResult = gen.ImportResultErfolgreich
-	if r, ok := req.Get(); ok {
-		if result, ok := importResultFromName(r.File.Name); ok {
-			task.importResult = result
-		}
-	}
+	task.importResult = h.importResult
 
 	return &gen.CreateImportRunResponse{
 		ImportRunId: runID,
@@ -309,32 +304,18 @@ func badRequest(detail string) *gen.APIImporttasksIDImportrunsPostBadRequest {
 	}
 }
 
-// analysisResultFromName maps filename markers to analysis outcomes for manual and
-// automated development scenarios.
-func analysisResultFromName(value string) (gen.AnalysisResult, bool) {
-	switch {
-	case strings.Contains(value, "mock-fehler"):
-		return gen.AnalysisResultFehler, true
-	case strings.Contains(value, "mock-konflikte"):
-		return gen.AnalysisResultKonflikte, true
-	case strings.Contains(value, "mock-allegleich"):
-		return gen.AnalysisResultAlleGleich, true
-	case strings.Contains(value, "mock-alleneu"):
-		return gen.AnalysisResultAlleNeu, true
-	default:
-		return "", false
-	}
+// ParseAnalysisResult parses a configured analysis result.
+func ParseAnalysisResult(value string) (gen.AnalysisResult, error) {
+	var result gen.AnalysisResult
+	err := result.UnmarshalText([]byte(strings.TrimSpace(value)))
+
+	return result, err
 }
 
-// importResultFromName maps filename markers to import outcomes for manual and
-// automated development scenarios.
-func importResultFromName(value string) (gen.ImportResult, bool) {
-	switch {
-	case strings.Contains(value, "mock-import-fehler"):
-		return gen.ImportResultFehler, true
-	case strings.Contains(value, "mock-import-erfolgreich"):
-		return gen.ImportResultErfolgreich, true
-	default:
-		return "", false
-	}
+// ParseImportResult parses a configured import result.
+func ParseImportResult(value string) (gen.ImportResult, error) {
+	var result gen.ImportResult
+	err := result.UnmarshalText([]byte(strings.TrimSpace(value)))
+
+	return result, err
 }

--- a/hack/apis-mock/internal/mock/server.go
+++ b/hack/apis-mock/internal/mock/server.go
@@ -155,8 +155,8 @@ func (h *Handler) APIImporttasksIDImportrunsPost(
 	if task.status != gen.ImportTaskStatusAnalysiert {
 		return badRequest("cannot create import run before analysis has finished"), nil
 	}
-	if task.analysisResult != gen.AnalysisResultAlleNeu && task.analysisResult != gen.AnalysisResultAlleGleich {
-		return badRequest("cannot create import run for this analysis result"), nil
+	if task.analysisResult == gen.AnalysisResultFehler {
+		return badRequest("cannot create import run for failed analysis result"), nil
 	}
 	if task.runID != "" {
 		return badRequest("cannot create a second import run for the same task"), nil

--- a/hack/apis-mock/internal/mock/server_test.go
+++ b/hack/apis-mock/internal/mock/server_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestTaskStatusDrivesAnalysisAndImportLifecycle(t *testing.T) {
 	ctx := t.Context()
-	h := mock.NewHandler()
+	h := newHandler()
 
 	taskID := createTask(t, ctx, h, "metadata.xml", "dev@example.com")
 	status := getTaskStatus(t, ctx, h, taskID)
@@ -65,9 +65,9 @@ func TestTaskStatusDrivesAnalysisAndImportLifecycle(t *testing.T) {
 
 func TestConflictTaskCanBeCancelled(t *testing.T) {
 	ctx := t.Context()
-	h := mock.NewHandler()
+	h := mock.NewHandler(gen.AnalysisResultKonflikte, gen.ImportResultErfolgreich)
 
-	taskID := createTask(t, ctx, h, "metadata-mock-konflikte.xml", "dev@example.com")
+	taskID := createTask(t, ctx, h, "metadata.xml", "dev@example.com")
 	_ = getTaskStatus(t, ctx, h, taskID)
 	_ = getTaskStatus(t, ctx, h, taskID)
 	status := getTaskStatus(t, ctx, h, taskID)
@@ -107,9 +107,9 @@ func TestConflictTaskCanBeCancelled(t *testing.T) {
 
 func TestConflictTaskCanStartImportRunAfterDecision(t *testing.T) {
 	ctx := t.Context()
-	h := mock.NewHandler()
+	h := mock.NewHandler(gen.AnalysisResultKonflikte, gen.ImportResultErfolgreich)
 
-	taskID := createTask(t, ctx, h, "metadata-mock-konflikte.xml", "dev@example.com")
+	taskID := createTask(t, ctx, h, "metadata.xml", "dev@example.com")
 	_ = getTaskStatus(t, ctx, h, taskID)
 	_ = getTaskStatus(t, ctx, h, taskID)
 	status := getTaskStatus(t, ctx, h, taskID)
@@ -133,13 +133,13 @@ func TestConflictTaskCanStartImportRunAfterDecision(t *testing.T) {
 
 func TestImportFailureIsSurfacedThroughTaskStatus(t *testing.T) {
 	ctx := t.Context()
-	h := mock.NewHandler()
+	h := mock.NewHandler(gen.AnalysisResultAlleNeu, gen.ImportResultFehler)
 
 	taskID := createTask(t, ctx, h, "metadata.xml", "dev@example.com")
 	_ = getTaskStatus(t, ctx, h, taskID)
 	_ = getTaskStatus(t, ctx, h, taskID)
 	_ = getTaskStatus(t, ctx, h, taskID)
-	runID := createRun(t, ctx, h, taskID, "METS-mock-import-fehler.xml", "")
+	runID := createRun(t, ctx, h, taskID, "METS.xml", "")
 	_ = getTaskStatus(t, ctx, h, taskID)
 	_ = getTaskStatus(t, ctx, h, taskID)
 	status := getTaskStatus(t, ctx, h, taskID)
@@ -156,9 +156,49 @@ func TestImportFailureIsSurfacedThroughTaskStatus(t *testing.T) {
 	})
 }
 
+func TestDefaultResultsCanBeConfigured(t *testing.T) {
+	ctx := t.Context()
+	h := mock.NewHandler(gen.AnalysisResultAlleGleich, gen.ImportResultFehler)
+
+	taskID := createTask(t, ctx, h, "metadata.xml", "dev@example.com")
+	_ = getTaskStatus(t, ctx, h, taskID)
+	_ = getTaskStatus(t, ctx, h, taskID)
+	_ = getTaskStatus(t, ctx, h, taskID)
+	runID := createRun(t, ctx, h, taskID, "METS.xml", "")
+	_ = getTaskStatus(t, ctx, h, taskID)
+	status := getTaskStatus(t, ctx, h, taskID)
+	assert.DeepEqual(t, status, &gen.ImportTaskStatusResponse{
+		Status:         gen.ImportTaskStatusImportiert,
+		AnalysisResult: gen.NewOptNilAnalysisResult(gen.AnalysisResultAlleGleich),
+		ImportResult:   gen.NewOptNilImportResult(gen.ImportResultFehler),
+	})
+
+	runStatus := getImportRunStatus(t, ctx, h, taskID, runID)
+	assert.DeepEqual(t, runStatus, &gen.ImportRunStatusResponse{
+		Status:       gen.ImportStatusFailed,
+		ImportResult: gen.NewOptNilImportResult(gen.ImportResultFehler),
+	})
+}
+
+func TestConfiguredResultParsing(t *testing.T) {
+	analysisResult, err := mock.ParseAnalysisResult(" Konflikte ")
+	assert.NilError(t, err)
+	assert.Equal(t, analysisResult, gen.AnalysisResultKonflikte)
+
+	importResult, err := mock.ParseImportResult("Fehler")
+	assert.NilError(t, err)
+	assert.Equal(t, importResult, gen.ImportResultFehler)
+
+	_, err = mock.ParseAnalysisResult("missing")
+	assert.ErrorContains(t, err, `invalid value: "missing"`)
+
+	_, err = mock.ParseImportResult("missing")
+	assert.ErrorContains(t, err, `invalid value: "missing"`)
+}
+
 func TestPatchUnknownTaskReturnsNotFound(t *testing.T) {
 	ctx := t.Context()
-	h := mock.NewHandler()
+	h := newHandler()
 
 	res, err := h.APIImporttasksIDCancelPost(
 		ctx,
@@ -175,7 +215,7 @@ func TestPatchUnknownTaskReturnsNotFound(t *testing.T) {
 
 func TestStatusUnknownTaskReturnsNotFound(t *testing.T) {
 	ctx := t.Context()
-	h := mock.NewHandler()
+	h := newHandler()
 
 	res, err := h.APIImporttasksIDStatusGet(ctx, gen.APIImporttasksIDStatusGetParams{ID: "missing"})
 	assert.NilError(t, err)
@@ -195,6 +235,10 @@ func TestSecurityHandlerTokenValidation(t *testing.T) {
 
 	_, err = sec.HandleSmart(ctx, gen.APIHealthzGetOperation, gen.Smart{Token: "wrong"})
 	assert.Error(t, err, "invalid bearer token")
+}
+
+func newHandler() *mock.Handler {
+	return mock.NewHandler(mock.DefaultAnalysisResult, mock.DefaultImportResult)
 }
 
 func createTask(t *testing.T, ctx context.Context, h *mock.Handler, filename, username string) string {

--- a/hack/apis-mock/internal/mock/server_test.go
+++ b/hack/apis-mock/internal/mock/server_test.go
@@ -105,6 +105,32 @@ func TestConflictTaskCanBeCancelled(t *testing.T) {
 	})
 }
 
+func TestConflictTaskCanStartImportRunAfterDecision(t *testing.T) {
+	ctx := t.Context()
+	h := mock.NewHandler()
+
+	taskID := createTask(t, ctx, h, "metadata-mock-konflikte.xml", "dev@example.com")
+	_ = getTaskStatus(t, ctx, h, taskID)
+	_ = getTaskStatus(t, ctx, h, taskID)
+	status := getTaskStatus(t, ctx, h, taskID)
+	assert.DeepEqual(t, status, &gen.ImportTaskStatusResponse{
+		Status:         gen.ImportTaskStatusAnalysiert,
+		AnalysisResult: gen.NewOptNilAnalysisResult(gen.AnalysisResultKonflikte),
+	})
+
+	runID := createRun(t, ctx, h, taskID, "METS.xml", gen.ImportBehaviourTypeOverwriteAndAppend)
+	status = getTaskStatus(t, ctx, h, taskID)
+	assert.DeepEqual(t, status, &gen.ImportTaskStatusResponse{
+		Status:         gen.ImportTaskStatusWirdImportiert,
+		AnalysisResult: gen.NewOptNilAnalysisResult(gen.AnalysisResultKonflikte),
+	})
+
+	runStatus := getImportRunStatus(t, ctx, h, taskID, runID)
+	assert.DeepEqual(t, runStatus, &gen.ImportRunStatusResponse{
+		Status: gen.ImportStatusStarted,
+	})
+}
+
 func TestImportFailureIsSurfacedThroughTaskStatus(t *testing.T) {
 	ctx := t.Context()
 	h := mock.NewHandler()

--- a/hack/kube/apis-mock.yaml
+++ b/hack/kube/apis-mock.yaml
@@ -17,6 +17,11 @@ spec:
       containers:
         - name: apis-mock
           image: apis-mock:dev
+          env:
+            - name: MOCK_ANALYSIS_RESULT
+              value: AlleNeu
+            - name: MOCK_IMPORT_RESULT
+              value: Erfolgreich
           ports:
             - containerPort: 8080
           resources: {}


### PR DESCRIPTION
- Bump Go from 1.25.0 to 1.26.3
- Allow conflict tasks to start import runs
- Configure mock results with env vars

Refs #174.