### PR TITLE
Don't move Prozess_Digitalisierung_PREMIS.xml

### DIFF
--- a/internal/activities/transform_sip.go
+++ b/internal/activities/transform_sip.go
@@ -8,7 +8,6 @@ import (
 
 	"go.artefactual.dev/tools/fsutil"
 
-	"github.com/artefactual-sdps/sfa-enduro-workflows/internal/enums"
 	"github.com/artefactual-sdps/sfa-enduro-workflows/internal/pips"
 	"github.com/artefactual-sdps/sfa-enduro-workflows/internal/sip"
 )
@@ -30,37 +29,15 @@ func NewTransformSIP() *TransformSIP {
 }
 
 func (a *TransformSIP) Execute(ctx context.Context, params *TransformSIPParams) (*TransformSIPResult, error) {
-	// Create a metadata directory.
-	mdPath := filepath.Join(params.SIP.Path, "metadata")
-	if err := os.MkdirAll(mdPath, 0o700); err != nil {
-		return nil, err
-	}
-
-	// Move the Prozess_Digitalisierung_PREMIS.xml file to the metadata
-	// directory. Prozess_Digitalisierung_PREMIS.xml is only present in
-	// digitized SIPs/AIPs, and there can only be one dossier in a digitized
-	// SIP/AIP.
-	if params.SIP.Type == enums.SIPTypeDigitizedSIP || params.SIP.Type == enums.SIPTypeDigitizedAIP {
-		entries, err := os.ReadDir(params.SIP.ContentPath)
-		if err != nil {
-			return nil, err
-		}
-
-		p := filepath.Join(
-			params.SIP.ContentPath,
-			entries[0].Name(), // dossier name.
-			"Prozess_Digitalisierung_PREMIS.xml",
-		)
-
-		err = fsutil.Move(p, filepath.Join(mdPath, "Prozess_Digitalisierung_PREMIS.xml"))
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	// Move the UpdatedAreldaMetatdata.xml and logical metadata files to the
 	// metadata directory (AIP only).
 	if params.SIP.IsAIP() {
+		// Create the metadata directory.
+		mdPath := filepath.Join(params.SIP.Path, "metadata")
+		if err := os.MkdirAll(mdPath, 0o700); err != nil {
+			return nil, err
+		}
+
 		err := fsutil.Move(
 			params.SIP.UpdatedAreldaMDPath,
 			filepath.Join(mdPath, filepath.Base(params.SIP.UpdatedAreldaMDPath)),
@@ -112,7 +89,6 @@ func (a *TransformSIP) Execute(ctx context.Context, params *TransformSIPParams) 
 		return nil, err
 	}
 
-	// Set all the file modes.
 	if err = fsutil.SetFileModes(params.SIP.Path, 0o700, 0o600); err != nil {
 		return nil, err
 	}

--- a/internal/activities/transform_sip_test.go
+++ b/internal/activities/transform_sip_test.go
@@ -79,6 +79,7 @@ func TestTransformSIP(t *testing.T) {
 					fs.WithDir("d_0000001", fs.WithMode(dmode),
 						fs.WithFile("00000001.jp2", "", fs.WithMode(fmode)),
 						fs.WithFile("00000001_PREMIS.xml", "", fs.WithMode(fmode)),
+						fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", "", fs.WithMode(fmode)),
 					),
 				),
 				fs.WithDir("header", fs.WithMode(dmode),
@@ -88,7 +89,6 @@ func TestTransformSIP(t *testing.T) {
 		),
 		fs.WithDir("metadata", fs.WithMode(dmode),
 			fs.WithFile("UpdatedAreldaMetadata.xml", "", fs.WithMode(fmode)),
-			fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", "", fs.WithMode(fmode)),
 			fs.WithFile("Vecteur_Digitized_AIP-premis.xml", "", fs.WithMode(fmode)),
 		),
 	)
@@ -100,15 +100,13 @@ func TestTransformSIP(t *testing.T) {
 					fs.WithDir("d_0000001", fs.WithMode(dmode),
 						fs.WithFile("00000001.jp2", "", fs.WithMode(fmode)),
 						fs.WithFile("00000001_PREMIS.xml", "", fs.WithMode(fmode)),
+						fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", "", fs.WithMode(fmode)),
 					),
 				),
 				fs.WithDir("header", fs.WithMode(dmode),
 					fs.WithFile("metadata.xml", "", fs.WithMode(fmode)),
 				),
 			),
-		),
-		fs.WithDir("metadata", fs.WithMode(dmode),
-			fs.WithFile("Prozess_Digitalisierung_PREMIS.xml", "", fs.WithMode(fmode)),
 		),
 	)
 

