### PR TITLE
Manage ogen with bine

### DIFF
--- a/.bine.json
+++ b/.bine.json
@@ -47,6 +47,11 @@
       "version": "0.6.0"
     },
     {
+      "name": "ogen",
+      "go_package": "github.com/ogen-go/ogen/cmd/ogen",
+      "version": "1.20.3"
+    },
+    {
       "name": "shfmt",
       "url": "https://github.com/mvdan/sh",
       "version": "3.13.0",

--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,11 @@ gen-apis: # @HELP Generate APIS client and mock server code from the shared Open
 	$(MAKE) gen-apis-client
 	$(MAKE) gen-apis-mock
 
-gen-apis-client: # @HELP Generate APIS client from the shared OpenAPI spec.
-	go generate ./internal/apis/gen
+gen-apis-client: tool-ogen # @HELP Generate APIS client from the shared OpenAPI spec.
+	ogen --config internal/apis/gen/ogen.yml --target internal/apis/gen --package gen --clean apis/openapi3.json
 
-gen-apis-mock: # @HELP Generate APIS mock server from the shared OpenAPI spec.
-	(cd ./hack/apis-mock && go generate ./internal/gen)
+gen-apis-mock: tool-ogen # @HELP Generate APIS mock server from the shared OpenAPI spec.
+	ogen --config hack/apis-mock/internal/gen/ogen.yml --target hack/apis-mock/internal/gen --package gen --clean apis/openapi3.json
 
 gen-ent: # @HELP Generate Ent assets.
 gen-ent: tool-ent

--- a/hack/apis-mock/README.md
+++ b/hack/apis-mock/README.md
@@ -104,7 +104,7 @@ integration issues.
 ## Regenerate after spec changes
 
 ```bash
-go generate ./internal/gen
+(cd ../.. && make gen-apis-mock)
 ```
 
 This regenerates all files in `internal/gen` from `../../apis/openapi3.json`.

--- a/hack/apis-mock/internal/gen/generate.go
+++ b/hack/apis-mock/internal/gen/generate.go
@@ -1,3 +1,0 @@
-package gen
-
-//go:generate go run github.com/ogen-go/ogen/cmd/ogen@v1.20.3 --config ogen.yml --target . --package gen --clean ../../../../apis/openapi3.json

--- a/internal/apis/gen/generate.go
+++ b/internal/apis/gen/generate.go
@@ -1,3 +1,0 @@
-package gen
-
-//go:generate go run github.com/ogen-go/ogen/cmd/ogen@v1.20.3 --config ogen.yml --target . --package gen --clean ../../../apis/openapi3.json


### PR DESCRIPTION
Move APIS code generation to Makefile targets that use the ogen binary managed by bine. Remove the go:generate stubs so APIS generation has only one supported entry point through make.