### PR TITLE
Handle APIS default values failure

### DIFF
--- a/internal/apis/create_import_task_activity.go
+++ b/internal/apis/create_import_task_activity.go
@@ -5,15 +5,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	ogenhttp "github.com/ogen-go/ogen/http"
 	"go.artefactual.dev/tools/temporal"
+	temporalsdk_temporal "go.temporal.io/sdk/temporal"
 
 	"github.com/artefactual-sdps/sfa-enduro-workflows/internal/apis/gen"
 	"github.com/artefactual-sdps/sfa-enduro-workflows/internal/sip"
 )
 
-const CreateImportTaskActivityName = "create-apis-import-task"
+const (
+	CreateImportTaskActivityName             = "create-apis-import-task"
+	CreateImportTaskDefaultValuesErrorType   = "APISImportTaskDefaultValuesError"
+	CreateImportTaskDefaultValuesErrorDetail = "The uploaded package contains information that didn't allow us to determine the default values."
+)
 
 type (
 	CreateImportTaskActivity struct {
@@ -75,9 +81,17 @@ func (a *CreateImportTaskActivity) Execute(
 		}
 		return &CreateImportTaskResult{TaskID: t.ImportTaskId}, nil
 	case *gen.APIImporttasksPostBadRequest:
+		detail := problemDetail(t.Detail)
+		if strings.Contains(detail, CreateImportTaskDefaultValuesErrorDetail) {
+			return nil, temporalsdk_temporal.NewNonRetryableApplicationError(
+				fmt.Sprintf("create APIS import task: bad request: %s", detail),
+				CreateImportTaskDefaultValuesErrorType,
+				nil,
+			)
+		}
 		return nil, temporal.NewNonRetryableError(fmt.Errorf(
 			"create APIS import task: bad request: %s",
-			problemDetail(t.Detail),
+			detail,
 		))
 	case *gen.APIImporttasksPostUnsupportedMediaType:
 		return nil, temporal.NewNonRetryableError(fmt.Errorf(

--- a/internal/apis/create_import_task_activity_test.go
+++ b/internal/apis/create_import_task_activity_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_temporal "go.temporal.io/sdk/temporal"
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
@@ -42,6 +43,7 @@ func TestCreateImportTaskActivity(t *testing.T) {
 		expect  func(*fake_apis.MockClientMockRecorder)
 		want    apis.CreateImportTaskResult
 		wantErr string
+		errType string
 	}{
 		{
 			name: "creates import task",
@@ -108,6 +110,22 @@ func TestCreateImportTaskActivity(t *testing.T) {
 			wantErr: "create APIS import task: bad request: invalid payload",
 		},
 		{
+			name: "returns typed default values error",
+			params: apis.CreateImportTaskParams{
+				SIP: sipValue,
+			},
+			expect: func(m *fake_apis.MockClientMockRecorder) {
+				m.APIImporttasksPost(gomock.Any(), gomock.Any()).Return(
+					&apisgen.APIImporttasksPostBadRequest{
+						Detail: apisgen.NewOptNilString(apis.CreateImportTaskDefaultValuesErrorDetail),
+					},
+					nil,
+				)
+			},
+			wantErr: "create APIS import task: bad request: " + apis.CreateImportTaskDefaultValuesErrorDetail,
+			errType: apis.CreateImportTaskDefaultValuesErrorType,
+		},
+		{
 			name: "returns unauthorized error",
 			params: apis.CreateImportTaskParams{
 				SIP: sipValue,
@@ -155,6 +173,11 @@ func TestCreateImportTaskActivity(t *testing.T) {
 					t.Fatalf("expected error containing %q", tt.wantErr)
 				}
 				assert.ErrorContains(t, err, tt.wantErr)
+				if tt.errType != "" {
+					var applicationErr *temporalsdk_temporal.ApplicationError
+					assert.Assert(t, errors.As(err, &applicationErr))
+					assert.Equal(t, applicationErr.Type(), tt.errType)
+				}
 
 				return
 			}

--- a/internal/workflows/preprocessing.go
+++ b/internal/workflows/preprocessing.go
@@ -1,6 +1,7 @@
 package workflows
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -31,6 +32,10 @@ type Preprocessing struct {
 	cfg         config.PreprocessingConfig
 	apisEnabled bool
 }
+
+const APISDefaultValuesFailureMessage = "No matching SIP information for this accession number could be found " +
+	"in the AIS, causing the analysis to fail. Please check if the accession information in the SIP matches with " +
+	"the record in the AIS and if it is linked with a (Teil-)Bestand and then restart the ingest."
 
 func NewPreprocessing(
 	cfg config.PreprocessingConfig,
@@ -564,6 +569,15 @@ func (w *Preprocessing) createAPISImportTask(
 		},
 	).Get(ctx, &createAPISImportTask)
 	if err != nil {
+		if isCreateAPISImportTaskDefaultValuesError(err) {
+			result.Outcome = childwf.OutcomeContentError
+			task.Complete(
+				temporalsdk_workflow.Now(ctx),
+				childwf.TaskOutcomeValidationFailure,
+				APISDefaultValuesFailureMessage,
+			)
+			return false
+		}
 		logger.Error("System error", "message", err.Error())
 		result.SystemError(
 			temporalsdk_workflow.Now(ctx),
@@ -663,6 +677,11 @@ func (w *Preprocessing) createAPISImportTask(
 	result.CustomMetadata = childwf.CustomMetadata{apis.CustomMetadataKey: data}
 
 	return true
+}
+
+func isCreateAPISImportTaskDefaultValuesError(err error) bool {
+	var applicationErr *temporalsdk_temporal.ApplicationError
+	return errors.As(err, &applicationErr) && applicationErr.Type() == apis.CreateImportTaskDefaultValuesErrorType
 }
 
 // waitForAPISDecision asks the parent workflow for a decision. It returns the

--- a/internal/workflows/preprocessing_test.go
+++ b/internal/workflows/preprocessing_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.artefactual.dev/tools/fsutil"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_temporal "go.temporal.io/sdk/temporal"
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
 	temporalsdk_worker "go.temporal.io/sdk/worker"
 	temporalsdk_workflow "go.temporal.io/sdk/workflow"
@@ -437,7 +438,7 @@ Tag-File-Character-Encoding: UTF-8
 	}
 }
 
-func (s *PreprocessingTestSuite) preAPISActivities(ar apisgen.AnalysisResult) (sip.SIP, string, string) {
+func (s *PreprocessingTestSuite) preAPISValidationActivities() (sip.SIP, string) {
 	extractPath := filepath.Join(filepath.Dir(s.sipPath), fsutil.BaseNoExt(filepath.Base(sipName)))
 	expectedSIP := s.digitizedAIP(extractPath)
 	ctx := mock.AnythingOfType("*context.valueCtx")
@@ -523,6 +524,14 @@ func (s *PreprocessingTestSuite) preAPISActivities(ar apisgen.AnalysisResult) (s
 	).Return(
 		&activities.ValidatePREMISResult{}, nil,
 	)
+
+	return expectedSIP, extractPath
+}
+
+func (s *PreprocessingTestSuite) preAPISActivities(ar apisgen.AnalysisResult) (sip.SIP, string, string) {
+	expectedSIP, extractPath := s.preAPISValidationActivities()
+	sessionCtx := mock.AnythingOfType("*context.timerCtx")
+
 	s.env.OnActivity(
 		apis.CreateImportTaskActivityName,
 		sessionCtx,
@@ -785,6 +794,65 @@ func (s *PreprocessingTestSuite) TestSuccess() {
 				childwf.TaskOutcomeSuccess,
 				true,
 			),
+		},
+		&result,
+	)
+}
+
+func (s *PreprocessingTestSuite) TestAPISCreateImportTaskDefaultValuesFailure() {
+	s.SetupTest(&config.Config{
+		APIS: apis.Config{Enabled: true},
+	})
+	s.writeBagitTxt(s.sipPath)
+
+	expectedSIP, extractPath := s.preAPISValidationActivities()
+	sessionCtx := mock.AnythingOfType("*context.timerCtx")
+	s.env.OnActivity(
+		apis.CreateImportTaskActivityName,
+		sessionCtx,
+		&apis.CreateImportTaskParams{
+			SIP:      expectedSIP,
+			Username: preprocessingWorkflowUser,
+		},
+	).Return(
+		nil,
+		temporalsdk_temporal.NewNonRetryableApplicationError(
+			"create APIS import task: bad request: "+apis.CreateImportTaskDefaultValuesErrorDetail,
+			apis.CreateImportTaskDefaultValuesErrorType,
+			nil,
+		),
+	)
+
+	s.env.ExecuteWorkflow(
+		s.workflow.Execute,
+		&childwf.PreprocessingParams{
+			RelativePath: relPath,
+			SIPID:        sipUUID,
+			SIPName:      sipName,
+		},
+	)
+	s.True(s.env.IsWorkflowCompleted())
+
+	updatedRelPath, err := filepath.Rel(s.testDir, extractPath)
+	s.NoError(err)
+
+	tasks := append([]*childwf.Task{}, preAPISEvents...)
+	tasks = append(tasks, &childwf.Task{
+		Name:        "Submit metadata to APIS",
+		Message:     workflows.APISDefaultValuesFailureMessage,
+		Outcome:     childwf.TaskOutcomeValidationFailure,
+		StartedAt:   testTime,
+		CompletedAt: testTime,
+	})
+
+	var result childwf.PreprocessingResult
+	err = s.env.GetWorkflowResult(&result)
+	s.NoError(err)
+	s.Equal(
+		&childwf.PreprocessingResult{
+			Outcome:      childwf.OutcomeContentError,
+			RelativePath: updatedRelPath,
+			Tasks:        tasks,
 		},
 		&result,
 	)


### PR DESCRIPTION
Detect the APIS 400 response used when default metadata values cannot be determined, map it to a content failure in preprocessing, and update the "Submit metadata to APIS" task error message.

Refs #173.