--- a/internal/activities/write_identifier_file_test.go
+++ b/internal/activities/write_identifier_file_test.go
@@ -82,15 +82,6 @@ func TestWriteIdentifierFile(t *testing.T) {
 			},
 			wantJSON: `[
     {
-        "file": "metadata/Prozess_Digitalisierung_PREMIS.xml",
-        "identifiers": [
-            {
-                "identifier": "_cQ6sm5CChWVqtqmrWvne0W",
-                "identifierType": "local"
-            }
-        ]
-    },
-    {
         "file": "objects/Test_Digitized_SIP/content/d_0000001/00000001.jp2",
         "identifiers": [
             {
@@ -122,6 +113,15 @@ func TestWriteIdentifierFile(t *testing.T) {
         "identifiers": [
             {
                 "identifier": "_Ohk77y2DJa82RXqsWG4S90",
+                "identifierType": "local"
+            }
+        ]
+    },
+    {
+        "file": "objects/Test_Digitized_SIP/content/d_0000001/Prozess_Digitalisierung_PREMIS.xml",
+        "identifiers": [
+            {
+                "identifier": "_cQ6sm5CChWVqtqmrWvne0W",
                 "identifierType": "local"
             }
         ]

--- a/internal/pips/pips.go
+++ b/internal/pips/pips.go
@@ -42,7 +42,7 @@ func (p PIP) Name() string {
 
 func (p PIP) ConvertSIPPath(path string) string {
 	switch name := filepath.Base(path); name {
-	case "Prozess_Digitalisierung_PREMIS.xml", "UpdatedAreldaMetadata.xml":
+	case "UpdatedAreldaMetadata.xml":
 		return filepath.Join("metadata", name)
 	case "metadata.xml":
 		return filepath.Join("objects", p.Name(), "header", name)

--- a/internal/pips/pips_test.go
+++ b/internal/pips/pips_test.go
@@ -82,10 +82,7 @@ func TestConvertSIPPath(t *testing.T) {
 	t.Parallel()
 
 	p := pips.New("/path/to/SIP_20201201_Vecteur", enums.SIPTypeDigitizedSIP)
-	assert.Equal(t,
-		p.ConvertSIPPath("content/d_0000001/Prozess_Digitalisierung_PREMIS.xml"),
-		"metadata/Prozess_Digitalisierung_PREMIS.xml",
-	)
+
 	assert.Equal(t,
 		p.ConvertSIPPath("header/metadata.xml"),
 		"objects/SIP_20201201_Vecteur/header/metadata.xml",
@@ -101,6 +98,10 @@ func TestConvertSIPPath(t *testing.T) {
 	assert.Equal(t,
 		p.ConvertSIPPath("content/d_0000001/00000001.jp2"),
 		"objects/SIP_20201201_Vecteur/content/d_0000001/00000001.jp2",
+	)
+	assert.Equal(t,
+		p.ConvertSIPPath("content/d_0000001/Prozess_Digitalisierung_PREMIS.xml"),
+		"objects/SIP_20201201_Vecteur/content/d_0000001/Prozess_Digitalisierung_PREMIS.xml",
 	)
 	assert.Equal(t, p.ConvertSIPPath("header/xsd/arelda.xsd"), "")
 }


### PR DESCRIPTION
Fixes #241.

- Don't move the Prozess_Digitalisierung_PREMIS.xml file to the PIP metadata directory when transforming the SIP so it's treated as a preservation object and its identifier is preserved in the METS file
- Change the Prozess_Digitalisierung_PREMIS.xml path in the "identifiers.json" file to match its path in the PIP content directory